### PR TITLE
Upgrade black to 22.3.0

### DIFF
--- a/black.ini
+++ b/black.ini
@@ -1,4 +1,4 @@
 [tool.black]
-required-version = "21.12b0"
+required-version = "22.3.0"
 line-length = 100
 target-version = ['py38']

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -19,6 +19,7 @@ flaky>=3.5.3,<4
 pytest-csv
 mypy==0.920
 black==21.12b0
+click<8.1
 
 # Test requirements
 pytest-dbt-adapter==0.6.0

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -18,8 +18,7 @@ pytest-xdist>=2.1.0,<3
 flaky>=3.5.3,<4
 pytest-csv
 mypy==0.920
-black==21.12b0
-click<8.1
+black==22.3.0
 
 # Test requirements
 pytest-dbt-adapter==0.6.0


### PR DESCRIPTION
### Description

The `black` command fails due to the dependency issue https://github.com/psf/black/issues/2964.
Upgrades `black` to `22.3.0`.
