### PR TITLE
Fix DatabricksCredentials._connection_keys

### DIFF
--- a/dbt/adapters/databricks/connections.py
+++ b/dbt/adapters/databricks/connections.py
@@ -98,9 +98,7 @@ class DatabricksCredentials(Credentials):
         return self.host
 
     def _connection_keys(self) -> Tuple[str, ...]:
-        connection_keys = ["host", "http_path", "schema"]
-        if self.database:
-            connection_keys.insert(2, "catalog")
+        connection_keys = ["host", "http_path", "database", "schema"]
         if self.session_properties:
             connection_keys.append("session_properties")
         return tuple(connection_keys)


### PR DESCRIPTION
### Description

Fixes `DatabricksCredentials._connection_keys`.

- `catalog` can't be used; should use `database`
- `database` can't be removed.

Otherwise, `Undefined` object comes from somewhere:

```
TypeError: can not serialize 'Undefined' object
```