### PR TITLE
Fix the user agent entry to avoid nested parens.

### DIFF
--- a/dbt/adapters/databricks/connections.py
+++ b/dbt/adapters/databricks/connections.py
@@ -259,7 +259,7 @@ class DatabricksConnectionManager(SparkConnectionManager):
 
                 dbt_databricks_version = __version__.version
                 dbt_invocation_env = os.getenv(DBT_INVOCATION_ENV) or "manual"
-                user_agent_entry = f"dbt-databricks/{dbt_databricks_version} ({dbt_invocation_env})"
+                user_agent_entry = f"dbt-databricks/{dbt_databricks_version}; {dbt_invocation_env}"
 
                 if parse(dbsql.__version__) < parse("2.0"):
                     session_configs = creds.session_properties or {}

--- a/tests/unit/test_adapter.py
+++ b/tests/unit/test_adapter.py
@@ -128,7 +128,7 @@ class TestDatabricksAdapter(unittest.TestCase):
                 self.assertNotIn(CATALOG_KEY_IN_SESSION_PROPERTIES, session_configuration)
                 self.assertEqual(
                     _user_agent_entry,
-                    f"dbt-databricks/{__version__.version} ({dbt_invocation_env})",
+                    f"dbt-databricks/{__version__.version}; {dbt_invocation_env}",
                 )
 
             return connect
@@ -156,7 +156,7 @@ class TestDatabricksAdapter(unittest.TestCase):
                 self.assertIsNone(catalog)
                 self.assertEqual(
                     _user_agent_entry,
-                    f"dbt-databricks/{__version__.version} ({dbt_invocation_env})",
+                    f"dbt-databricks/{__version__.version}; {dbt_invocation_env}",
                 )
 
             return connect
@@ -204,7 +204,7 @@ class TestDatabricksAdapter(unittest.TestCase):
                 self.assertEqual(session_configuration[CATALOG_KEY_IN_SESSION_PROPERTIES], "main")
                 self.assertEqual(
                     _user_agent_entry,
-                    f"dbt-databricks/{__version__.version} ({dbt_invocation_env})",
+                    f"dbt-databricks/{__version__.version}; {dbt_invocation_env}",
                 )
 
             return connect
@@ -232,7 +232,7 @@ class TestDatabricksAdapter(unittest.TestCase):
                 self.assertEqual(catalog, "main")
                 self.assertEqual(
                     _user_agent_entry,
-                    f"dbt-databricks/{__version__.version} ({dbt_invocation_env})",
+                    f"dbt-databricks/{__version__.version}; {dbt_invocation_env}",
                 )
 
             return connect


### PR DESCRIPTION
### Description

Fixes the user agent entry to avoid nested parens.

The full user agent was like `PyDatabricksSqlConnector/2.0.2 (dbt-databricks/1.2.0 (dbt-cloud))`, but we should avoid nested parens.

The full user agent after the fix will be like `PyDatabricksSqlConnector/2.0.2 (dbt-databricks/1.2.0; dbt-cloud)`.