### PR TITLE
Disable auto-closing issues/PRs.

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -9,9 +9,11 @@ jobs:
       # pinned at v4 (https://github.com/actions/stale/releases/tag/v4.0.0)
       - uses: actions/stale@cdf15f641adb27a71842045a94023bef6945e3aa
         with:
-          stale-issue-message: "This issue has been marked as Stale because it has been open for 180 days with no activity. If you would like the issue to remain open, please remove the stale label or comment on the issue, or it will be closed in 7 days."
-          stale-pr-message: "This PR has been marked as Stale because it has been open for 180 days with no activity. If you would like the PR to remain open, please remove the stale label or comment on the PR, or it will be closed in 7 days."
+          stale-issue-message: "This issue has been marked as Stale because it has been open for 180 days with no activity. If you would like the issue to remain open, please remove the stale label or comment on the issue."
+          stale-pr-message: "This PR has been marked as Stale because it has been open for 180 days with no activity. If you would like the PR to remain open, please remove the stale label or comment on the PR."
           # mark issues/PRs stale when they haven't seen activity in 180 days
           days-before-stale: 180
+          # disable auto-close.
+          days-before-close: -1
           # ignore checking issues with the following labels
           exempt-issue-labels: "epic, discussion"


### PR DESCRIPTION
### Description

Disables auto-closing issues/PRs.
The `Stale` label will still be added after 180 days with no activity.