### PR TITLE
Bump up databricks-sql-connector to 1.0.1 and use the Cursor APIs.

### DIFF
--- a/dbt/adapters/databricks/connections.py
+++ b/dbt/adapters/databricks/connections.py
@@ -4,7 +4,7 @@ import re
 import time
 from typing import Any, Callable, ClassVar, Dict, Iterator, List, Optional, Sequence, Tuple
 
-import agate
+from agate import Table
 
 import dbt.exceptions
 from dbt.adapters.base import Credentials
@@ -183,8 +183,8 @@ class DatabricksConnectionManager(SparkConnectionManager):
                 raise dbt.exceptions.RuntimeException(str(exc))
 
     def _execute_cursor(
-        self, log_sql: str, f: Callable[[DatabricksSQLCursor], None]
-    ) -> agate.Table:
+        self, log_sql: str, f: Callable[[DatabricksSQLConnectionWrapper], None]
+    ) -> Table:
         connection = self.get_thread_connection()
 
         fire_event(ConnectionUsed(conn_type=self.TYPE, conn_name=connection.name))
@@ -205,7 +205,7 @@ class DatabricksConnectionManager(SparkConnectionManager):
 
         return self.get_result_from_cursor(cursor)
 
-    def list_schemas(self, database: Optional[str], schema: Optional[str] = None) -> agate.Table:
+    def list_schemas(self, database: Optional[str], schema: Optional[str] = None) -> Table:
         return self._execute_cursor(
             "GetSchemas",
             lambda cursor: cursor.schemas(catalog_name=database, schema_name=schema),

--- a/dbt/adapters/databricks/connections.py
+++ b/dbt/adapters/databricks/connections.py
@@ -2,13 +2,17 @@ from contextlib import contextmanager
 from dataclasses import dataclass, field
 import re
 import time
-from typing import Any, ClassVar, Dict, Iterator, List, Optional, Sequence, Tuple
+from typing import Any, Callable, ClassVar, Dict, Iterator, List, Optional, Sequence, Tuple
+
+import agate
 
 import dbt.exceptions
 from dbt.adapters.base import Credentials
 from dbt.adapters.databricks import __version__
 from dbt.contracts.connection import Connection, ConnectionState
 from dbt.events import AdapterLogger
+from dbt.events.functions import fire_event
+from dbt.events.types import ConnectionUsed, SQLQuery, SQLQueryStatus
 from dbt.utils import DECIMALS
 
 from dbt.adapters.spark.connections import SparkConnectionManager, _is_retryable_error
@@ -134,6 +138,15 @@ class DatabricksSQLConnectionWrapper(object):
         assert self._cursor is not None
         return self._cursor.description
 
+    def schemas(
+        self, catalog_name: Optional[str] = None, schema_name: Optional[str] = None
+    ) -> None:
+        assert self._cursor is not None
+        self._cursor.schemas(
+            catalog_name=catalog_name if isinstance(catalog_name, str) else None,
+            schema_name=schema_name if isinstance(schema_name, str) else None,
+        )
+
 
 class DatabricksConnectionManager(SparkConnectionManager):
     TYPE: ClassVar[str] = "databricks"
@@ -168,6 +181,35 @@ class DatabricksConnectionManager(SparkConnectionManager):
                 raise dbt.exceptions.RuntimeException(msg)
             else:
                 raise dbt.exceptions.RuntimeException(str(exc))
+
+    def _execute_cursor(
+        self, log_sql: str, f: Callable[[DatabricksSQLCursor], None]
+    ) -> agate.Table:
+        connection = self.get_thread_connection()
+
+        fire_event(ConnectionUsed(conn_type=self.TYPE, conn_name=connection.name))
+
+        with self.exception_handler(log_sql):
+            fire_event(SQLQuery(conn_name=connection.name, sql=log_sql))
+            pre = time.time()
+
+            handle: DatabricksSQLConnectionWrapper = connection.handle
+            cursor = handle.cursor()
+            f(cursor)
+
+            fire_event(
+                SQLQueryStatus(
+                    status=str(self.get_response(cursor)), elapsed=round((time.time() - pre), 2)
+                )
+            )
+
+        return self.get_result_from_cursor(cursor)
+
+    def list_schemas(self, database: Optional[str], schema: Optional[str] = None) -> agate.Table:
+        return self._execute_cursor(
+            "GetSchemas",
+            lambda cursor: cursor.schemas(catalog_name=database, schema_name=schema),
+        )
 
     @classmethod
     def validate_creds(cls, creds: DatabricksCredentials, required: List[str]) -> None:

--- a/dbt/adapters/databricks/impl.py
+++ b/dbt/adapters/databricks/impl.py
@@ -29,3 +29,13 @@ class DatabricksAdapter(SparkAdapter):
     connections: DatabricksConnectionManager
 
     AdapterSpecificConfigs = DatabricksConfig
+
+    def list_schemas(self, database: Optional[str]) -> List[str]:
+        """Get a list of existing schemas in database."""
+        results = self.connections.list_schemas(database=database)
+        return [row[0] for row in results]
+
+    def check_schema_exists(self, database: Optional[str], schema: str) -> bool:
+        """Check if a schema exists."""
+        results = self.connections.list_schemas(database=database, schema=schema)
+        return schema.lower() in [row[0].lower() for row in results]

--- a/mypy.ini
+++ b/mypy.ini
@@ -9,3 +9,6 @@ ignore_missing_imports = True
 
 [mypy-databricks.*]
 ignore_missing_imports = True
+
+[mypy-agate.*]
+ignore_missing_imports = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-databricks-sql-connector>=0.9.0
+databricks-sql-connector>=1.0.1
 dbt-spark~=1.0.0

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ setup(
     include_package_data=True,
     install_requires=[
         'dbt-spark~={}'.format(dbt_core_version),
-        'databricks-sql-connector>=0.9.0',
+        'databricks-sql-connector>=1.0.1',
     ],
     zip_safe=False,
     classifiers=[


### PR DESCRIPTION
### Description

Bumps up databricks-sql-connector to `1.0.1` and use the Cursor APIs.

- `Cursor.schemas()` to retrieve a list of schemas.