### PR TITLE
Add integration test profiles against UC clusters.

### DIFF
--- a/tests/integration/base.py
+++ b/tests/integration/base.py
@@ -182,23 +182,31 @@ class DBTIntegrationTest(unittest.TestCase):
 
     def databricks_cluster_profile(self):
         return self._build_databricks_cluster_profile(
-            http_path=os.getenv('DBT_DATABRICKS_CLUSTER_HTTP_PATH'),
+            http_path=os.getenv(
+                "DBT_DATABRICKS_CLUSTER_HTTP_PATH", os.getenv("DBT_DATABRICKS_HTTP_PATH")
+            ),
         )
 
     def databricks_uc_cluster_profile(self):
         return self._build_databricks_cluster_profile(
-            http_path=os.getenv('DBT_DATABRICKS_UC_CLUSTER_HTTP_PATH'),
+            http_path=os.getenv(
+                "DBT_DATABRICKS_UC_CLUSTER_HTTP_PATH", os.getenv("DBT_DATABRICKS_HTTP_PATH")
+            ),
             catalog=os.getenv('DBT_DATABRICKS_UC_INITIAL_CATALOG', 'main'),
         )
 
     def databricks_sql_endpoint_profile(self):
         return self._build_databricks_cluster_profile(
-            http_path=os.getenv('DBT_DATABRICKS_ENDPOINT_HTTP_PATH'),
+            http_path=os.getenv(
+                "DBT_DATABRICKS_ENDPOINT_HTTP_PATH", os.getenv("DBT_DATABRICKS_HTTP_PATH")
+            ),
         )
 
     def databricks_uc_sql_endpoint_profile(self):
         return self._build_databricks_cluster_profile(
-            http_path=os.getenv('DBT_DATABRICKS_UC_ENDPOINT_HTTP_PATH'),
+            http_path=os.getenv(
+                "DBT_DATABRICKS_UC_ENDPOINT_HTTP_PATH", os.getenv("DBT_DATABRICKS_HTTP_PATH")
+            ),
             catalog=os.getenv('DBT_DATABRICKS_UC_INITIAL_CATALOG', 'main'),
         )
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -3,5 +3,11 @@ def pytest_configure(config):
         "markers", "profile_databricks_cluster"
     )
     config.addinivalue_line(
+        "markers", "profile_databricks_uc_cluster"
+    )
+    config.addinivalue_line(
         "markers", "profile_databricks_sql_endpoint"
+    )
+    config.addinivalue_line(
+        "markers", "profile_databricks_uc_sql_endpoint"
     )

--- a/tests/integration/current_catalog/models/current_catalog.sql
+++ b/tests/integration/current_catalog/models/current_catalog.sql
@@ -1,0 +1,1 @@
+SELECT current_catalog() as cat

--- a/tests/integration/current_catalog/models/expected.sql
+++ b/tests/integration/current_catalog/models/expected.sql
@@ -1,1 +1,1 @@
-SELECT '{{ env_var('DBT_DATABRICKS_UC_DEFAULT_CATALOG', 'main') }}' as cat
+SELECT '{{ env_var('DBT_DATABRICKS_UC_INITIAL_CATALOG', 'main') }}' as cat

--- a/tests/integration/current_catalog/models/expected.sql
+++ b/tests/integration/current_catalog/models/expected.sql
@@ -1,0 +1,1 @@
+SELECT '{{ env_var('DBT_DATABRICKS_UC_DEFAULT_CATALOG', 'main') }}' as cat

--- a/tests/integration/current_catalog/seeds/expected.csv
+++ b/tests/integration/current_catalog/seeds/expected.csv
@@ -1,0 +1,2 @@
+cat
+main

--- a/tests/integration/current_catalog/seeds/expected.csv
+++ b/tests/integration/current_catalog/seeds/expected.csv
@@ -1,2 +1,0 @@
-cat
-main

--- a/tests/integration/current_catalog/test_current_catalog.py
+++ b/tests/integration/current_catalog/test_current_catalog.py
@@ -19,7 +19,6 @@ class TestCurrentCatalog(DBTIntegrationTest):
         self.assertEqual(results[0][1], "true")
 
     def run_and_test(self):
-        self.run_dbt(['seed'])
         self.run_dbt(["run"])
         self.assertTablesEqual("current_catalog", "expected")
 

--- a/tests/integration/current_catalog/test_current_catalog.py
+++ b/tests/integration/current_catalog/test_current_catalog.py
@@ -30,5 +30,4 @@ class TestCurrentCatalog(DBTIntegrationTest):
 
     @use_profile("databricks_uc_sql_endpoint")
     def test_current_catalog_databricks_uc_sql_endpoint(self):
-        self.unity_catalog_enabled()
         self.run_and_test()

--- a/tests/integration/current_catalog/test_current_catalog.py
+++ b/tests/integration/current_catalog/test_current_catalog.py
@@ -12,7 +12,7 @@ class TestCurrentCatalog(DBTIntegrationTest):
 
     def unity_catalog_enabled(self):
         results = self.run_sql(
-            'SET spark.databricks.unityCatalog.enabled',
+            "SET spark.databricks.unityCatalog.enabled",
             fetch='all'
         )
         self.assertEqual(len(results), 1)

--- a/tests/integration/current_catalog/test_current_catalog.py
+++ b/tests/integration/current_catalog/test_current_catalog.py
@@ -1,0 +1,34 @@
+from tests.integration.base import DBTIntegrationTest, use_profile
+
+
+class TestCurrentCatalog(DBTIntegrationTest):
+    @property
+    def schema(self):
+        return "current_catalog"
+
+    @property
+    def models(self):
+        return "models"
+
+    def unity_catalog_enabled(self):
+        results = self.run_sql(
+            'SET spark.databricks.unityCatalog.enabled',
+            fetch='all'
+        )
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0][1], "true")
+
+    def run_and_test(self):
+        self.run_dbt(['seed'])
+        self.run_dbt(["run"])
+        self.assertTablesEqual("current_catalog", "expected")
+
+    @use_profile("databricks_uc_cluster")
+    def test_current_catalog_databricks_uc_cluster(self):
+        self.unity_catalog_enabled()
+        self.run_and_test()
+
+    @use_profile("databricks_uc_sql_endpoint")
+    def test_current_catalog_databricks_uc_sql_endpoint(self):
+        self.unity_catalog_enabled()
+        self.run_and_test()

--- a/tests/integration/get_columns_in_relation/test_get_columns_in_relation.py
+++ b/tests/integration/get_columns_in_relation/test_get_columns_in_relation.py
@@ -18,6 +18,14 @@ class TestGetColumnInRelationInSameRun(DBTIntegrationTest):
     def test_get_columns_in_relation_in_same_run_databricks_cluster(self):
         self.run_and_test()
 
+    @use_profile("databricks_uc_cluster")
+    def test_get_columns_in_relation_in_same_run_databricks_uc_cluster(self):
+        self.run_and_test()
+
     @use_profile("databricks_sql_endpoint")
     def test_get_columns_in_relation_in_same_run_databricks_sql_endpoint(self):
+        self.run_and_test()
+
+    @use_profile("databricks_uc_sql_endpoint")
+    def test_get_columns_in_relation_in_same_run_databricks_uc_sql_endpoint(self):
         self.run_and_test()

--- a/tests/integration/incremental_on_schema_change/test_incremental_on_schema_change.py
+++ b/tests/integration/incremental_on_schema_change/test_incremental_on_schema_change.py
@@ -87,6 +87,18 @@ class TestDeltaAppend(TestIncrementalOnSchemaChange):
     def test__databricks_cluster__run_incremental_sync_all_columns(self):
         self.run_incremental_sync_all_columns()
 
+    @use_profile('databricks_uc_cluster')
+    def test__databricks_uc_cluster__run_incremental_ignore(self):
+        self.run_incremental_ignore()
+
+    @use_profile('databricks_uc_cluster')
+    def test__databricks_uc_cluster__run_incremental_fail_on_schema_change(self):
+        self.run_incremental_fail_on_schema_change()
+
+    @use_profile('databricks_uc_cluster')
+    def test__databricks_uc_cluster__run_incremental_sync_all_columns(self):
+        self.run_incremental_sync_all_columns()
+
     @use_profile('databricks_sql_endpoint')
     def test__databricks_sql_endpoint__run_incremental_ignore(self):
         self.run_incremental_ignore()
@@ -97,6 +109,18 @@ class TestDeltaAppend(TestIncrementalOnSchemaChange):
 
     @use_profile('databricks_sql_endpoint')
     def test__databricks_sql_endpoint__run_incremental_sync_all_columns(self):
+        self.run_incremental_sync_all_columns()
+
+    @use_profile('databricks_uc_sql_endpoint')
+    def test__databricks_uc_sql_endpoint__run_incremental_ignore(self):
+        self.run_incremental_ignore()
+
+    @use_profile('databricks_uc_sql_endpoint')
+    def test__databricks_uc_sql_endpoint__run_incremental_fail_on_schema_change(self):
+        self.run_incremental_fail_on_schema_change()
+
+    @use_profile('databricks_uc_sql_endpoint')
+    def test__databricks_uc_sql_endpoint__run_incremental_sync_all_columns(self):
         self.run_incremental_sync_all_columns()
 
 
@@ -127,6 +151,22 @@ class TestDeltaOnSchemaChange(TestIncrementalOnSchemaChange):
     def test__databricks_cluster__run_incremental_sync_all_columns(self):
         self.run_incremental_sync_all_columns()
 
+    @use_profile('databricks_uc_cluster')
+    def test__databricks_uc_cluster__run_incremental_ignore(self):
+        self.run_incremental_ignore()
+
+    @use_profile('databricks_uc_cluster')
+    def test__databricks_uc_cluster__run_incremental_fail_on_schema_change(self):
+        self.run_incremental_fail_on_schema_change()
+
+    @use_profile('databricks_uc_cluster')
+    def test__databricks_uc_cluster__run_incremental_append_new_columns(self):
+        self.run_incremental_append_new_columns()
+
+    @use_profile('databricks_uc_cluster')
+    def test__databricks_uc_cluster__run_incremental_sync_all_columns(self):
+        self.run_incremental_sync_all_columns()
+
     @use_profile('databricks_sql_endpoint')
     def test__databricks_sql_endpoint__run_incremental_ignore(self):
         self.run_incremental_ignore()
@@ -141,4 +181,20 @@ class TestDeltaOnSchemaChange(TestIncrementalOnSchemaChange):
 
     @use_profile('databricks_sql_endpoint')
     def test__databricks_sql_endpoint__run_incremental_sync_all_columns(self):
+        self.run_incremental_sync_all_columns()
+
+    @use_profile('databricks_uc_sql_endpoint')
+    def test__databricks_uc_sql_endpoint__run_incremental_ignore(self):
+        self.run_incremental_ignore()
+
+    @use_profile('databricks_uc_sql_endpoint')
+    def test__databricks_uc_sql_endpoint__run_incremental_fail_on_schema_change(self):
+        self.run_incremental_fail_on_schema_change()
+
+    @use_profile('databricks_uc_sql_endpoint')
+    def test__databricks_uc_sql_endpoint__run_incremental_append_new_columns(self):
+        self.run_incremental_append_new_columns()
+
+    @use_profile('databricks_uc_sql_endpoint')
+    def test__databricks_uc_sql_endpoint__run_incremental_sync_all_columns(self):
         self.run_incremental_sync_all_columns()

--- a/tests/integration/incremental_strategies/test_incremental_strategies.py
+++ b/tests/integration/incremental_strategies/test_incremental_strategies.py
@@ -73,8 +73,16 @@ class TestDeltaStrategies(TestIncrementalStrategies):
     def test_delta_strategies_databricks_cluster(self):
         self.run_and_test()
 
+    @use_profile("databricks_uc_cluster")
+    def test_delta_strategies_databricks_uc_cluster(self):
+        self.run_and_test()
+
     @use_profile("databricks_sql_endpoint")
     def test_delta_strategies_databricks_sql_endpoint(self):
+        self.run_and_test()
+
+    @use_profile("databricks_uc_sql_endpoint")
+    def test_delta_strategies_databricks_uc_sql_endpoint(self):
         self.run_and_test()
 
 
@@ -115,6 +123,14 @@ class TestBadStrategies(TestIncrementalStrategies):
     def test_bad_strategies_databricks_cluster(self):
         self.run_and_test()
 
+    @use_profile("databricks_uc_cluster")
+    def test_bad_strategies_databricks_uc_cluster(self):
+        self.run_and_test()
+
     @use_profile("databricks_sql_endpoint")
     def test_bad_strategies_databricks_sql_endpoint(self):
+        self.run_and_test()
+
+    @use_profile("databricks_uc_sql_endpoint")
+    def test_bad_strategies_databricks_uc_sql_endpoint(self):
         self.run_and_test()

--- a/tests/integration/persist_docs/test_persist_docs.py
+++ b/tests/integration/persist_docs/test_persist_docs.py
@@ -64,6 +64,14 @@ class TestPersistDocsDelta(DBTIntegrationTest):
     def test_delta_comments_databricks_cluster(self):
         self.test_delta_comments()
 
+    @use_profile("databricks_uc_cluster")
+    def test_delta_comments_databricks_uc_cluster(self):
+        self.test_delta_comments()
+
     @use_profile("databricks_sql_endpoint")
     def test_delta_comments_databricks_sql_endpoint(self):
+        self.test_delta_comments()
+
+    @use_profile("databricks_uc_sql_endpoint")
+    def test_delta_comments_databricks_uc_sql_endpoint(self):
         self.test_delta_comments()

--- a/tests/integration/seed_column_types/test_seed_column_types.py
+++ b/tests/integration/seed_column_types/test_seed_column_types.py
@@ -24,6 +24,14 @@ class TestSeedColumnTypeCast(DBTIntegrationTest):
     def test_seed_column_types_databricks_cluster(self):
         self.run_dbt(["seed"])
 
+    @use_profile("databricks_uc_cluster")
+    def test_seed_column_types_databricks_uc_cluster(self):
+        self.run_dbt(["seed"])
+
     @use_profile("databricks_sql_endpoint")
     def test_seed_column_types_databricks_sql_endpoint(self):
+        self.run_dbt(["seed"])
+
+    @use_profile("databricks_uc_sql_endpoint")
+    def test_seed_column_types_databricks_uc_sql_endpoint(self):
         self.run_dbt(["seed"])

--- a/tests/integration/set_tblproperties/test_set_tblproperties.py
+++ b/tests/integration/set_tblproperties/test_set_tblproperties.py
@@ -47,6 +47,14 @@ class TestSetTblproperties(DBTIntegrationTest):
     def test_set_tblproperties_databricks_cluster(self):
         self.test_set_tblproperties()
 
+    @use_profile("databricks_uc_cluster")
+    def test_set_tblproperties_databricks_uc_cluster(self):
+        self.test_set_tblproperties()
+
     @use_profile("databricks_sql_endpoint")
     def test_set_tblproperties_databricks_sql_endpoint(self):
+        self.test_set_tblproperties()
+
+    @use_profile("databricks_uc_sql_endpoint")
+    def test_set_tblproperties_databricks_uc_sql_endpoint(self):
         self.test_set_tblproperties()

--- a/tests/integration/store_failures/test_store_failures.py
+++ b/tests/integration/store_failures/test_store_failures.py
@@ -30,8 +30,16 @@ class TestStoreFailuresDelta(TestStoreFailures):
     def test_store_failures_databricks_cluster(self):
         self.test_store_failures()
 
+    @use_profile("databricks_uc_cluster")
+    def test_store_failures_databricks_uc_cluster(self):
+        self.test_store_failures()
+
     @use_profile("databricks_sql_endpoint")
     def test_store_failures_databricks_sql_endpoint(self):
+        self.test_store_failures()
+
+    @use_profile("databricks_uc_sql_endpoint")
+    def test_store_failures_databricks_uc_sql_endpoint(self):
         self.test_store_failures()
 
 

--- a/tests/specs/databricks-cluster.dbtspec
+++ b/tests/specs/databricks-cluster.dbtspec
@@ -1,7 +1,7 @@
 target:
   type: databricks
   host: "{{ env_var('DBT_DATABRICKS_HOST_NAME') }}"
-  http_path: "{{ env_var('DBT_DATABRICKS_CLUSTER_HTTP_PATH') }}"
+  http_path: "{{ env_var('DBT_DATABRICKS_CLUSTER_HTTP_PATH', env_var('DBT_DATABRICKS_HTTP_PATH', '')) }}"
   token: "{{ env_var('DBT_DATABRICKS_TOKEN') }}"
   schema: "analytics_{{ var('_dbt_random_suffix') }}"
   connect_retries: 5

--- a/tests/specs/databricks-sql-endpoint.dbtspec
+++ b/tests/specs/databricks-sql-endpoint.dbtspec
@@ -1,7 +1,7 @@
 target:
   type: databricks
   host: "{{ env_var('DBT_DATABRICKS_HOST_NAME') }}"
-  http_path: "{{ env_var('DBT_DATABRICKS_ENDPOINT_HTTP_PATH') }}"
+  http_path: "{{ env_var('DBT_DATABRICKS_ENDPOINT_HTTP_PATH', env_var('DBT_DATABRICKS_HTTP_PATH', '')) }}"
   token: "{{ env_var('DBT_DATABRICKS_TOKEN') }}"
   schema: "analytics_{{ var('_dbt_random_suffix') }}"
   connect_retries: 5

--- a/tests/specs/databricks-uc-cluster.dbtspec
+++ b/tests/specs/databricks-uc-cluster.dbtspec
@@ -6,9 +6,9 @@ target:
   schema: "analytics_{{ var('_dbt_random_suffix') }}"
   # TODO: catalog should be set as 'catalog' or 'database'
   #       instead of using 'session_properties'
-  # catalog: "{{ env_var('DBT_DATABRICKS_UC_DEFAULT_CATALOG', 'main') }}"
+  # catalog: "{{ env_var('DBT_DATABRICKS_UC_INITIAL_CATALOG', 'main') }}"
   session_properties:
-    databricks.catalog: "{{ env_var('DBT_DATABRICKS_UC_DEFAULT_CATALOG', 'main') }}"
+    databricks.catalog: "{{ env_var('DBT_DATABRICKS_UC_INITIAL_CATALOG', 'main') }}"
   connect_retries: 5
   connect_timeout: 60
 projects:

--- a/tests/specs/databricks-uc-cluster.dbtspec
+++ b/tests/specs/databricks-uc-cluster.dbtspec
@@ -1,7 +1,7 @@
 target:
   type: databricks
   host: "{{ env_var('DBT_DATABRICKS_HOST_NAME') }}"
-  http_path: "{{ env_var('DBT_DATABRICKS_UC_CLUSTER_HTTP_PATH') }}"
+  http_path: "{{ env_var('DBT_DATABRICKS_UC_CLUSTER_HTTP_PATH', env_var('DBT_DATABRICKS_HTTP_PATH', '')) }}"
   token: "{{ env_var('DBT_DATABRICKS_TOKEN') }}"
   schema: "analytics_{{ var('_dbt_random_suffix') }}"
   # TODO: catalog should be set as 'catalog' or 'database'

--- a/tests/specs/databricks-uc-cluster.dbtspec
+++ b/tests/specs/databricks-uc-cluster.dbtspec
@@ -1,0 +1,35 @@
+target:
+  type: databricks
+  host: "{{ env_var('DBT_DATABRICKS_HOST_NAME') }}"
+  http_path: "{{ env_var('DBT_DATABRICKS_UC_CLUSTER_HTTP_PATH') }}"
+  token: "{{ env_var('DBT_DATABRICKS_TOKEN') }}"
+  schema: "analytics_{{ var('_dbt_random_suffix') }}"
+  # TODO: catalog should be set as 'catalog' or 'database'
+  #       instead of using 'session_properties'
+  # catalog: "{{ env_var('DBT_DATABRICKS_UC_DEFAULT_CATALOG', 'main') }}"
+  session_properties:
+    databricks.catalog: "{{ env_var('DBT_DATABRICKS_UC_DEFAULT_CATALOG', 'main') }}"
+  connect_retries: 5
+  connect_timeout: 60
+projects:
+  - overrides: snapshot_strategy_check_cols
+    dbt_project_yml: &file_format_delta
+      # we're going to UPDATE the seed tables as part of testing, so we must make them delta format
+      seeds:
+        dbt_test_project:
+          file_format: delta
+      snapshots:
+        dbt_test_project:
+          file_format: delta
+  - overrides: snapshot_strategy_timestamp
+    dbt_project_yml: *file_format_delta
+sequences:
+  test_dbt_empty: empty
+  test_dbt_base: base
+  test_dbt_ephemeral: ephemeral
+  test_dbt_incremental: incremental
+  test_dbt_snapshot_strategy_timestamp: snapshot_strategy_timestamp
+  test_dbt_snapshot_strategy_check_cols: snapshot_strategy_check_cols
+  test_dbt_data_test: data_test
+  test_dbt_ephemeral_data_tests: data_test_ephemeral_models
+  test_dbt_schema_test: schema_test

--- a/tests/specs/databricks-uc-sql-endpoint.dbtspec
+++ b/tests/specs/databricks-uc-sql-endpoint.dbtspec
@@ -6,9 +6,9 @@ target:
   schema: "analytics_{{ var('_dbt_random_suffix') }}"
   # TODO: catalog should be set as 'catalog' or 'database'
   #       instead of using 'session_properties'
-  # catalog: "{{ env_var('DBT_DATABRICKS_UC_DEFAULT_CATALOG', 'main') }}"
+  # catalog: "{{ env_var('DBT_DATABRICKS_UC_INITIAL_CATALOG', 'main') }}"
   session_properties:
-    databricks.catalog: "{{ env_var('DBT_DATABRICKS_UC_DEFAULT_CATALOG', 'main') }}"
+    databricks.catalog: "{{ env_var('DBT_DATABRICKS_UC_INITIAL_CATALOG', 'main') }}"
   connect_retries: 5
   connect_timeout: 60
 projects:

--- a/tests/specs/databricks-uc-sql-endpoint.dbtspec
+++ b/tests/specs/databricks-uc-sql-endpoint.dbtspec
@@ -1,0 +1,36 @@
+target:
+  type: databricks
+  host: "{{ env_var('DBT_DATABRICKS_HOST_NAME') }}"
+  http_path: "{{ env_var('DBT_DATABRICKS_UC_ENDPOINT_HTTP_PATH') }}"
+  token: "{{ env_var('DBT_DATABRICKS_TOKEN') }}"
+  schema: "analytics_{{ var('_dbt_random_suffix') }}"
+  # TODO: catalog should be set as 'catalog' or 'database'
+  #       instead of using 'session_properties'
+  # catalog: "{{ env_var('DBT_DATABRICKS_UC_DEFAULT_CATALOG', 'main') }}"
+  session_properties:
+    databricks.catalog: "{{ env_var('DBT_DATABRICKS_UC_DEFAULT_CATALOG', 'main') }}"
+  connect_retries: 5
+  connect_timeout: 60
+projects:
+  - overrides: snapshot_strategy_check_cols
+    dbt_project_yml: &file_format_delta
+      # we're going to UPDATE the seed tables as part of testing, so we must make them delta format
+      seeds:
+        dbt_test_project:
+          file_format: delta
+      snapshots:
+        dbt_test_project:
+          file_format: delta
+  - overrides: snapshot_strategy_timestamp
+    dbt_project_yml: *file_format_delta
+sequences:
+  test_dbt_empty: empty
+  # Skip for now as not all `SET` commands work on endpoints
+  # test_dbt_base: base
+  test_dbt_ephemeral: ephemeral
+  test_dbt_incremental: incremental
+  test_dbt_snapshot_strategy_timestamp: snapshot_strategy_timestamp
+  test_dbt_snapshot_strategy_check_cols: snapshot_strategy_check_cols
+  test_dbt_data_test: data_test
+  test_dbt_ephemeral_data_tests: data_test_ephemeral_models
+  test_dbt_schema_test: schema_test

--- a/tests/specs/databricks-uc-sql-endpoint.dbtspec
+++ b/tests/specs/databricks-uc-sql-endpoint.dbtspec
@@ -1,7 +1,7 @@
 target:
   type: databricks
   host: "{{ env_var('DBT_DATABRICKS_HOST_NAME') }}"
-  http_path: "{{ env_var('DBT_DATABRICKS_UC_ENDPOINT_HTTP_PATH') }}"
+  http_path: "{{ env_var('DBT_DATABRICKS_UC_ENDPOINT_HTTP_PATH', env_var('DBT_DATABRICKS_HTTP_PATH', '')) }}"
   token: "{{ env_var('DBT_DATABRICKS_TOKEN') }}"
   schema: "analytics_{{ var('_dbt_random_suffix') }}"
   # TODO: catalog should be set as 'catalog' or 'database'

--- a/tox.ini
+++ b/tox.ini
@@ -37,10 +37,30 @@ deps =
     -r{toxinidir}/dev_requirements.txt
     -e.
 
+[testenv:integration-databricks-uc-cluster]
+basepython = python3
+commands = /bin/bash -c '{envpython} -m pytest -v tests/specs/databricks-uc-cluster.dbtspec'
+           /bin/bash -c '{envpython} -m pytest -v -m profile_databricks_uc_cluster {posargs} -n4 tests/integration/*'
+passenv = DBT_* PYTEST_ADDOPTS
+deps =
+    -r{toxinidir}/requirements.txt
+    -r{toxinidir}/dev_requirements.txt
+    -e.
+
 [testenv:integration-databricks-sql-endpoint]
 basepython = python3
 commands = /bin/bash -c '{envpython} -m pytest -v tests/specs/databricks-sql-endpoint.dbtspec'
            /bin/bash -c '{envpython} -m pytest -v -m profile_databricks_sql_endpoint {posargs} -n4 tests/integration/*'
+passenv = DBT_* PYTEST_ADDOPTS
+deps =
+    -r{toxinidir}/requirements.txt
+    -r{toxinidir}/dev_requirements.txt
+    -e.
+
+[testenv:integration-databricks-uc-sql-endpoint]
+basepython = python3
+commands = /bin/bash -c '{envpython} -m pytest -v tests/specs/databricks-uc-sql-endpoint.dbtspec'
+           /bin/bash -c '{envpython} -m pytest -v -m profile_databricks_uc_sql_endpoint {posargs} -n4 tests/integration/*'
 passenv = DBT_* PYTEST_ADDOPTS
 deps =
     -r{toxinidir}/requirements.txt


### PR DESCRIPTION
### Description

Adds integration test profiles against UC clusters.

The http-path should be set by environment variables:

- `DBT_DATABRICKS_UC_CLUSTER_HTTP_PATH`
- `DBT_DATABRICKS_UC_ENDPOINT_HTTP_PATH`

The initial catalog can be set by:

- `DBT_DATABRICKS_UC_INITIAL_CATALOG`

or "main" if not exist.

To run the tests:

- `tox -e integration-databricks-uc-cluster`
- `tox -e integration-databricks-uc-sql-endpoint`