### PR TITLE
Add connection_parameters for databricks-sql-connector connection parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@
 ### Features
 - Add grants to materializations ([dbt-labs/dbt-spark#366](https://github.com/dbt-labs/dbt-spark/issues/366), [dbt-labs/dbt-spark#381](https://github.com/dbt-labs/dbt-spark/pull/381))
 - Add `connection_parameters` for databricks-sql-connector connection parameters ([#135](https://github.com/databricks/dbt-databricks/pull/135))
+    - This can be used to customize the connection by setting the additional parameters.
+    - The full parameters are listed at [Databricks SQL Connector for Python](https://docs.databricks.com/dev-tools/python-sql-connector.html#connect-method).
+    - Currently, the following parameters are reserved for `dbt-databricks`. Please use the normal credential settings instead.
+        - server_hostname
+        - http_path
+        - access_token
+        - session_configuration
+        - catalog
+        - schema
 
 ### Under the hood
 - Update `SparkColumn.numeric_type` to return `decimal` instead of `numeric`, since SparkSQL exclusively supports the former ([dbt-labs/dbt-spark#380](https://github.com/dbt-labs/dbt-spark/pull/380))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 ### Features
 - Add grants to materializations ([dbt-labs/dbt-spark#366](https://github.com/dbt-labs/dbt-spark/issues/366), [dbt-labs/dbt-spark#381](https://github.com/dbt-labs/dbt-spark/pull/381))
 - Add `connection_parameters` for databricks-sql-connector connection parameters ([#135](https://github.com/databricks/dbt-databricks/pull/135))
-    - This can be used to customize the connection by setting the additional parameters.
+    - This can be used to customize the connection by setting additional parameters.
     - The full parameters are listed at [Databricks SQL Connector for Python](https://docs.databricks.com/dev-tools/python-sql-connector.html#connect-method).
     - Currently, the following parameters are reserved for `dbt-databricks`. Please use the normal credential settings instead.
         - server_hostname

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Features
 - Add grants to materializations ([dbt-labs/dbt-spark#366](https://github.com/dbt-labs/dbt-spark/issues/366), [dbt-labs/dbt-spark#381](https://github.com/dbt-labs/dbt-spark/pull/381))
+- Add `connection_parameters` for databricks-sql-connector connection parameters ([#135](https://github.com/databricks/dbt-databricks/pull/135))
 
 ### Under the hood
 - Update `SparkColumn.numeric_type` to return `decimal` instead of `numeric`, since SparkSQL exclusively supports the former ([dbt-labs/dbt-spark#380](https://github.com/dbt-labs/dbt-spark/pull/380))

--- a/dbt/adapters/databricks/connections.py
+++ b/dbt/adapters/databricks/connections.py
@@ -38,6 +38,7 @@ class DatabricksCredentials(Credentials):
     connect_retries: int = 0
     connect_timeout: int = 10
     session_properties: Optional[Dict[str, Any]] = None
+    connection_parameters: Optional[Dict[str, Any]] = None
     retry_all: bool = False
 
     _ALIASES = {
@@ -64,8 +65,29 @@ class DatabricksCredentials(Credentials):
                 )
         self.session_properties = session_properties
 
-        if self.database is not None and not self.database.strip():
-            raise dbt.exceptions.ValidationException(f"Invalid catalog name : {self.database}.")
+        if self.database is not None:
+            database = self.database.strip()
+            if not database:
+                raise dbt.exceptions.ValidationException(
+                    f"Invalid catalog name : `{self.database}`."
+                )
+            self.database = database
+
+        connection_parameters = self.connection_parameters or {}
+        for key in (
+            "server_hostname",
+            "http_path",
+            "access_token",
+            "session_configuration",
+            "catalog",
+            "schema",
+            "_user_agent_entry",
+        ):
+            if key in connection_parameters:
+                raise dbt.exceptions.ValidationException(
+                    f"The connection parameter `{key}` is reserved."
+                )
+        self.connection_parameters = connection_parameters
 
     @property
     def type(self) -> str:
@@ -253,7 +275,9 @@ class DatabricksConnectionManager(SparkConnectionManager):
                     access_token=creds.token,
                     session_configuration=creds.session_properties,
                     catalog=creds.database,
+                    # schema=creds.schema,  # TODO: Explicitly set once DBR 7.3LTS is EOL.
                     _user_agent_entry=user_agent_entry,
+                    **creds.connection_parameters,
                 )
                 handle = DatabricksSQLConnectionWrapper(conn)
                 break

--- a/tests/unit/test_adapter.py
+++ b/tests/unit/test_adapter.py
@@ -115,6 +115,28 @@ class TestDatabricksAdapter(unittest.TestCase):
                 },
             )
 
+    def test_reserved_connection_parameters(self):
+        with self.assertRaisesRegex(
+            dbt.exceptions.DbtProfileError,
+            "The connection parameter `server_hostname` is reserved.",
+        ):
+            config_from_parts_or_dicts(
+                self.project_cfg,
+                {
+                    "outputs": {
+                        "test": {
+                            "type": "databricks",
+                            "schema": "analytics",
+                            "host": "yourorg.databricks.com",
+                            "http_path": "sql/protocolv1/o/1234567890123456/1234-567890-test123",
+                            "token": "dapiXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+                            "connection_parameters": {"server_hostname": "theirorg.databricks.com"},
+                        }
+                    },
+                    "target": "test",
+                },
+            )
+
     def _connect_func(self, *, expected_catalog=None):
         def connect(
             server_hostname,


### PR DESCRIPTION
### Description

Adds `connection_parameters` as part of credential for `databricks-sql-connector` connection parameters.

This can be used to customize the connection by setting additional parameters.
The full parameters are listed at [Databricks SQL Connector for Python](https://docs.databricks.com/dev-tools/python-sql-connector.html#connect-method).

Currently, the following parameters are reserved for `dbt-databricks`.

- server_hostname
- http_path
- access_token
- session_configuration
- catalog
- schema
