### PR TITLE
Apply connection retry refactor, add defaults with exponential backoff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Features
 - Support Python 3.11 ([#233](https://github.com/databricks/dbt-databricks/pull/233))
 - Support `incremental_predicates` ([#161](https://github.com/databricks/dbt-databricks/pull/161))
+- Apply connection retry refactor, add defaults with exponential backoff ([#137](https://github.com/databricks/dbt-databricks/pull/137))
 
 ## dbt-databricks 1.3.3 (Release TBD)
 

--- a/dbt/adapters/databricks/connections.py
+++ b/dbt/adapters/databricks/connections.py
@@ -25,7 +25,7 @@ from agate import Table
 import dbt.exceptions
 from dbt.adapters.base import Credentials
 from dbt.adapters.base.query_headers import MacroQueryStringSetter
-from dbt.adapters.databricks.__version__ import version as __version__
+from dbt.adapters.spark.connections import SparkConnectionManager
 from dbt.clients import agate_helper
 from dbt.contracts.connection import (
     AdapterResponse,
@@ -39,19 +39,14 @@ from dbt.events.functions import fire_event
 from dbt.events.types import ConnectionUsed, SQLQuery, SQLQueryStatus
 from dbt.utils import DECIMALS, cast_to_str
 
-from dbt.adapters.spark.connections import SparkConnectionManager
-
 from databricks import sql as dbsql
 from databricks.sql.client import (
     Connection as DatabricksSQLConnection,
     Cursor as DatabricksSQLCursor,
 )
-from databricks.sql.exc import (
-    Error,
-    InternalError,
-    RequestError,
-    ServerOperationError,
-)
+from databricks.sql.exc import Error
+
+from dbt.adapters.databricks.__version__ import version as __version__
 from dbt.adapters.databricks.utils import redact_credentials
 
 logger = AdapterLogger("Databricks")
@@ -589,11 +584,7 @@ class DatabricksConnectionManager(SparkConnectionManager):
         def exponential_backoff(attempt: int) -> int:
             return attempt * attempt
 
-        retryable_exceptions = [
-            InternalError,
-            RequestError,
-            ServerOperationError,
-        ]
+        retryable_exceptions = []
         # this option is for backwards compatibility
         if creds.retry_all:
             retryable_exceptions = [Error]


### PR DESCRIPTION
### Description

Applies connection retry refactor, add defaults with exponential backoff as per an item from #127.

- Refactors retry logic to use `retry_connection` from core.
- Adds consistent defaults with other adpaters:
  - if `connect_retries` and `connect_timeout` are not specified: 1 retry after 1s
  - if `connect_retries` is specified but `connect_timeout` is not, it will use exponential backoff
