### PR TITLE
Enable custom integration tests for SQL Endpoint and refine integration tests.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -79,7 +79,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8] # TODO: support unit testing for python 3.9 (https://github.com/dbt-labs/dbt/issues/3689)
+        python-version: [3.7, 3.8, 3.9]
 
     env:
       TOXENV: "unit"

--- a/tests/integration/base.py
+++ b/tests/integration/base.py
@@ -85,7 +85,7 @@ class TestArgs:
 
 
 def _profile_from_test_name(test_name):
-    adapter_names = ('databricks_sql_connector', 'databricks_sql_endpoint_connector')
+    adapter_names = ('databricks_cluster', 'databricks_sql_endpoint')
     adapters_in_name = sum(x in test_name for x in adapter_names)
     if adapters_in_name != 1:
         raise ValueError(
@@ -143,7 +143,7 @@ class DBTIntegrationTest(unittest.TestCase):
     prefix = f'test{_runtime}{_randint:04}'
     setup_alternate_db = False
 
-    def databricks_sql_connector_profile(self):
+    def databricks_cluster_profile(self):
         return {
             'config': {
                 'send_anonymous_usage_stats': False
@@ -153,7 +153,7 @@ class DBTIntegrationTest(unittest.TestCase):
                     'dbsql': {
                         'type': 'databricks',
                         'host': os.getenv('DBT_DATABRICKS_HOST_NAME'),
-                        'http_path': os.getenv('DBT_DATABRICKS_HTTP_PATH'),
+                        'http_path': os.getenv('DBT_DATABRICKS_CLUSTER_HTTP_PATH'),
                         'token': os.getenv('DBT_DATABRICKS_TOKEN'),
                         'schema': self.unique_schema()
                     },
@@ -162,7 +162,7 @@ class DBTIntegrationTest(unittest.TestCase):
             }
         }
 
-    def databricks_sql_endpoint_connector_profile(self):
+    def databricks_sql_endpoint_profile(self):
         return {
             'config': {
                 'send_anonymous_usage_stats': False
@@ -206,10 +206,10 @@ class DBTIntegrationTest(unittest.TestCase):
         return None
 
     def get_profile(self, adapter_type):
-        if adapter_type == 'databricks_sql_connector':
-            return self.databricks_sql_connector_profile()
-        elif adapter_type == 'databricks_sql_endpoint_connector':
-            return self.databricks_sql_endpoint_connector_profile()
+        if adapter_type == 'databricks_cluster':
+            return self.databricks_cluster_profile()
+        elif adapter_type == 'databricks_sql_endpoint':
+            return self.databricks_sql_endpoint_profile()
         else:
             raise ValueError('invalid adapter type {}'.format(adapter_type))
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,7 +1,7 @@
 def pytest_configure(config):
     config.addinivalue_line(
-        "markers", "profile_databricks_sql_connector"
+        "markers", "profile_databricks_cluster"
     )
     config.addinivalue_line(
-        "markers", "profile_databricks_sql_endpoint_connector"
+        "markers", "profile_databricks_sql_endpoint"
     )

--- a/tests/integration/get_columns_in_relation/test_get_columns_in_relation.py
+++ b/tests/integration/get_columns_in_relation/test_get_columns_in_relation.py
@@ -14,6 +14,10 @@ class TestGetColumnInRelationInSameRun(DBTIntegrationTest):
         self.run_dbt(["run"])
         self.assertTablesEqual("child", "get_columns_from_child")
 
-    @use_profile("databricks_sql_connector")
-    def test_get_columns_in_relation_in_same_run_databricks_sql_connector(self):
+    @use_profile("databricks_cluster")
+    def test_get_columns_in_relation_in_same_run_databricks_cluster(self):
+        self.run_and_test()
+
+    @use_profile("databricks_sql_endpoint")
+    def test_get_columns_in_relation_in_same_run_databricks_sql_endpoint(self):
         self.run_and_test()

--- a/tests/integration/incremental_on_schema_change/test_incremental_on_schema_change.py
+++ b/tests/integration/incremental_on_schema_change/test_incremental_on_schema_change.py
@@ -63,6 +63,43 @@ class TestIncrementalOnSchemaChange(DBTIntegrationTest):
         self.assertIn('Compilation Error', results_two[1].message)
 
 
+class TestDeltaAppend(TestIncrementalOnSchemaChange):
+
+    @property
+    def project_config(self):
+        return {
+            "config-version": 2,
+            "test-paths": ["tests"],
+            "models": {
+                "+incremental_strategy": "append",
+            }
+        }
+
+    @use_profile('databricks_cluster')
+    def test__databricks_cluster__run_incremental_ignore(self):
+        self.run_incremental_ignore()
+
+    @use_profile('databricks_cluster')
+    def test__databricks_cluster__run_incremental_fail_on_schema_change(self):
+        self.run_incremental_fail_on_schema_change()
+
+    @use_profile('databricks_cluster')
+    def test__databricks_cluster__run_incremental_sync_all_columns(self):
+        self.run_incremental_sync_all_columns()
+
+    @use_profile('databricks_sql_endpoint')
+    def test__databricks_sql_endpoint__run_incremental_ignore(self):
+        self.run_incremental_ignore()
+
+    @use_profile('databricks_sql_endpoint')
+    def test__databricks_sql_endpoint__run_incremental_fail_on_schema_change(self):
+        self.run_incremental_fail_on_schema_change()
+
+    @use_profile('databricks_sql_endpoint')
+    def test__databricks_sql_endpoint__run_incremental_sync_all_columns(self):
+        self.run_incremental_sync_all_columns()
+
+
 class TestDeltaOnSchemaChange(TestIncrementalOnSchemaChange):
     @property
     def project_config(self):
@@ -74,18 +111,34 @@ class TestDeltaOnSchemaChange(TestIncrementalOnSchemaChange):
             }
         }
 
-    @use_profile('databricks_sql_connector')
-    def test__databricks_sql_connector__run_incremental_ignore(self):
+    @use_profile('databricks_cluster')
+    def test__databricks_cluster__run_incremental_ignore(self):
         self.run_incremental_ignore()
 
-    @use_profile('databricks_sql_connector')
-    def test__databricks_sql_connector__run_incremental_fail_on_schema_change(self):
+    @use_profile('databricks_cluster')
+    def test__databricks_cluster__run_incremental_fail_on_schema_change(self):
         self.run_incremental_fail_on_schema_change()
 
-    @use_profile('databricks_sql_connector')
-    def test__databricks_sql_connector__run_incremental_append_new_columns(self):
+    @use_profile('databricks_cluster')
+    def test__databricks_cluster__run_incremental_append_new_columns(self):
         self.run_incremental_append_new_columns()
 
-    @use_profile('databricks_sql_connector')
-    def test__databricks_sql_connector__run_incremental_sync_all_columns(self):
+    @use_profile('databricks_cluster')
+    def test__databricks_cluster__run_incremental_sync_all_columns(self):
+        self.run_incremental_sync_all_columns()
+
+    @use_profile('databricks_sql_endpoint')
+    def test__databricks_sql_endpoint__run_incremental_ignore(self):
+        self.run_incremental_ignore()
+
+    @use_profile('databricks_sql_endpoint')
+    def test__databricks_sql_endpoint__run_incremental_fail_on_schema_change(self):
+        self.run_incremental_fail_on_schema_change()
+
+    @use_profile('databricks_sql_endpoint')
+    def test__databricks_sql_endpoint__run_incremental_append_new_columns(self):
+        self.run_incremental_append_new_columns()
+
+    @use_profile('databricks_sql_endpoint')
+    def test__databricks_sql_endpoint__run_incremental_sync_all_columns(self):
         self.run_incremental_sync_all_columns()

--- a/tests/integration/incremental_strategies/test_incremental_strategies.py
+++ b/tests/integration/incremental_strategies/test_incremental_strategies.py
@@ -26,7 +26,7 @@ class TestIncrementalStrategies(DBTIntegrationTest):
         self.run_dbt(["run"])
 
 
-class TestDefaultAppend(TestIncrementalStrategies):
+class TestParquetAppend(TestIncrementalStrategies):
     @property
     def models(self):
         return "models"
@@ -35,12 +35,12 @@ class TestDefaultAppend(TestIncrementalStrategies):
         self.seed_and_run_twice()
         self.assertTablesEqual("default_append", "expected_append")
 
-    @use_profile("databricks_sql_connector")
-    def test_default_append_databricks_sql_connector(self):
+    @use_profile("databricks_cluster")
+    def test_default_append_databricks_cluster(self):
         self.run_and_test()
 
 
-class TestInsertOverwrite(TestIncrementalStrategies):
+class TestParquetInsertOverwrite(TestIncrementalStrategies):
     @property
     def models(self):
         return "models_insert_overwrite"
@@ -52,8 +52,8 @@ class TestInsertOverwrite(TestIncrementalStrategies):
         self.assertTablesEqual(
             "insert_overwrite_partitions", "expected_upsert")
 
-    @use_profile("databricks_sql_connector")
-    def test_insert_overwrite_databricks_sql_connector(self):
+    @use_profile("databricks_cluster")
+    def test_insert_overwrite_databricks_cluster(self):
         self.run_and_test()
 
 
@@ -69,9 +69,14 @@ class TestDeltaStrategies(TestIncrementalStrategies):
         self.assertTablesEqual("merge_unique_key", "expected_upsert")
         self.assertTablesEqual("merge_update_columns", "expected_partial_upsert")
 
-    @use_profile("databricks_sql_connector")
-    def test_delta_strategies_databricks_sql_connector(self):
+    @use_profile("databricks_cluster")
+    def test_delta_strategies_databricks_cluster(self):
         self.run_and_test()
+
+    @use_profile("databricks_sql_endpoint")
+    def test_delta_strategies_databricks_sql_endpoint(self):
+        self.run_and_test()
+
 
 # Uncomment this hudi integration test after the hudi 0.10.0 release to make it work.
 # class TestHudiStrategies(TestIncrementalStrategies):
@@ -106,6 +111,10 @@ class TestBadStrategies(TestIncrementalStrategies):
             self.assertEqual("error", result.status)
             self.assertIn("Compilation Error in model", result.message)
 
-    @use_profile("databricks_sql_connector")
-    def test_bad_strategies_databricks_sql_connector(self):
+    @use_profile("databricks_cluster")
+    def test_bad_strategies_databricks_cluster(self):
+        self.run_and_test()
+
+    @use_profile("databricks_sql_endpoint")
+    def test_bad_strategies_databricks_sql_endpoint(self):
         self.run_and_test()

--- a/tests/integration/persist_docs/test_persist_docs.py
+++ b/tests/integration/persist_docs/test_persist_docs.py
@@ -60,7 +60,10 @@ class TestPersistDocsDelta(DBTIntegrationTest):
                 if result[0] == 'name':
                     assert result[2].startswith('Some stuff here and then a call to')
 
-    # runs on Spark v3.0
-    @use_profile("databricks_sql_connector")
-    def test_delta_comments_databricks_sql_connector(self):
+    @use_profile("databricks_cluster")
+    def test_delta_comments_databricks_cluster(self):
+        self.test_delta_comments()
+
+    @use_profile("databricks_sql_endpoint")
+    def test_delta_comments_databricks_sql_endpoint(self):
         self.test_delta_comments()

--- a/tests/integration/seed_column_types/test_seed_column_types.py
+++ b/tests/integration/seed_column_types/test_seed_column_types.py
@@ -20,6 +20,10 @@ class TestSeedColumnTypeCast(DBTIntegrationTest):
             },
         }
 
-    @use_profile("databricks_sql_connector")
-    def test_seed_column_types_databricks_sql_connector(self):
+    @use_profile("databricks_cluster")
+    def test_seed_column_types_databricks_cluster(self):
+        self.run_dbt(["seed"])
+
+    @use_profile("databricks_sql_endpoint")
+    def test_seed_column_types_databricks_sql_endpoint(self):
         self.run_dbt(["seed"])

--- a/tests/integration/store_failures/test_store_failures.py
+++ b/tests/integration/store_failures/test_store_failures.py
@@ -24,6 +24,17 @@ class TestStoreFailures(DBTIntegrationTest):
         results = self.run_dbt(['test', '--store-failures'])
 
 
+class TestStoreFailuresDelta(TestStoreFailures):
+
+    @use_profile("databricks_cluster")
+    def test_store_failures_databricks_cluster(self):
+        self.test_store_failures()
+
+    @use_profile("databricks_sql_endpoint")
+    def test_store_failures_databricks_sql_endpoint(self):
+        self.test_store_failures()
+
+
 class TestStoreFailuresParquet(TestStoreFailures):
 
     @property
@@ -37,6 +48,6 @@ class TestStoreFailuresParquet(TestStoreFailures):
             }
         }
 
-    @use_profile("databricks_sql_connector")
-    def test_store_failures_databricks_sql_connector(self):
+    @use_profile("databricks_cluster")
+    def test_store_failures_databricks_cluster(self):
         self.test_store_failures()

--- a/tests/specs/databricks-cluster.dbtspec
+++ b/tests/specs/databricks-cluster.dbtspec
@@ -1,9 +1,8 @@
 target:
   type: databricks
   host: "{{ env_var('DBT_DATABRICKS_HOST_NAME') }}"
-  http_path: "{{ env_var('DBT_DATABRICKS_ENDPOINT_HTTP_PATH') }}"
+  http_path: "{{ env_var('DBT_DATABRICKS_CLUSTER_HTTP_PATH') }}"
   token: "{{ env_var('DBT_DATABRICKS_TOKEN') }}"
-  port: 443
   schema: "analytics_{{ var('_dbt_random_suffix') }}"
   connect_retries: 5
   connect_timeout: 60
@@ -21,8 +20,7 @@ projects:
     dbt_project_yml: *file_format_delta
 sequences:
   test_dbt_empty: empty
-  # Skip for now as not all `SET` commands work on endpoints
-  # test_dbt_base: base
+  test_dbt_base: base
   test_dbt_ephemeral: ephemeral
   test_dbt_incremental: incremental
   test_dbt_snapshot_strategy_timestamp: snapshot_strategy_timestamp

--- a/tests/specs/databricks-sql-endpoint.dbtspec
+++ b/tests/specs/databricks-sql-endpoint.dbtspec
@@ -1,7 +1,7 @@
 target:
   type: databricks
   host: "{{ env_var('DBT_DATABRICKS_HOST_NAME') }}"
-  http_path: "{{ env_var('DBT_DATABRICKS_HTTP_PATH') }}"
+  http_path: "{{ env_var('DBT_DATABRICKS_ENDPOINT_HTTP_PATH') }}"
   token: "{{ env_var('DBT_DATABRICKS_TOKEN') }}"
   schema: "analytics_{{ var('_dbt_random_suffix') }}"
   connect_retries: 5
@@ -20,7 +20,8 @@ projects:
     dbt_project_yml: *file_format_delta
 sequences:
   test_dbt_empty: empty
-  test_dbt_base: base
+  # Skip for now as not all `SET` commands work on endpoints
+  # test_dbt_base: base
   test_dbt_ephemeral: ephemeral
   test_dbt_incremental: incremental
   test_dbt_snapshot_strategy_timestamp: snapshot_strategy_timestamp

--- a/tox.ini
+++ b/tox.ini
@@ -1,37 +1,36 @@
 [tox]
 skipsdist = True
-envlist = unit, flake8, integration-spark-databricks-sql-connector
-
+envlist = flake8, unit
 
 [testenv:flake8]
-basepython = python3.8
+basepython = python3
 commands = /bin/bash -c '$(which flake8) --select=E,W,F --ignore=W504 dbt/'
 passenv = DBT_* PYTEST_ADDOPTS
 deps =
      -r{toxinidir}/dev_requirements.txt
 
 [testenv:unit]
-basepython = python3.8
+basepython = python3
 commands = /bin/bash -c '{envpython} -m pytest -v {posargs} tests/unit'
 passenv = DBT_* PYTEST_ADDOPTS
 deps =
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/dev_requirements.txt
 
-[testenv:integration-spark-databricks-sql-connector]
-basepython = python3.8
-commands = /bin/bash -c '{envpython} -m pytest -v tests/specs/spark-databricks-sql-connector.dbtspec'
-           /bin/bash -c '{envpython} -m pytest -v -m profile_databricks_sql_connector {posargs} -n4 tests/integration/*'
+[testenv:integration-databricks-cluster]
+basepython = python3
+commands = /bin/bash -c '{envpython} -m pytest -v tests/specs/databricks-cluster.dbtspec'
+           /bin/bash -c '{envpython} -m pytest -v -m profile_databricks_cluster {posargs} -n4 tests/integration/*'
 passenv = DBT_* PYTEST_ADDOPTS
 deps =
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/dev_requirements.txt
     -e.
 
-[testenv:integration-spark-databricks-sql-endpoint-connector]
-basepython = python3.8
-commands = /bin/bash -c '{envpython} -m pytest -v tests/specs/spark-databricks-sql-endpoint-connector.dbtspec'
-           /bin/bash -c '{envpython} -m pytest -v -m profile_databricks_sql_connector {posargs} -n4 tests/integration/*'
+[testenv:integration-databricks-sql-endpoint]
+basepython = python3
+commands = /bin/bash -c '{envpython} -m pytest -v tests/specs/databricks-sql-endpoint.dbtspec'
+           /bin/bash -c '{envpython} -m pytest -v -m profile_databricks_sql_endpoint {posargs} -n4 tests/integration/*'
 passenv = DBT_* PYTEST_ADDOPTS
 deps =
     -r{toxinidir}/requirements.txt


### PR DESCRIPTION
Enables custom integration tests for SQL Endpoint and refines integration tests.

### Description

- Enable custom integration tests for SQL Endpoint
- Rename the tox env name for integration tests:
  - For the all purpose cluster: `integration-spark-databricks-sql-connector` -> `integration-databricks-cluster`
  - For the SQL Endpoint: `integration-spark-databricks-sql-endpoint-connector` -> `integration-databricks-sql-endpoint`
- Rename the environment variable name `DBT_DATABRICKS_HTTP_PATH` to `DBT_DATABRICKS_CLUSTER_HTTP_PATH`

After this, we need to setup environment variable for integration tests:

```
export DBT_DATABRICKS_HOST_NAME='<server-hostname>'
export DBT_DATABRICKS_CLUSTER_HTTP_PATH='<http-path> for the all purpose cluster'
export DBT_DATABRICKS_ENDPOINT_HTTP_PATH='<http-path> for the SQL Endpoint'
export DBT_DATABRICKS_TOKEN='<personal-access-token>'
```

and tox commands will be:

```
tox -e integration-databricks-cluster
tox -e integration-databricks-sql-endpoint
```