### PR TITLE
Set upper bound for databricks-sql-connector instead of Python

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@
 - Update `SparkColumn.numeric_type` to return `decimal` instead of `numeric`, since SparkSQL exclusively supports the former ([dbt-labs/dbt-spark#380](https://github.com/dbt-labs/dbt-spark/pull/380))
 - Make minimal changes to support dbt Core incremental materialization refactor ([dbt-labs/dbt-spark#402](https://github.com/dbt-labs/dbt-spark/issue/402), [dbt-labs/dbt-spark#394](httpe://github.com/dbt-labs/dbt-spark/pull/394), [#136](https://github.com/databricks/dbt-databricks/pull/136))
 - Add new basic tests `TestDocsGenerateDatabricks` and `TestDocsGenReferencesDatabricks` ([#134](https://github.com/databricks/dbt-databricks/pull/134))
+- Set upper bound for `databricks-sql-connector` when Python 3.10 ([#154](https://github.com/databricks/dbt-databricks/pull/154))
+    - Note that `databricks-sql-connector` does not officially support Python 3.10 yet.
 
 ### Contributors
 - [@grindheim](https://github.com/grindheim) ([dbt-labs/dbt-spark#287](https://github.com/dbt-labs/dbt-spark/pull/287/))

--- a/README.md
+++ b/README.md
@@ -67,4 +67,7 @@ These following quick starts will get you up and running with the `dbt-databrick
 
 ### Compatibility
 
-The `dbt-databricks` adapter has been tested against `Databricks SQL` and `Databricks runtime releases 9.1 LTS` and later.
+The `dbt-databricks` adapter has been tested:
+
+- with Python >=3.7, <3.10.
+- against `Databricks SQL` and `Databricks runtime releases 9.1 LTS` and later.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
-databricks-sql-connector>=2.0.2
+databricks-sql-connector>=2.0.2; python_version<'3.10'
+databricks-sql-connector>=2.0.2,<2.0.3; python_version=='3.10'
 dbt-spark~=1.3.0a1

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,8 @@ setup(
     include_package_data=True,
     install_requires=[
         "dbt-spark~={}".format(dbt_spark_version),
-        "databricks-sql-connector>=2.0.2",
+        "databricks-sql-connector>=2.0.2; python_version<'3.10'",
+        "databricks-sql-connector>=2.0.2,<2.0.3; python_version=='3.10'",
     ],
     zip_safe=False,
     classifiers=[
@@ -69,5 +70,5 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
     ],
-    python_requires=">=3.7,<3.10",
+    python_requires=">=3.7",
 )


### PR DESCRIPTION
### Description

Set upper bound for `databricks-sql-connector` when Python 3.10 instead of `Python`.

Note that `databricks-sql-connector` doesn't support Python 3.10 yet, so `dbt-databricks` doesn't either.