### PR TITLE
Upgrade databricks-sql-connector to 2.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### Under the hood
 - Explicitly close cursors ([#163](https://github.com/databricks/dbt-databricks/pull/163))
+- Upgrade databricks-sql-connector to 2.0.5 ([#166](https://github.com/databricks/dbt-databricks/pull/166))
 
 ## dbt-databricks 1.2.1 (August 24, 2022)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-databricks-sql-connector>=2.0.4
+databricks-sql-connector>=2.0.5
 dbt-spark~=1.3.0a1

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "dbt-spark~={}".format(dbt_spark_version),
-        "databricks-sql-connector>=2.0.4",
+        "databricks-sql-connector>=2.0.5",
     ],
     zip_safe=False,
     classifiers=[


### PR DESCRIPTION
### Description

Upgrades `databricks-sql-connector` to `2.0.5`.