### PR TITLE
Fix double quoting strings in HTTP headers

### DIFF
--- a/dbt/adapters/databricks/connections.py
+++ b/dbt/adapters/databricks/connections.py
@@ -156,7 +156,7 @@ class DatabricksCredentials(Credentials):
         )
 
         http_session_headers_dict: Dict[str, str] = (
-            {k: json.dumps(v) for k, v in json.loads(http_session_headers_str).items()}
+            {k: v if isinstance(v, str) else json.dumps(v) for k, v in json.loads(http_session_headers_str).items()}
             if http_session_headers_str is not None
             else {}
         )

--- a/dbt/adapters/databricks/connections.py
+++ b/dbt/adapters/databricks/connections.py
@@ -156,7 +156,10 @@ class DatabricksCredentials(Credentials):
         )
 
         http_session_headers_dict: Dict[str, str] = (
-            {k: v if isinstance(v, str) else json.dumps(v) for k, v in json.loads(http_session_headers_str).items()}
+            {
+                k: v if isinstance(v, str) else json.dumps(v)
+                for k, v in json.loads(http_session_headers_str).items()
+            }
             if http_session_headers_str is not None
             else {}
         )

--- a/tests/unit/test_adapter.py
+++ b/tests/unit/test_adapter.py
@@ -237,9 +237,7 @@ class TestDatabricksAdapter(unittest.TestCase):
     def test_environment_http_headers_string(self):
         self._test_environment_http_headers(
             http_headers_str='{"string":"some-string"}',
-            expected_http_headers=[
-                ("string", "some-string")
-            ],
+            expected_http_headers=[("string", "some-string")],
         )
 
     def _test_environment_http_headers(

--- a/tests/unit/test_adapter.py
+++ b/tests/unit/test_adapter.py
@@ -234,6 +234,14 @@ class TestDatabricksAdapter(unittest.TestCase):
             ],
         )
 
+    def test_environment_http_headers_string(self):
+        self._test_environment_http_headers(
+            http_headers_str='{"string":"some-string"}',
+            expected_http_headers=[
+                ("string", "some-string")
+            ],
+        )
+
     def _test_environment_http_headers(
         self, http_headers_str, expected_http_headers, user_http_headers=None
     ):


### PR DESCRIPTION
### Description

Before a header like `{'string': 'some-string'}` would result in the header: `{'string': '"some-string"'}`. This PR fixes this and returns the correct header `{'string': 'some-string'}`.

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
