### PR TITLE
[1.0] Block taking jinja2.runtime.Undefined into DatabricksAdapter.

### DIFF
--- a/dbt/adapters/databricks/connections.py
+++ b/dbt/adapters/databricks/connections.py
@@ -203,8 +203,6 @@ class DatabricksConnectionManager(SparkConnectionManager):
         return self.get_result_from_cursor(cursor)
 
     def list_schemas(self, database: Optional[str], schema: Optional[str] = None) -> Table:
-        database = database if isinstance(database, str) else None
-        schema = schema if isinstance(schema, str) else None
         return self._execute_cursor(
             f"GetSchemas(database={database}, schema={schema})",
             lambda cursor: cursor.schemas(catalog_name=database, schema_name=schema),

--- a/dbt/adapters/databricks/impl.py
+++ b/dbt/adapters/databricks/impl.py
@@ -2,11 +2,12 @@ from dataclasses import dataclass
 from typing import Optional, List, Dict, Union
 
 from dbt.adapters.base import AdapterConfig
-from dbt.adapters.databricks import DatabricksConnectionManager
-from dbt.adapters.databricks.relation import DatabricksRelation
-from dbt.adapters.databricks.column import DatabricksColumn
-
 from dbt.adapters.spark.impl import SparkAdapter
+
+from dbt.adapters.databricks.column import DatabricksColumn
+from dbt.adapters.databricks.connections import DatabricksConnectionManager
+from dbt.adapters.databricks.relation import DatabricksRelation
+from dbt.adapters.databricks.utils import undefined_proof
 
 
 @dataclass
@@ -21,6 +22,7 @@ class DatabricksConfig(AdapterConfig):
     tblproperties: Optional[Dict[str, str]] = None
 
 
+@undefined_proof
 class DatabricksAdapter(SparkAdapter):
 
     Relation = DatabricksRelation

--- a/dbt/adapters/databricks/relation.py
+++ b/dbt/adapters/databricks/relation.py
@@ -1,12 +1,23 @@
 from dataclasses import dataclass
-
-from dbt.exceptions import RuntimeException
+from typing import Any, Dict
 
 from dbt.adapters.spark.relation import SparkRelation
+from dbt.exceptions import RuntimeException
+
+from dbt.adapters.databricks.utils import remove_undefined
 
 
 @dataclass(frozen=True, eq=False, repr=False)
 class DatabricksRelation(SparkRelation):
+    @classmethod
+    def __pre_deserialize__(cls, data: Dict[Any, Any]) -> Dict[Any, Any]:
+        data = super().__pre_deserialize__(data)
+        if "database" not in data["path"]:
+            data["path"]["database"] = None
+        else:
+            data["path"]["database"] = remove_undefined(data["path"]["database"])
+        return data
+
     def __post_init__(self) -> None:
         if self.database != self.schema and self.database:
             raise RuntimeException("Cannot set database in Databricks!")

--- a/dbt/adapters/databricks/utils.py
+++ b/dbt/adapters/databricks/utils.py
@@ -1,0 +1,51 @@
+import functools
+import inspect
+from typing import Any, Callable, Type, TypeVar
+
+from dbt.adapters.base import BaseAdapter
+from jinja2.runtime import Undefined
+
+
+A = TypeVar("A", bound=BaseAdapter)
+
+
+def remove_undefined(v: Any) -> Any:
+    return None if isinstance(v, Undefined) else v
+
+
+def undefined_proof(cls: Type[A]) -> Type[A]:
+    for name in cls._available_:
+        func = getattr(cls, name)
+        if not callable(func):
+            continue
+        try:
+            static_attr = inspect.getattr_static(cls, name)
+            isstatic = isinstance(static_attr, staticmethod)
+            isclass = isinstance(static_attr, classmethod)
+        except AttributeError:
+            isstatic = False
+            isclass = False
+        wrapped_function = _wrap_function(func.__func__ if isclass else func)
+        setattr(
+            cls,
+            name,
+            (
+                staticmethod(wrapped_function)
+                if isstatic
+                else classmethod(wrapped_function)
+                if isclass
+                else wrapped_function
+            ),
+        )
+
+    return cls
+
+
+def _wrap_function(func: Callable) -> Callable:
+    @functools.wraps(func)
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
+        new_args = [remove_undefined(arg) for arg in args]
+        new_kwargs = {key: remove_undefined(value) for key, value in kwargs.items()}
+        return func(*new_args, **new_kwargs)
+
+    return wrapper


### PR DESCRIPTION
### Description

Backport of #98 

Blocks taking `jinja2.runtime.Undefined` into `DatabricksAdapter`.

When calling the adapter method from macros, `jinja2.runtime.Undefined` can be passed to `DatabricksAdapter` that could cause unexpected behavior.

For example,

https://github.com/databricks/dbt-databricks/blob/b8152b697b003e02fb52e86f59b2bde4b492cc0a/dbt/include/databricks/macros/materializations/snapshot.sql#L33

The `model.database` is not defined and `jinja2.runtime.Undefined` will be used to call `adapter.check_schema_exists`.