### PR TITLE
Add TestBaseAdapterMethodDatabricks.

### DIFF
--- a/tests/functional/adapter/test_basic.py
+++ b/tests/functional/adapter/test_basic.py
@@ -9,6 +9,7 @@ from dbt.tests.adapter.basic.test_incremental import BaseIncremental
 from dbt.tests.adapter.basic.test_generic_tests import BaseGenericTests
 from dbt.tests.adapter.basic.test_snapshot_check_cols import BaseSnapshotCheckCols
 from dbt.tests.adapter.basic.test_snapshot_timestamp import BaseSnapshotTimestamp
+from dbt.tests.adapter.basic.test_adapter_methods import BaseAdapterMethod
 
 
 class TestSimpleMaterializationsDatabricks(BaseSimpleMaterializations):
@@ -44,4 +45,8 @@ class TestSnapshotCheckColsDatabricks(BaseSnapshotCheckCols):
 
 
 class TestSnapshotTimestampDatabricks(BaseSnapshotTimestamp):
+    pass
+
+
+class TestBaseAdapterMethodDatabricks(BaseAdapterMethod):
     pass


### PR DESCRIPTION

### Description

Adds `TestBaseAdapterMethodDatabricks` that is a port from https://github.com/dbt-labs/dbt-spark/pull/328.