### PR TITLE
Setup linter checks.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,7 +44,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        toxenv: [flake8]
+        toxenv: [linter]
 
     env:
       TOXENV: ${{ matrix.toxenv }}

--- a/black.ini
+++ b/black.ini
@@ -1,0 +1,4 @@
+[tool.black]
+required-version = "21.12b0"
+line-length = 100
+target-version = ['py37']

--- a/dbt/adapters/databricks/__init__.py
+++ b/dbt/adapters/databricks/__init__.py
@@ -11,5 +11,5 @@ Plugin = AdapterPlugin(
     adapter=DatabricksAdapter,
     credentials=DatabricksCredentials,
     include_path=databricks.PACKAGE_PATH,
-    dependencies=['spark']
+    dependencies=["spark"],
 )

--- a/dbt/adapters/databricks/__version__.py
+++ b/dbt/adapters/databricks/__version__.py
@@ -1,1 +1,1 @@
-version = "1.0.1.dev0"
+version: str = "1.0.1.dev0"

--- a/dbt/adapters/databricks/column.py
+++ b/dbt/adapters/databricks/column.py
@@ -5,6 +5,5 @@ from dbt.adapters.spark.column import SparkColumn
 
 @dataclass
 class DatabricksColumn(SparkColumn):
-
     def __repr__(self) -> str:
         return "<DatabricksColumn {} ({})>".format(self.name, self.data_type)

--- a/dbt/adapters/databricks/connections.py
+++ b/dbt/adapters/databricks/connections.py
@@ -2,18 +2,16 @@ from contextlib import contextmanager
 from dataclasses import dataclass, field
 import re
 import time
-from typing import Any, ClassVar, Dict, Optional
+from typing import Any, ClassVar, Dict, Iterator, List, Optional, Sequence, Tuple
 
 import dbt.exceptions
 from dbt.adapters.base import Credentials
 from dbt.adapters.databricks import __version__
-from dbt.contracts.connection import ConnectionState
+from dbt.contracts.connection import Connection, ConnectionState
 from dbt.events import AdapterLogger
 from dbt.utils import DECIMALS
 
-from dbt.adapters.spark.connections import (
-    SparkConnectionManager, _is_retryable_error
-)
+from dbt.adapters.spark.connections import SparkConnectionManager, _is_retryable_error
 
 from databricks import sql as dbsql
 from databricks.sql.client import (
@@ -37,36 +35,33 @@ class DatabricksCredentials(Credentials):
     retry_all: bool = False
 
     @classmethod
-    def __pre_deserialize__(cls, data):
+    def __pre_deserialize__(cls, data: Dict[Any, Any]) -> Dict[Any, Any]:
         data = super().__pre_deserialize__(data)
-        if 'database' not in data:
-            data['database'] = None
+        if "database" not in data:
+            data["database"] = None
         return data
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         # spark classifies database and schema as the same thing
-        if (
-            self.database is not None and
-            self.database != self.schema
-        ):
+        if self.database is not None and self.database != self.schema:
             raise dbt.exceptions.RuntimeException(
-                f'    schema: {self.schema} \n'
-                f'    database: {self.database} \n'
-                f'On Spark, database must be omitted or have the same value as'
-                f' schema.'
+                f"    schema: {self.schema} \n"
+                f"    database: {self.database} \n"
+                f"On Spark, database must be omitted or have the same value as"
+                f" schema."
             )
         self.database = None
 
     @property
-    def type(self):
-        return 'databricks'
+    def type(self) -> str:
+        return "databricks"
 
     @property
-    def unique_field(self):
+    def unique_field(self) -> str:
         return self.host
 
-    def _connection_keys(self):
-        return 'host', 'port', 'http_path', 'schema'
+    def _connection_keys(self) -> Tuple[str, ...]:
+        return "host", "port", "http_path", "schema"
 
 
 class DatabricksSQLConnectionWrapper(object):
@@ -79,37 +74,33 @@ class DatabricksSQLConnectionWrapper(object):
         self._conn = conn
         self._cursor = None
 
-    def cursor(self):
+    def cursor(self) -> "DatabricksSQLConnectionWrapper":
         self._cursor = self._conn.cursor()
         return self
 
-    def cancel(self):
+    def cancel(self) -> None:
         if self._cursor:
             try:
                 self._cursor.cancel()
             except OperationalError as exc:
-                logger.debug(
-                    "Exception while cancelling query: {}".format(exc)
-                )
+                logger.debug("Exception while cancelling query: {}".format(exc))
 
-    def close(self):
+    def close(self) -> None:
         if self._cursor:
             try:
                 self._cursor.close()
             except OperationalError as exc:
-                logger.debug(
-                    "Exception while closing cursor: {}".format(exc)
-                )
+                logger.debug("Exception while closing cursor: {}".format(exc))
         self._conn.close()
 
-    def rollback(self, *args, **kwargs):
+    def rollback(self, *args: Any, **kwargs: Any) -> None:
         logger.debug("NotImplemented: rollback")
 
-    def fetchall(self):
+    def fetchall(self) -> Sequence[Tuple]:
         assert self._cursor is not None
         return self._cursor.fetchall()
 
-    def execute(self, sql, bindings=None):
+    def execute(self, sql: str, bindings: Optional[Sequence[Any]] = None) -> None:
         assert self._cursor is not None
         if sql.strip().endswith(";"):
             sql = sql.strip()[:-1]
@@ -118,29 +109,41 @@ class DatabricksSQLConnectionWrapper(object):
         self._cursor.execute(sql, bindings)
 
     @classmethod
-    def _fix_binding(cls, value):
+    def _fix_binding(cls, value: Any) -> Any:
         """Convert complex datatypes to primitives that can be loaded by
-           the Spark driver"""
+        the Spark driver"""
         if isinstance(value, DECIMALS):
             return float(value)
         else:
             return value
 
     @property
-    def description(self):
+    def description(
+        self,
+    ) -> Sequence[
+        Tuple[
+            str,
+            str,
+            Optional[int],
+            Optional[int],
+            Optional[int],
+            Optional[int],
+            Optional[bool],
+        ]
+    ]:
         assert self._cursor is not None
         return self._cursor.description
 
 
 class DatabricksConnectionManager(SparkConnectionManager):
-    TYPE: ClassVar[str] = 'databricks'
+    TYPE: ClassVar[str] = "databricks"
 
     DROP_JAVA_STACKTRACE_REGEX: ClassVar["re.Pattern[str]"] = re.compile(
         r"(?<=Caused by: )(.+?)(?=^\t?at )", re.DOTALL | re.MULTILINE
     )
 
     @contextmanager
-    def exception_handler(self, sql: str):
+    def exception_handler(self, sql: str) -> Iterator[None]:
         try:
             yield
 
@@ -150,9 +153,7 @@ class DatabricksConnectionManager(SparkConnectionManager):
             msg = str(exc)
             m = self.DROP_JAVA_STACKTRACE_REGEX.search(msg)
             if m:
-                msg = (
-                    "Query execution failed.\nError message: {}"
-                ).format(m.group().strip())
+                msg = ("Query execution failed.\nError message: {}").format(m.group().strip())
             raise dbt.exceptions.RuntimeException(msg)
 
         except Exception as exc:
@@ -162,29 +163,28 @@ class DatabricksConnectionManager(SparkConnectionManager):
                 raise
 
             thrift_resp = exc.args[0]
-            if hasattr(thrift_resp, 'status'):
+            if hasattr(thrift_resp, "status"):
                 msg = thrift_resp.status.errorMessage
                 raise dbt.exceptions.RuntimeException(msg)
             else:
                 raise dbt.exceptions.RuntimeException(str(exc))
 
     @classmethod
-    def validate_creds(cls, creds, required):
+    def validate_creds(cls, creds: DatabricksCredentials, required: List[str]) -> None:
         for key in required:
             if not hasattr(creds, key):
                 raise dbt.exceptions.DbtProfileError(
-                    "The config '{}' is required to connect to Databricks"
-                    .format(key)
+                    "The config '{}' is required to connect to Databricks".format(key)
                 )
 
     @classmethod
-    def open(cls, connection):
+    def open(cls, connection: Connection) -> Connection:
         if connection.state == ConnectionState.OPEN:
-            logger.debug('Connection is already open, skipping open.')
+            logger.debug("Connection is already open, skipping open.")
             return connection
 
-        creds = connection.credentials
-        exc = None
+        creds: DatabricksCredentials = connection.credentials
+        exc: Optional[Exception] = None
 
         for i in range(1 + creds.connect_retries):
             try:
@@ -193,7 +193,7 @@ class DatabricksConnectionManager(SparkConnectionManager):
                         "`http_path` must set when"
                         " using the dbsql method to connect to Databricks"
                     )
-                required_fields = ['host', 'http_path', 'token']
+                required_fields = ["host", "http_path", "token"]
 
                 cls.validate_creds(creds, required_fields)
 
@@ -213,9 +213,9 @@ class DatabricksConnectionManager(SparkConnectionManager):
                 if isinstance(e, EOFError):
                     # The user almost certainly has invalid credentials.
                     # Perhaps a token expired, or something
-                    msg = 'Failed to connect'
+                    msg = "Failed to connect"
                     if creds.token is not None:
-                        msg += ', is your token valid?'
+                        msg += ", is your token valid?"
                     raise dbt.exceptions.FailedToConnectException(msg) from e
                 retryable_message = _is_retryable_error(e)
                 if retryable_message and creds.connect_retries > 0:
@@ -237,10 +237,9 @@ class DatabricksConnectionManager(SparkConnectionManager):
                     logger.warning(msg)
                     time.sleep(creds.connect_timeout)
                 else:
-                    raise dbt.exceptions.FailedToConnectException(
-                        'failed to connect'
-                    ) from e
+                    raise dbt.exceptions.FailedToConnectException("failed to connect") from e
         else:
+            assert exc is not None
             raise exc
 
         connection.handle = handle

--- a/dbt/adapters/databricks/impl.py
+++ b/dbt/adapters/databricks/impl.py
@@ -11,7 +11,7 @@ from dbt.adapters.spark.impl import SparkAdapter
 
 @dataclass
 class DatabricksConfig(AdapterConfig):
-    file_format: str = 'delta'
+    file_format: str = "delta"
     location_root: Optional[str] = None
     partition_by: Optional[Union[List[str], str]] = None
     clustered_by: Optional[Union[List[str], str]] = None

--- a/dbt/adapters/databricks/relation.py
+++ b/dbt/adapters/databricks/relation.py
@@ -7,7 +7,6 @@ from dbt.adapters.spark.relation import SparkRelation
 
 @dataclass(frozen=True, eq=False, repr=False)
 class DatabricksRelation(SparkRelation):
-
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         if self.database != self.schema and self.database:
-            raise RuntimeException('Cannot set database in Databricks!')
+            raise RuntimeException("Cannot set database in Databricks!")

--- a/dbt/include/databricks/__init__.py
+++ b/dbt/include/databricks/__init__.py
@@ -1,2 +1,3 @@
 import os
+
 PACKAGE_PATH = os.path.dirname(__file__)

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -13,6 +13,8 @@ ipdb
 pytest-xdist>=2.1.0,<3
 flaky>=3.5.3,<4
 pytest-csv
+mypy==0.920
+black==21.12b0
 
 # Test requirements
 pytest-dbt-adapter==0.6.0

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,11 @@
+[mypy]
+strict_optional = True
+no_implicit_optional = True
+disallow_untyped_defs = True
+show_error_codes = True
+
+[mypy-dbt.*]
+ignore_missing_imports = True
+
+[mypy-databricks.*]
+ignore_missing_imports = True

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,20 @@
 [tox]
 skipsdist = True
-envlist = flake8, unit
+envlist = linter, unit
 
-[testenv:flake8]
+[testenv:linter]
 basepython = python3
-commands = /bin/bash -c '$(which flake8) --select=E,W,F --ignore=W504 dbt/'
+commands = /bin/bash -c '$(which black) --config black.ini --check dbt'
+           /bin/bash -c '$(which flake8) --select=E,W,F --ignore=E203 --max-line-length=100 dbt'
+           /bin/bash -c '$(which mypy) --config-file mypy.ini --namespace-packages --explicit-package-bases dbt'
+passenv = DBT_* PYTEST_ADDOPTS
+deps =
+     -r{toxinidir}/requirements.txt
+     -r{toxinidir}/dev_requirements.txt
+
+[testenv:black]
+basepython = python3
+commands = /bin/bash -c '$(which black) --config black.ini dbt'
 passenv = DBT_* PYTEST_ADDOPTS
 deps =
      -r{toxinidir}/dev_requirements.txt


### PR DESCRIPTION
### Description

Setups linter checks.

#### Rename `flake8` tox environment to `linter` and includes:
  - `mypy` check and fix the type hint errors.
  - `black` check and apply black formatter.

To run linter:

```
tox -e linter
```

#### Setup `black` tox environment to apply black formatter.

To apply black formatter:

```
tox -e black
```