### PR TITLE
Avoid comparing the query itself.

### DIFF
--- a/tests/functional/adapter/test_ephemeral.py
+++ b/tests/functional/adapter/test_ephemeral.py
@@ -1,6 +1,3 @@
-import os
-import re
-
 from dbt.tests.adapter.ephemeral.test_ephemeral import BaseEphemeralMulti
 from dbt.tests.util import run_dbt, check_relations_equal
 
@@ -14,25 +11,3 @@ class TestEphemeralMultiDatabricks(BaseEphemeralMulti):
         check_relations_equal(project.adapter, ["seed", "dependent"])
         check_relations_equal(project.adapter, ["seed", "double_dependent"])
         check_relations_equal(project.adapter, ["seed", "super_dependent"])
-
-        assert os.path.exists("./target/run/test/models/double_dependent.sql")
-        with open("./target/run/test/models/double_dependent.sql", "r") as fp:
-            sql_file = fp.read()
-
-        sql_file = re.sub(r"\d+", "", sql_file)
-        expected_sql = (
-            "create or replace view test_test_ephemeral.double_dependent"
-            "as"
-            "with __dbt__cte__base as ("
-            "select * from test_test_ephemeral.seed"
-            "),  __dbt__cte__base_copy as ("
-            "select * from __dbt__cte__base"
-            ")-- base_copy just pulls from base. Make sure the listed"
-            "-- graph of CTEs all share the same dbt_cte__base cte"
-            "select * from __dbt__cte__base where gender = 'Male'"
-            "union all"
-            "select * from __dbt__cte__base_copy where gender = 'Female'"
-        )
-        sql_file = "".join(sql_file.split())
-        expected_sql = "".join(expected_sql.split())
-        assert sql_file == expected_sql


### PR DESCRIPTION
### Description

Avoids comparing the query itself because the table names are different between non-UC and UC tests.