### PR TITLE
Fix integration test failures.

### DIFF
--- a/tests/integration/incremental_strategies/models_bad/bad_merge_not_delta.sql
+++ b/tests/integration/incremental_strategies/models_bad/bad_merge_not_delta.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
     incremental_strategy = 'merge',
+    file_format = 'parquet',
 ) }}
 
 {% if not is_incremental() %}

--- a/tests/integration/incremental_strategies/models_insert_overwrite/insert_overwrite_no_partitions.sql
+++ b/tests/integration/incremental_strategies/models_insert_overwrite/insert_overwrite_no_partitions.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
     incremental_strategy = 'insert_overwrite',
+    file_format = 'parquet',
 ) }}
 
 {% if not is_incremental() %}


### PR DESCRIPTION
### Description

Fix integration test failures.

There are a couple of tests which came to fail after changing the default file format to 'delta'.

```
============================================================================= short test summary info ==============================================================================
FAILED tests/integration/incremental_strategies/test_incremental_strategies.py::TestInsertOverwrite::test_insert_overwrite_databricks_sql_connector - AssertionError: False != Tr...
FAILED tests/integration/incremental_strategies/test_incremental_strategies.py::TestBadStrategies::test_bad_strategies_databricks_sql_connector - AssertionError: 'error' != <Run...
============================================================== 2 failed, 10 passed, 622 warnings in 218.41s (0:03:38) ==============================================================
```

Because they assume the file format is 'parquet' that used to be the default.

### Checklist

- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-spark next" section.