### PR TITLE
Set the upper bound on databricks-sql-connector.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-databricks-sql-connector>=1.0.1
+databricks-sql-connector>=1.0.1,<2.0
 dbt-spark~=1.0.1

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "dbt-spark~={}".format(dbt_spark_version),
-        "databricks-sql-connector>=1.0.1",
+        "databricks-sql-connector>=1.0.1,<2.0",
     ],
     zip_safe=False,
     classifiers=[


### PR DESCRIPTION
### Description

Sets the upper bound on `databricks-sql-connector`.

`databricks-sql-connector 2.0.0` has been released, but it has a dependency issue.