### PR TITLE
Avoid using default as a temporary fix for dbt-labs/dbt-core#5359.

### DIFF
--- a/dbt/include/databricks/macros/materializations/incremental/incremental.sql
+++ b/dbt/include/databricks/macros/materializations/incremental/incremental.sql
@@ -2,7 +2,7 @@
 
   {#-- Validate early so we don't run SQL if the file_format + strategy combo is invalid --#}
   {%- set raw_file_format = config.get('file_format', default='delta') -%}
-  {%- set raw_strategy = config.get('incremental_strategy', default='merge') -%}
+  {%- set raw_strategy = config.get('incremental_strategy') or 'merge' -%}
   {%- set grant_config = config.get('grants') -%}
 
   {%- set file_format = dbt_spark_validate_get_file_format(raw_file_format) -%}


### PR DESCRIPTION
### Description

Avoids using default as a temporary fix for dbt-labs/dbt-core#5359.

This is a temporary fix and dbt-labs/dbt-spark#394 should be ported later.