### PR TITLE
Refine macros to explicitly use 'delta' for 'file_format'.

### DIFF
--- a/dbt/include/databricks/macros/adapters.sql
+++ b/dbt/include/databricks/macros/adapters.sql
@@ -1,5 +1,5 @@
 {% macro file_format_clause() %}
-  {%- set file_format = config.get('file_format', validator=validation.any[basestring]) -%}
+  {%- set file_format = config.get('file_format', default='delta') -%}
   {%- if file_format is not none %}
     using {{ file_format }}
   {%- endif %}
@@ -87,7 +87,7 @@
   {% if temporary -%}
     {{ create_temporary_view(relation, sql) }}
   {%- else -%}
-    {% if config.get('file_format', validator=validation.any[basestring]) == 'delta' %}
+    {% if config.get('file_format', default='delta') == 'delta' %}
       create or replace table {{ relation }}
     {% else %}
       create table {{ relation }}
@@ -181,7 +181,7 @@
 {% endmacro %}
 
 {% macro databricks__alter_column_comment(relation, column_dict) %}
-  {% if config.get('file_format', validator=validation.any[basestring]) == 'delta' %}
+  {% if config.get('file_format', default='delta') == 'delta' %}
     {% for column_name in column_dict %}
       {% set comment = column_dict[column_name]['description'] %}
       {% set escaped_comment = comment | replace('\'', '\\\'') %}

--- a/dbt/include/databricks/macros/materializations/table.sql
+++ b/dbt/include/databricks/macros/materializations/table.sql
@@ -13,7 +13,7 @@
   -- setup: if the target relation already exists, drop it
   -- in case if the existing and future table is delta, we want to do a
   -- create or replace table instead of dropping, so we don't have the table unavailable
-  {% if old_relation and not (old_relation.is_delta and config.get('file_format', validator=validation.any[basestring]) == 'delta') -%}
+  {% if old_relation and not (old_relation.is_delta and config.get('file_format', default='delta') == 'delta') -%}
     {{ adapter.drop_relation(old_relation) }}
   {%- endif %}
 

--- a/test/custom/incremental_on_schema_change/test_incremental_on_schema_change.py
+++ b/test/custom/incremental_on_schema_change/test_incremental_on_schema_change.py
@@ -70,7 +70,6 @@ class TestDeltaOnSchemaChange(TestIncrementalOnSchemaChange):
             "config-version": 2,
             "test-paths": ["tests"],
             "models": {
-                "+file_format": "delta",
                 "+incremental_strategy": "merge",
                 "+unique_key": "id",
             }

--- a/test/custom/incremental_strategies/models_bad/bad_insert_overwrite_delta.sql
+++ b/test/custom/incremental_strategies/models_bad/bad_insert_overwrite_delta.sql
@@ -1,7 +1,6 @@
 {{ config(
     materialized = 'incremental',
     incremental_strategy = 'insert_overwrite',
-    file_format = 'delta',
 ) }}
 
 {% if not is_incremental() %}

--- a/test/custom/incremental_strategies/models_delta/append_delta.sql
+++ b/test/custom/incremental_strategies/models_delta/append_delta.sql
@@ -1,7 +1,6 @@
 {{ config(
     materialized = 'incremental',
     incremental_strategy = 'append',
-    file_format = 'delta',
 ) }}
 
 {% if not is_incremental() %}

--- a/test/custom/incremental_strategies/models_delta/merge_no_key.sql
+++ b/test/custom/incremental_strategies/models_delta/merge_no_key.sql
@@ -1,7 +1,6 @@
 {{ config(
     materialized = 'incremental',
     incremental_strategy = 'merge',
-    file_format = 'delta',
 ) }}
 
 {% if not is_incremental() %}

--- a/test/custom/incremental_strategies/models_delta/merge_unique_key.sql
+++ b/test/custom/incremental_strategies/models_delta/merge_unique_key.sql
@@ -1,7 +1,6 @@
 {{ config(
     materialized = 'incremental',
     incremental_strategy = 'merge',
-    file_format = 'delta',
     unique_key = 'id',
 ) }}
 

--- a/test/custom/incremental_strategies/models_delta/merge_update_columns.sql
+++ b/test/custom/incremental_strategies/models_delta/merge_update_columns.sql
@@ -1,7 +1,6 @@
 {{ config(
     materialized = 'incremental',
     incremental_strategy = 'merge',
-    file_format = 'delta',
     unique_key = 'id',
     merge_update_columns = ['msg'],
 ) }}

--- a/test/custom/persist_docs/models/incremental_delta_model.sql
+++ b/test/custom/persist_docs/models/incremental_delta_model.sql
@@ -1,2 +1,2 @@
-{{ config(materialized='incremental', file_format='delta') }}
+{{ config(materialized='incremental') }}
 select 1 as id, 'Joe' as name

--- a/test/custom/persist_docs/models/table_delta_model.sql
+++ b/test/custom/persist_docs/models/table_delta_model.sql
@@ -1,2 +1,2 @@
-{{ config(materialized='table', file_format='delta') }}
+{{ config(materialized='table') }}
 select 1 as id, 'Joe' as name

--- a/test/custom/store_failures/test_store_failures.py
+++ b/test/custom/store_failures/test_store_failures.py
@@ -24,7 +24,7 @@ class TestStoreFailures(DBTSparkIntegrationTest):
         results = self.run_dbt(['test', '--store-failures'], strict = False)
 
 
-class TestStoreFailuresDelta(TestStoreFailures):
+class TestStoreFailuresParquet(TestStoreFailures):
 
     @property
     def project_config(self):
@@ -33,7 +33,7 @@ class TestStoreFailuresDelta(TestStoreFailures):
             'tests': {
                 '+store_failures': True,
                 '+severity': 'warn',
-                '+file_format': 'delta',
+                '+file_format': 'parquet',
             }
         }
 

--- a/test/unit/test_macros.py
+++ b/test/unit/test_macros.py
@@ -34,19 +34,18 @@ class TestSparkMacros(unittest.TestCase):
         template = self.__get_template('adapters.sql')
         sql = self.__run_macro(template, 'databricks__create_table_as', False, 'my_table', 'select 1').strip()
 
-        self.assertEqual(sql, "create table my_table as select 1")
+        self.assertEqual(sql, "create or replace table my_table using delta as select 1")
 
     def test_macros_create_table_as_file_format(self):
         template = self.__get_template('adapters.sql')
 
-        self.config['file_format'] = 'delta'
+        self.config['file_format'] = 'parquet'
         sql = self.__run_macro(template, 'databricks__create_table_as', False, 'my_table', 'select 1').strip()
-        self.assertEqual(sql, "create or replace table my_table using delta as select 1")
+        self.assertEqual(sql, "create table my_table using parquet as select 1")
 
     def test_macros_create_table_as_options(self):
         template = self.__get_template('adapters.sql')
 
-        self.config['file_format'] = 'delta'
         self.config['options'] = {"compression": "gzip"}
         sql = self.__run_macro(template, 'databricks__create_table_as', False, 'my_table', 'select 1').strip()
         self.assertEqual(sql, 'create or replace table my_table using delta options (compression "gzip" ) as select 1')
@@ -56,7 +55,7 @@ class TestSparkMacros(unittest.TestCase):
 
         self.config['partition_by'] = 'partition_1'
         sql = self.__run_macro(template, 'databricks__create_table_as', False, 'my_table', 'select 1').strip()
-        self.assertEqual(sql, "create table my_table partitioned by (partition_1) as select 1")
+        self.assertEqual(sql, "create or replace table my_table using delta partitioned by (partition_1) as select 1")
 
     def test_macros_create_table_as_partitions(self):
         template = self.__get_template('adapters.sql')
@@ -64,7 +63,7 @@ class TestSparkMacros(unittest.TestCase):
         self.config['partition_by'] = ['partition_1', 'partition_2']
         sql = self.__run_macro(template, 'databricks__create_table_as', False, 'my_table', 'select 1').strip()
         self.assertEqual(sql,
-                         "create table my_table partitioned by (partition_1,partition_2) as select 1")
+                         "create or replace table my_table using delta partitioned by (partition_1,partition_2) as select 1")
 
     def test_macros_create_table_as_cluster(self):
         template = self.__get_template('adapters.sql')
@@ -72,7 +71,7 @@ class TestSparkMacros(unittest.TestCase):
         self.config['clustered_by'] = 'cluster_1'
         self.config['buckets'] = '1'
         sql = self.__run_macro(template, 'databricks__create_table_as', False, 'my_table', 'select 1').strip()
-        self.assertEqual(sql, "create table my_table clustered by (cluster_1) into 1 buckets as select 1")
+        self.assertEqual(sql, "create or replace table my_table using delta clustered by (cluster_1) into 1 buckets as select 1")
 
     def test_macros_create_table_as_clusters(self):
         template = self.__get_template('adapters.sql')
@@ -80,14 +79,14 @@ class TestSparkMacros(unittest.TestCase):
         self.config['clustered_by'] = ['cluster_1', 'cluster_2']
         self.config['buckets'] = '1'
         sql = self.__run_macro(template, 'databricks__create_table_as', False, 'my_table', 'select 1').strip()
-        self.assertEqual(sql, "create table my_table clustered by (cluster_1,cluster_2) into 1 buckets as select 1")
+        self.assertEqual(sql, "create or replace table my_table using delta clustered by (cluster_1,cluster_2) into 1 buckets as select 1")
 
     def test_macros_create_table_as_location(self):
         template = self.__get_template('adapters.sql')
 
         self.config['location_root'] = '/mnt/root'
         sql = self.__run_macro(template, 'databricks__create_table_as', False, 'my_table', 'select 1').strip()
-        self.assertEqual(sql, "create table my_table location '/mnt/root/my_table' as select 1")
+        self.assertEqual(sql, "create or replace table my_table using delta location '/mnt/root/my_table' as select 1")
 
     def test_macros_create_table_as_comment(self):
         template = self.__get_template('adapters.sql')
@@ -95,7 +94,7 @@ class TestSparkMacros(unittest.TestCase):
         self.config['persist_docs'] = {'relation': True}
         self.default_context['model'].description = 'Description Test'
         sql = self.__run_macro(template, 'databricks__create_table_as', False, 'my_table', 'select 1').strip()
-        self.assertEqual(sql, "create table my_table comment 'Description Test' as select 1")
+        self.assertEqual(sql, "create or replace table my_table using delta comment 'Description Test' as select 1")
 
     def test_macros_create_table_as_all(self):
         template = self.__get_template('adapters.sql')


### PR DESCRIPTION
### Description

Refines macros to explicitly use 'delta' for 'file_format'.

### Checklist

- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-spark next" section.