### PR TITLE
Refine DatabricksCredentials._connection_keys to show only meaningful configs

### DIFF
--- a/dbt/adapters/databricks/connections.py
+++ b/dbt/adapters/databricks/connections.py
@@ -103,8 +103,6 @@ class DatabricksCredentials(Credentials):
             connection_keys.insert(2, "catalog")
         if self.session_properties:
             connection_keys.append("session_properties")
-        if self.connection_parameters:
-            connection_keys.append("connection_parameters")
         return tuple(connection_keys)
 
 

--- a/dbt/adapters/databricks/connections.py
+++ b/dbt/adapters/databricks/connections.py
@@ -98,7 +98,14 @@ class DatabricksCredentials(Credentials):
         return self.host
 
     def _connection_keys(self) -> Tuple[str, ...]:
-        return "host", "http_path", "database", "schema", "session_properties"
+        connection_keys = ["host", "http_path", "schema"]
+        if self.database:
+            connection_keys.insert(2, "catalog")
+        if self.session_properties:
+            connection_keys.append("session_properties")
+        if self.connection_parameters:
+            connection_keys.append("connection_parameters")
+        return tuple(connection_keys)
 
 
 class DatabricksSQLConnectionWrapper(object):


### PR DESCRIPTION
### Description

Refines `DatabricksCredentials._connection_keys` to show only meaningful configs.

Currently `dbt debug` shows always shows `host`, `http_path`, `database`, `schema`, and `session_properties`, but we should show only meaningful configs.

Also use `catalog` instead of `database` for the catalog config name:

For example:

```
$ dbt debug
...
Connection:
  host: your.databrickshost.com
  http_path: /sql/your/http/path
  schema: schema_name
...
```

If `catalog` is set:

```
$ dbt debug
...
Connection:
  host: your.databrickshost.com
  http_path: /sql/your/http/path
  catalog: catalog_name
  schema: schema_name
...
```
