### PR TITLE
Manage cursors to avoid relying on the protected member.

### DIFF
--- a/dbt/adapters/databricks/connections.py
+++ b/dbt/adapters/databricks/connections.py
@@ -172,15 +172,19 @@ class DatabricksSQLConnectionWrapper:
     """Wrap a Databricks SQL connector in a way that no-ops transactions"""
 
     _conn: DatabricksSQLConnection
+    _cursors: List[DatabricksSQLCursor]
 
     def __init__(self, conn: DatabricksSQLConnection):
         self._conn = conn
+        self._cursors = []
 
     def cursor(self) -> "DatabricksSQLCursorWrapper":
-        return DatabricksSQLCursorWrapper(self._conn.cursor())
+        cursor = self._conn.cursor()
+        self._cursors.append(cursor)
+        return DatabricksSQLCursorWrapper(cursor)
 
     def cancel(self) -> None:
-        cursors: List[DatabricksSQLCursor] = self._conn._cursors
+        cursors: List[DatabricksSQLCursor] = self._cursors
 
         for cursor in cursors:
             try:


### PR DESCRIPTION
### Description

Manages cursors to avoid relying on the protected member.