### PR TITLE
Backports to 1.1.latest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## dbt-databricks 1.1.2 (Release TBD)
 
+- Set upper bound for `databricks-sql-connector` when Python 3.10 ([#154](https://github.com/databricks/dbt-databricks/pull/154))
+    - Note that `databricks-sql-connector` does not officially support Python 3.10 yet.
+
 ## dbt-databricks 1.1.1 (July 19, 2022)
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -67,4 +67,7 @@ These following quick starts will get you up and running with the `dbt-databrick
 
 ### Compatibility
 
-The `dbt-databricks` adapter has been tested against `Databricks SQL` and `Databricks runtime releases 9.1 LTS` and later.
+The `dbt-databricks` adapter has been tested:
+
+- with Python >=3.7, <3.10.
+- against `Databricks SQL` and `Databricks runtime releases 9.1 LTS` and later.

--- a/dbt/adapters/databricks/connections.py
+++ b/dbt/adapters/databricks/connections.py
@@ -1,5 +1,6 @@
 from contextlib import contextmanager
 from dataclasses import dataclass
+import os
 import re
 import time
 from typing import Any, Callable, ClassVar, Dict, Iterator, List, Optional, Sequence, Tuple
@@ -27,6 +28,8 @@ from databricks.sql.exc import Error as DBSQLError
 logger = AdapterLogger("Databricks")
 
 CATALOG_KEY_IN_SESSION_PROPERTIES = "databricks.catalog"
+DBT_DATABRICKS_INVOCATION_ENV = "DBT_DATABRICKS_INVOCATION_ENV"
+DBT_DATABRICKS_INVOCATION_ENV_REGEX = re.compile("^[A-z0-9\\-]+$")
 
 
 @dataclass
@@ -224,6 +227,14 @@ class DatabricksConnectionManager(SparkConnectionManager):
                 )
 
     @classmethod
+    def validate_invocation_env(cls, invocation_env: str) -> None:
+        # Thrift doesn't allow nested () so we need to ensure that the passed user agent is valid
+        if not DBT_DATABRICKS_INVOCATION_ENV_REGEX.search(invocation_env):
+            raise dbt.exceptions.ValidationException(
+                f"Invalid invocation environment: {invocation_env}"
+            )
+
+    @classmethod
     def open(cls, connection: Connection) -> Connection:
         if connection.state == ConnectionState.OPEN:
             logger.debug("Connection is already open, skipping open.")
@@ -231,6 +242,14 @@ class DatabricksConnectionManager(SparkConnectionManager):
 
         creds: DatabricksCredentials = connection.credentials
         exc: Optional[Exception] = None
+
+        dbt_databricks_version = __version__.version
+        user_agent_entry = f"dbt-databricks/{dbt_databricks_version}"
+
+        invocation_env = os.environ.get(DBT_DATABRICKS_INVOCATION_ENV)
+        if invocation_env is not None and len(invocation_env) > 0:
+            cls.validate_invocation_env(invocation_env)
+            user_agent_entry = f"{user_agent_entry}; {invocation_env}"
 
         for i in range(1 + creds.connect_retries):
             try:
@@ -242,9 +261,6 @@ class DatabricksConnectionManager(SparkConnectionManager):
                 required_fields = ["host", "http_path", "token"]
 
                 cls.validate_creds(creds, required_fields)
-
-                dbt_databricks_version = __version__.version
-                user_agent_entry = f"dbt-databricks/{dbt_databricks_version}"
 
                 # TODO: what is the error when a user specifies a catalog they don't have access to
                 conn: DatabricksSQLConnection = dbsql.connect(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
-databricks-sql-connector>=2.0.1
+databricks-sql-connector>=2.0.2; python_version<'3.10'
+databricks-sql-connector>=2.0.2,<2.0.3; python_version=='3.10'
 dbt-spark~=1.1.0

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,8 @@ setup(
     include_package_data=True,
     install_requires=[
         "dbt-spark~={}".format(dbt_spark_version),
-        "databricks-sql-connector>=2.0.1",
+        "databricks-sql-connector>=2.0.2; python_version<'3.10'",
+        "databricks-sql-connector>=2.0.2,<2.0.3; python_version=='3.10'",
     ],
     zip_safe=False,
     classifiers=[

--- a/tests/unit/test_adapter.py
+++ b/tests/unit/test_adapter.py
@@ -7,7 +7,10 @@ import dbt.exceptions
 
 from dbt.adapters.databricks import __version__
 from dbt.adapters.databricks import DatabricksAdapter, DatabricksRelation
-from dbt.adapters.databricks.connections import CATALOG_KEY_IN_SESSION_PROPERTIES
+from dbt.adapters.databricks.connections import (
+    CATALOG_KEY_IN_SESSION_PROPERTIES,
+    DBT_DATABRICKS_INVOCATION_ENV,
+)
 from tests.unit.utils import config_from_parts_or_dicts
 
 
@@ -115,7 +118,32 @@ class TestDatabricksAdapter(unittest.TestCase):
                 },
             )
 
-    def _connect_func(self, *, expected_catalog=None):
+    def test_invalid_custom_user_agent(self):
+        with self.assertRaisesRegex(
+            dbt.exceptions.ValidationException,
+            "Invalid invocation environment",
+        ):
+            config = self._get_target_databricks_sql_connector(self.project_cfg)
+            adapter = DatabricksAdapter(config)
+            with mock.patch.dict("os.environ", **{DBT_DATABRICKS_INVOCATION_ENV: "(Some-thing)"}):
+                connection = adapter.acquire_connection("dummy")
+                connection.handle  # trigger lazy-load
+
+    def test_custom_user_agent(self):
+        config = self._get_target_databricks_sql_connector(self.project_cfg)
+        adapter = DatabricksAdapter(config)
+
+        with mock.patch(
+            "dbt.adapters.databricks.connections.dbsql.connect",
+            new=self._connect_func(expected_invocation_env="databricks-workflows"),
+        ):
+            with mock.patch.dict(
+                "os.environ", **{DBT_DATABRICKS_INVOCATION_ENV: "databricks-workflows"}
+            ):
+                connection = adapter.acquire_connection("dummy")
+                connection.handle  # trigger lazy-load
+
+    def _connect_func(self, *, expected_catalog=None, expected_invocation_env=None):
         def connect(
             server_hostname,
             http_path,
@@ -132,7 +160,13 @@ class TestDatabricksAdapter(unittest.TestCase):
                 self.assertIsNone(catalog)
             else:
                 self.assertEqual(catalog, expected_catalog)
-            self.assertEqual(_user_agent_entry, f"dbt-databricks/{__version__.version}")
+            if expected_invocation_env is not None:
+                self.assertEqual(
+                    _user_agent_entry,
+                    f"dbt-databricks/{__version__.version}; {expected_invocation_env}",
+                )
+            else:
+                self.assertEqual(_user_agent_entry, f"dbt-databricks/{__version__.version}")
 
         return connect
 


### PR DESCRIPTION
### Description

Backports two commits to `1.1.latest`.

- Set upper bound for databricks-sql-connector instead of Python (#154)
- Include the value of environment variable "DBT_DATABRICKS_INVOCATION_ENV" to the user agent entry. (#155)
