### PR TITLE
Backports to 1.1.latest

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -78,7 +78,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
 
     env:
       TOXENV: "unit"
@@ -177,7 +177,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.7, 3.8, 3.9]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
 
     steps:
       - name: Set up Python ${{ matrix.python-version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## dbt-databricks 1.1.3 (Release TBD)
 
 ### Features
+- Support Python 3.10 ([#158](https://github.com/databricks/dbt-databricks/pull/158))
 - Add `connection_parameters` for databricks-sql-connector connection parameters ([#135](https://github.com/databricks/dbt-databricks/pull/135))
     - This can be used to customize the connection by setting additional parameters.
     - The full parameters are listed at [Databricks SQL Connector for Python](https://docs.databricks.com/dev-tools/python-sql-connector.html#connect-method).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 ## dbt-databricks 1.1.3 (Release TBD)
 
+### Features
+- Add `connection_parameters` for databricks-sql-connector connection parameters ([#135](https://github.com/databricks/dbt-databricks/pull/135))
+    - This can be used to customize the connection by setting additional parameters.
+    - The full parameters are listed at [Databricks SQL Connector for Python](https://docs.databricks.com/dev-tools/python-sql-connector.html#connect-method).
+    - Currently, the following parameters are reserved for `dbt-databricks`. Please use the normal credential settings instead.
+        - server_hostname
+        - http_path
+        - access_token
+        - session_configuration
+        - catalog
+        - schema
+
 ## dbt-databricks 1.1.2 (August 18, 2022)
 
 ### Under the hood

--- a/README.md
+++ b/README.md
@@ -69,5 +69,5 @@ These following quick starts will get you up and running with the `dbt-databrick
 
 The `dbt-databricks` adapter has been tested:
 
-- with Python >=3.7, <3.10.
+- with Python 3.7 or above.
 - against `Databricks SQL` and `Databricks runtime releases 9.1 LTS` and later.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-databricks-sql-connector>=2.0.2; python_version<'3.10'
-databricks-sql-connector>=2.0.2,<2.0.3; python_version=='3.10'
+databricks-sql-connector>=2.0.4
 dbt-spark~=1.1.0

--- a/setup.py
+++ b/setup.py
@@ -56,8 +56,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "dbt-spark~={}".format(dbt_spark_version),
-        "databricks-sql-connector>=2.0.2; python_version<'3.10'",
-        "databricks-sql-connector>=2.0.2,<2.0.3; python_version=='3.10'",
+        "databricks-sql-connector>=2.0.4",
     ],
     zip_safe=False,
     classifiers=[
@@ -69,6 +68,7 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
     ],
     python_requires=">=3.7",
 )

--- a/tests/unit/test_adapter.py
+++ b/tests/unit/test_adapter.py
@@ -118,6 +118,28 @@ class TestDatabricksAdapter(unittest.TestCase):
                 },
             )
 
+    def test_reserved_connection_parameters(self):
+        with self.assertRaisesRegex(
+            dbt.exceptions.DbtProfileError,
+            "The connection parameter `server_hostname` is reserved.",
+        ):
+            config_from_parts_or_dicts(
+                self.project_cfg,
+                {
+                    "outputs": {
+                        "test": {
+                            "type": "databricks",
+                            "schema": "analytics",
+                            "host": "yourorg.databricks.com",
+                            "http_path": "sql/protocolv1/o/1234567890123456/1234-567890-test123",
+                            "token": "dapiXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+                            "connection_parameters": {"server_hostname": "theirorg.databricks.com"},
+                        }
+                    },
+                    "target": "test",
+                },
+            )
+
     def test_invalid_custom_user_agent(self):
         with self.assertRaisesRegex(
             dbt.exceptions.ValidationException,


### PR DESCRIPTION
### Description

Backports two commits to `1.1.latest`.

- Add connection_parameters for databricks-sql-connector connection parameters (#135)
- Support Python 3.10 (#158)