### PR TITLE
Inherit from dbt-spark for backward compatibility

### DIFF
--- a/dbt/adapters/databricks/__init__.py
+++ b/dbt/adapters/databricks/__init__.py
@@ -10,4 +10,6 @@ from dbt.include import databricks
 Plugin = AdapterPlugin(
     adapter=DatabricksAdapter,
     credentials=DatabricksCredentials,
-    include_path=databricks.PACKAGE_PATH)
+    include_path=databricks.PACKAGE_PATH,
+    dependencies=['spark']
+)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 databricks-sql-connector>=0.9.0
+dbt-spark ~= 1.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 databricks-sql-connector>=0.9.0
-dbt-spark ~= 1.0.0
+dbt-spark~=1.0.0

--- a/setup.py
+++ b/setup.py
@@ -77,6 +77,7 @@ setup(
     include_package_data=True,
     install_requires=[
         'dbt-core~={}'.format(dbt_core_version),
+        'dbt-spark~={}'.format(dbt_core_version),
         'databricks-sql-connector>=0.9.0',
     ],
     zip_safe=False,

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,6 @@ setup(
     packages=find_namespace_packages(include=['dbt', 'dbt.*']),
     include_package_data=True,
     install_requires=[
-        'dbt-core~={}'.format(dbt_core_version),
         'dbt-spark~={}'.format(dbt_core_version),
         'databricks-sql-connector>=0.9.0',
     ],


### PR DESCRIPTION
Resolves #32
Fixes dbt-labs/spark-utils#23

Integration tests will be added to dbt-labs/spark_utils to ensure compatibility with dbt-databricks.

### Description

Inherit from dbt-spark in order to maintain compatibility with existing spark-utils and other macros.

### Checklist

- [ x] I have run this code in development and it appears to resolve the stated issue