### PR TITLE
Backports to 1.1.latest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## dbt-databricks 1.1.4 (Release TBD)
 
+### Fixes
+- Data is duplicated on reloading seeds that are using an external table ([#114](https://github.com/databricks/dbt-databricks/issues/114), [#149](https://github.com/databricks/dbt-databricks/issues/149))
+
 ### Under the hood
 - Explicitly close cursors ([#163](https://github.com/databricks/dbt-databricks/pull/163))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## dbt-databricks 1.1.4 (Release TBD)
 
+### Under the hood
+- Explicitly close cursors ([#163](https://github.com/databricks/dbt-databricks/pull/163))
+
 ## dbt-databricks 1.1.3 (August 24, 2022)
 
 ### Features

--- a/dbt/adapters/databricks/connections.py
+++ b/dbt/adapters/databricks/connections.py
@@ -1,3 +1,4 @@
+import warnings
 from contextlib import contextmanager
 from dataclasses import dataclass
 import os
@@ -10,7 +11,8 @@ from agate import Table
 import dbt.exceptions
 from dbt.adapters.base import Credentials
 from dbt.adapters.databricks import __version__
-from dbt.contracts.connection import Connection, ConnectionState
+from dbt.clients import agate_helper
+from dbt.contracts.connection import AdapterResponse, Connection, ConnectionState
 from dbt.events import AdapterLogger
 from dbt.events.functions import fire_event
 from dbt.events.types import ConnectionUsed, SQLQuery, SQLQueryStatus
@@ -104,46 +106,53 @@ class DatabricksCredentials(Credentials):
         return "host", "http_path", "database", "schema", "session_properties"
 
 
-class DatabricksSQLConnectionWrapper(object):
+class DatabricksSQLConnectionWrapper:
     """Wrap a Databricks SQL connector in a way that no-ops transactions"""
 
     _conn: DatabricksSQLConnection
-    _cursor: Optional[DatabricksSQLCursor]
 
     def __init__(self, conn: DatabricksSQLConnection):
         self._conn = conn
-        self._cursor = None
 
-    def cursor(self) -> "DatabricksSQLConnectionWrapper":
-        self._cursor = self._conn.cursor()
-        return self
-
-    def cancel(self) -> None:
-        if self._cursor:
-            try:
-                self._cursor.cancel()
-            except DBSQLError as exc:
-                logger.debug("Exception while cancelling query: {}".format(exc))
-                _log_dbsql_errors(exc)
+    def cursor(self) -> "DatabricksSQLCursorWrapper":
+        return DatabricksSQLCursorWrapper(self._conn.cursor())
 
     def close(self) -> None:
-        if self._cursor:
-            try:
-                self._cursor.close()
-            except DBSQLError as exc:
-                logger.debug("Exception while closing cursor: {}".format(exc))
-                _log_dbsql_errors(exc)
         self._conn.close()
 
     def rollback(self, *args: Any, **kwargs: Any) -> None:
         logger.debug("NotImplemented: rollback")
 
+
+class DatabricksSQLCursorWrapper:
+    """Wrap a Databricks SQL cursor in a way that no-ops transactions"""
+
+    _cursor: DatabricksSQLCursor
+
+    def __init__(self, cursor: DatabricksSQLCursor):
+        self._cursor = cursor
+
+    def cancel(self) -> None:
+        try:
+            self._cursor.cancel()
+        except DBSQLError as exc:
+            logger.debug("Exception while cancelling query: {}".format(exc))
+            _log_dbsql_errors(exc)
+
+    def close(self) -> None:
+        try:
+            self._cursor.close()
+        except DBSQLError as exc:
+            logger.debug("Exception while closing cursor: {}".format(exc))
+            _log_dbsql_errors(exc)
+
     def fetchall(self) -> Sequence[Tuple]:
-        assert self._cursor is not None
         return self._cursor.fetchall()
 
+    def fetchone(self) -> Optional[Tuple]:
+        return self._cursor.fetchone()
+
     def execute(self, sql: str, bindings: Optional[Sequence[Any]] = None) -> None:
-        assert self._cursor is not None
         if sql.strip().endswith(";"):
             sql = sql.strip()[:-1]
         if bindings is not None:
@@ -173,20 +182,22 @@ class DatabricksSQLConnectionWrapper(object):
             Optional[bool],
         ]
     ]:
-        assert self._cursor is not None
         return self._cursor.description
 
     def schemas(self, catalog_name: str, schema_name: Optional[str] = None) -> None:
-        assert self._cursor is not None
         self._cursor.schemas(catalog_name=catalog_name, schema_name=schema_name)
+
+    def __del__(self) -> None:
+        if self._cursor.open:
+            # This should not happen. The cursor should explicitly be closed.
+            self._cursor.close()
+            with warnings.catch_warnings():
+                warnings.simplefilter("always")
+                warnings.warn("The cursor was closed by destructor.")
 
 
 class DatabricksConnectionManager(SparkConnectionManager):
     TYPE: ClassVar[str] = "databricks"
-
-    DROP_JAVA_STACKTRACE_REGEX: ClassVar["re.Pattern[str]"] = re.compile(
-        r"(?<=Caused by: )(.+?)(?=^\t?at )", re.DOTALL | re.MULTILINE
-    )
 
     @contextmanager
     def exception_handler(self, sql: str) -> Iterator[None]:
@@ -211,28 +222,62 @@ class DatabricksConnectionManager(SparkConnectionManager):
             else:
                 raise dbt.exceptions.RuntimeException(str(exc)) from exc
 
+    def add_query(
+        self,
+        sql: str,
+        auto_begin: bool = True,
+        bindings: Optional[Any] = None,
+        abridge_sql_log: bool = False,
+        *,
+        close_cursor: bool = False,
+    ) -> Tuple[Connection, Any]:
+        conn, cursor = super().add_query(sql, auto_begin, bindings, abridge_sql_log)
+        if close_cursor and hasattr(cursor, "close"):
+            cursor.close()
+        return conn, cursor
+
+    def execute(
+        self, sql: str, auto_begin: bool = False, fetch: bool = False
+    ) -> Tuple[AdapterResponse, Table]:
+        sql = self._add_query_comment(sql)
+        _, cursor = self.add_query(sql, auto_begin)
+        try:
+            response = self.get_response(cursor)
+            if fetch:
+                table = self.get_result_from_cursor(cursor)
+            else:
+                table = agate_helper.empty_table()
+            return response, table
+        finally:
+            cursor.close()
+
     def _execute_cursor(
-        self, log_sql: str, f: Callable[[DatabricksSQLConnectionWrapper], None]
+        self, log_sql: str, f: Callable[[DatabricksSQLCursorWrapper], None]
     ) -> Table:
         connection = self.get_thread_connection()
 
         fire_event(ConnectionUsed(conn_type=self.TYPE, conn_name=connection.name))
 
-        with self.exception_handler(log_sql):
-            fire_event(SQLQuery(conn_name=connection.name, sql=log_sql))
-            pre = time.time()
+        cursor: Optional[DatabricksSQLCursorWrapper] = None
+        try:
+            with self.exception_handler(log_sql):
+                fire_event(SQLQuery(conn_name=connection.name, sql=log_sql))
+                pre = time.time()
 
-            handle: DatabricksSQLConnectionWrapper = connection.handle
-            cursor = handle.cursor()
-            f(cursor)
+                handle: DatabricksSQLConnectionWrapper = connection.handle
+                cursor = handle.cursor()
+                f(cursor)
 
-            fire_event(
-                SQLQueryStatus(
-                    status=str(self.get_response(cursor)), elapsed=round((time.time() - pre), 2)
+                fire_event(
+                    SQLQueryStatus(
+                        status=str(self.get_response(cursor)), elapsed=round((time.time() - pre), 2)
+                    )
                 )
-            )
 
-        return self.get_result_from_cursor(cursor)
+            return self.get_result_from_cursor(cursor)
+        finally:
+            if cursor is not None:
+                cursor.close()
 
     def list_schemas(self, database: str, schema: Optional[str] = None) -> Table:
         return self._execute_cursor(

--- a/dbt/adapters/databricks/impl.py
+++ b/dbt/adapters/databricks/impl.py
@@ -16,7 +16,7 @@ from dbt.adapters.spark.impl import (
     LIST_RELATIONS_MACRO_NAME,
     LIST_SCHEMAS_MACRO_NAME,
 )
-from dbt.contracts.connection import AdapterResponse
+from dbt.contracts.connection import AdapterResponse, Connection
 from dbt.contracts.graph.manifest import Manifest
 from dbt.contracts.relation import RelationType
 import dbt.exceptions
@@ -210,6 +210,39 @@ class DatabricksAdapter(SparkAdapter):
             as_dict["column_name"] = as_dict.pop("column", None)
             as_dict["column_type"] = as_dict.pop("dtype")
             yield as_dict
+
+    def add_query(
+        self,
+        sql: str,
+        auto_begin: bool = True,
+        bindings: Optional[Any] = None,
+        abridge_sql_log: bool = False,
+        *,
+        close_cursor: bool = False,
+    ) -> Tuple[Connection, Any]:
+        return self.connections.add_query(
+            sql, auto_begin, bindings, abridge_sql_log, close_cursor=close_cursor
+        )
+
+    def run_sql_for_tests(
+        self, sql: str, fetch: str, conn: Connection
+    ) -> Optional[Union[Optional[Tuple], List[Tuple]]]:
+        cursor = conn.handle.cursor()
+        try:
+            cursor.execute(sql)
+            if fetch == "one":
+                return cursor.fetchone()
+            elif fetch == "all":
+                return cursor.fetchall()
+            else:
+                return None
+        except BaseException as e:
+            print(sql)
+            print(e)
+            raise
+        finally:
+            cursor.close()
+            conn.transaction_open = False
 
     @contextmanager
     def _catalog(self, catalog: Optional[str]) -> Iterator[None]:

--- a/dbt/include/databricks/macros/materializations/seed.sql
+++ b/dbt/include/databricks/macros/materializations/seed.sql
@@ -2,6 +2,44 @@
   {{ return('%s') }}
 {% endmacro %}
 
+{% macro databricks__load_csv_rows(model, agate_table) %}
+
+  {% set batch_size = get_batch_size() %}
+  {% set column_override = model['config'].get('column_types', {}) %}
+
+  {% set statements = [] %}
+
+  {% for chunk in agate_table.rows | batch(batch_size) %}
+      {% set bindings = [] %}
+
+      {% for row in chunk %}
+          {% do bindings.extend(row) %}
+      {% endfor %}
+
+      {% set sql %}
+          insert {% if loop.index0 == 0 -%} overwrite {% else -%} into {% endif -%} {{ this.render() }} values
+          {% for row in chunk -%}
+              ({%- for col_name in agate_table.column_names -%}
+                  {%- set inferred_type = adapter.convert_type(agate_table, loop.index0) -%}
+                  {%- set type = column_override.get(col_name, inferred_type) -%}
+                    cast({{ get_binding_char() }} as {{type}})
+                  {%- if not loop.last%},{%- endif %}
+              {%- endfor -%})
+              {%- if not loop.last%},{%- endif %}
+          {%- endfor %}
+      {% endset %}
+
+      {% do adapter.add_query(sql, bindings=bindings, abridge_sql_log=True) %}
+
+      {% if loop.index0 == 0 %}
+          {% do statements.append(sql) %}
+      {% endif %}
+  {% endfor %}
+
+  {# Return SQL so we can render it out into the compiled files #}
+  {{ return(statements[0]) }}
+{% endmacro %}
+
 {% macro databricks__create_csv_table(model, agate_table) %}
   {%- set column_override = model['config'].get('column_types', {}) -%}
   {%- set quote_seed_column = model['config'].get('quote_columns', None) -%}

--- a/dbt/include/databricks/macros/materializations/seed.sql
+++ b/dbt/include/databricks/macros/materializations/seed.sql
@@ -29,7 +29,7 @@
           {%- endfor %}
       {% endset %}
 
-      {% do adapter.add_query(sql, bindings=bindings, abridge_sql_log=True) %}
+      {% do adapter.add_query(sql, bindings=bindings, abridge_sql_log=True, close_cursor=True) %}
 
       {% if loop.index0 == 0 %}
           {% do statements.append(sql) %}

--- a/tests/integration/base.py
+++ b/tests/integration/base.py
@@ -478,7 +478,7 @@ class DBTIntegrationTest(unittest.TestCase):
             try:
                 cursor.execute(sql)
                 if fetch == "one":
-                    return cursor.fetchall()[0]
+                    return cursor.fetchone()
                 elif fetch == "all":
                     return cursor.fetchall()
                 else:


### PR DESCRIPTION
### Description

Backports two commits to `1.1.latest`.

- Use insert overwrite for the first batch of seed (#149)
- Explicitly close cursors (#163)