### PR TITLE
Add setting of UC to the project template

### DIFF
--- a/dbt/include/databricks/profile_template.yml
+++ b/dbt/include/databricks/profile_template.yml
@@ -8,6 +8,12 @@ prompts:
   token:
     hint: 'dapiXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
     hide_input: true
+  _choose_unity_catalog:
+    'use Unity Catalog':
+      catalog:
+        hint: 'initial catalog'
+    'not use Unity Catalog':
+      _fixed_catalog: null
   schema:
     hint: 'default schema that dbt will build objects in'
   threads:


### PR DESCRIPTION
### Description

Adds setting of UC to the project template:

- When using UC:

```
$ dbt init
...
[1] use Unity Catalog
[2] not use Unity Catalog
Desired unity catalog option (enter a number): 1
catalog (initial catalog): cat
...
```

- When not using UC:

```
$ dbt init
...
[1] use Unity Catalog
[2] not use Unity Catalog
Desired unity catalog option (enter a number): 2
...
```