### PR TITLE
Fix snapshot to always drop the staging table

### DIFF
--- a/dbt/include/databricks/macros/materializations/snapshot.sql
+++ b/dbt/include/databricks/macros/materializations/snapshot.sql
@@ -50,6 +50,10 @@
       {% set build_sql = build_snapshot_table(strategy, model['compiled_sql']) %}
       {% set final_sql = create_table_as(False, target_relation, build_sql) %}
 
+      {% call statement('main') %}
+          {{ final_sql }}
+      {% endcall %}
+
   {% else %}
 
       {{ adapter.valid_snapshot_target(target_relation) }}
@@ -88,11 +92,11 @@
          )
       %}
 
-  {% endif %}
+      {% call statement_with_staging_table('main', staging_table) %}
+          {{ final_sql }}
+      {% endcall %}
 
-  {% call statement('main') %}
-      {{ final_sql }}
-  {% endcall %}
+  {% endif %}
 
   {% do persist_docs(target_relation, model) %}
 
@@ -101,10 +105,6 @@
   {{ run_hooks(post_hooks, inside_transaction=True) }}
 
   {{ adapter.commit() }}
-
-  {% if staging_table is defined %}
-      {% do post_snapshot(staging_table) %}
-  {% endif %}
 
   {{ run_hooks(post_hooks, inside_transaction=False) }}
 

--- a/dbt/include/databricks/macros/statement.sql
+++ b/dbt/include/databricks/macros/statement.sql
@@ -1,0 +1,16 @@
+{% macro statement_with_staging_table(name=None, staging_table=None, fetch_result=False, auto_begin=True) -%}
+  {%- if execute: -%}
+    {%- set sql = caller() -%}
+
+    {%- if name == 'main' -%}
+      {{ log('Writing runtime SQL for node "{}"'.format(model['unique_id'])) }}
+      {{ write(sql) }}
+    {%- endif -%}
+
+    {%- set res, table = adapter.execute(sql, auto_begin=auto_begin, fetch=fetch_result, staging_table=staging_table) -%}
+    {%- if name is not none -%}
+      {{ store_result(name, response=res, agate_table=table) }}
+    {%- endif -%}
+
+  {%- endif -%}
+{%- endmacro %}

--- a/dbt/include/databricks/macros/statement.sql
+++ b/dbt/include/databricks/macros/statement.sql
@@ -1,3 +1,4 @@
+{# executes a query and explicitly drops the staging table. #}
 {% macro statement_with_staging_table(name=None, staging_table=None, fetch_result=False, auto_begin=True) -%}
   {%- if execute: -%}
     {%- set sql = caller() -%}


### PR DESCRIPTION
### Description

We introduced Delta constraints at #71 and now that snapshot query could fail when it's violating the constraints.
In that case, the temporary view keeps existing because snapshot uses a permanent view and drop it later.

We should always drop them.