### PR TITLE
Fix cancellation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
 - Apply "Initial refactoring of incremental materialization" ([#148](https://github.com/databricks/dbt-databricks/pull/148))
     - Now dbt-databricks uses `adapter.get_incremental_strategy_macro` instead of `dbt_spark_get_incremental_sql` macro to dispatch the incremental strategy macro. The overwritten `dbt_spark_get_incremental_sql` macro will not work anymore.
 
+## dbt-databricks 1.2.3 (Release TBD)
+
+### Fixes
+- Fix cancellation ([#173](https://github.com/databricks/dbt-databricks/pull/173))
+
 ## dbt-databricks 1.2.2 (September 8, 2022)
 
 ### Fixes

--- a/dbt/adapters/databricks/connections.py
+++ b/dbt/adapters/databricks/connections.py
@@ -169,8 +169,22 @@ class DatabricksSQLConnectionWrapper:
     def cursor(self) -> "DatabricksSQLCursorWrapper":
         return DatabricksSQLCursorWrapper(self._conn.cursor())
 
+    def cancel(self) -> None:
+        cursors: List[DatabricksSQLCursor] = self._conn._cursors
+
+        for cursor in cursors:
+            try:
+                cursor.cancel()
+            except DBSQLError as exc:
+                logger.debug("Exception while cancelling query: {}".format(exc))
+                _log_dbsql_errors(exc)
+
     def close(self) -> None:
-        self._conn.close()
+        try:
+            self._conn.close()
+        except DBSQLError as exc:
+            logger.debug("Exception while closing connection: {}".format(exc))
+            _log_dbsql_errors(exc)
 
     def rollback(self, *args: Any, **kwargs: Any) -> None:
         logger.debug("NotImplemented: rollback")

--- a/tests/integration/fail_fast/models/schema.yml
+++ b/tests/integration/fail_fast/models/schema.yml
@@ -1,0 +1,9 @@
+version: 2
+
+models:
+  - name: view_model
+    columns:
+      - name: id
+        tests:
+          - unique
+          - not_null

--- a/tests/integration/fail_fast/models/view_model.sql
+++ b/tests/integration/fail_fast/models/view_model.sql
@@ -1,0 +1,5 @@
+select 1 as id
+union all
+select 1 as id
+union all
+select null as id

--- a/tests/integration/fail_fast/test_fail_fast.py
+++ b/tests/integration/fail_fast/test_fail_fast.py
@@ -1,0 +1,37 @@
+from dbt.exceptions import FailFastException
+
+from tests.integration.base import DBTIntegrationTest, use_profile
+
+
+class TesFailFast(DBTIntegrationTest):
+    @property
+    def schema(self):
+        return "fail_fast"
+
+    @property
+    def models(self):
+        return "models"
+
+    def test_fail_fast(self):
+        self.run_dbt(["run"])
+
+        with self.assertRaisesRegex(
+            FailFastException, "Failing early due to test failure or runtime error"
+        ):
+            self.run_dbt(["test", "--fail-fast"])
+
+    @use_profile("databricks_cluster")
+    def test_fail_fast_databricks_cluster(self):
+        self.test_fail_fast()
+
+    @use_profile("databricks_uc_cluster")
+    def test_fail_fast_databricks_uc_cluster(self):
+        self.test_fail_fast()
+
+    @use_profile("databricks_sql_endpoint")
+    def test_fail_fast_databricks_sql_endpoint(self):
+        self.test_fail_fast()
+
+    @use_profile("databricks_uc_sql_endpoint")
+    def test_fail_fast_databricks_uc_sql_endpoint(self):
+        self.test_fail_fast()


### PR DESCRIPTION
### Description

`DatabricksSQLConnectionWrapper` should have `cancel` method and handle it properly.

Otherwise, the following error will be seen when cancelling the session due to e.g., `dbt test --fail-fast`:

```
AttributeError: 'DatabricksSQLConnectionWrapper' object has no attribute 'cancel'
```