### PR TITLE
Upgrade the lower bound for databricks-sql-connector

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-databricks-sql-connector>=2.0.1
+databricks-sql-connector>=2.0.2
 dbt-spark~=1.3.0a1

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "dbt-spark~={}".format(dbt_spark_version),
-        "databricks-sql-connector>=2.0.1",
+        "databricks-sql-connector>=2.0.2",
     ],
     zip_safe=False,
     classifiers=[


### PR DESCRIPTION
### Description

Upgrades the lower bound for `databricks-sql-connector` to `2.0.2`.