### PR TITLE
Support Python 3.10

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -80,7 +80,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
 
     env:
       TOXENV: "unit"
@@ -177,7 +177,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.7", "3.8", "3.9"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
 
     steps:
       - name: Set up Python ${{ matrix.python-version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## dbt-databricks 1.3.0 (Release TBD)
 
+## dbt-databricks 1.2.1 (Release TBD)
+
+### Features
+- Support Python 3.10 ([#158](https://github.com/databricks/dbt-databricks/pull/158))
+
 ## dbt-databricks 1.2.0 (August 16, 2022)
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -69,5 +69,5 @@ These following quick starts will get you up and running with the `dbt-databrick
 
 The `dbt-databricks` adapter has been tested:
 
-- with Python >=3.7, <3.10.
+- with Python 3.7 or above.
 - against `Databricks SQL` and `Databricks runtime releases 9.1 LTS` and later.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-databricks-sql-connector>=2.0.2; python_version<'3.10'
-databricks-sql-connector>=2.0.2,<2.0.3; python_version=='3.10'
+databricks-sql-connector>=2.0.4
 dbt-spark~=1.3.0a1

--- a/setup.py
+++ b/setup.py
@@ -56,8 +56,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "dbt-spark~={}".format(dbt_spark_version),
-        "databricks-sql-connector>=2.0.2; python_version<'3.10'",
-        "databricks-sql-connector>=2.0.2,<2.0.3; python_version=='3.10'",
+        "databricks-sql-connector>=2.0.4",
     ],
     zip_safe=False,
     classifiers=[
@@ -69,6 +68,7 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
     ],
     python_requires=">=3.7",
 )


### PR DESCRIPTION
### Description

Supports Python 3.10.

[`databricks-sql-connector 2.0.4`](https://pypi.org/project/databricks-sql-connector/2.0.4/) has been released with [Python 3.10 support](https://github.com/databricks/databricks-sql-python/issues/26).