### PR TITLE
Show and log a warning when schema contains '.'.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## dbt-databricks 1.4.0 (Release TBD)
 
+## dbt-databricks 1.3.1 (Release TBD)
+
+### Under the hood
+- Show and log a warning when schema contains '.'. ([#221](https://github.com/databricks/dbt-databricks/pull/221))
+
 ## dbt-databricks 1.3.0 (October 14, 2022)
 
 ### Features

--- a/dbt/adapters/databricks/connections.py
+++ b/dbt/adapters/databricks/connections.py
@@ -86,7 +86,7 @@ class DatabricksCredentials(Credentials):
     def __post_init__(self) -> None:
         if "." in self.schema:
             logger.warning(
-                "The specified schema contains '.', which could cause unexpected behavior.\n"
+               f"The specified schema '{self.schema}' contains '.', which could cause unexpected behavior.\n"
                 "It will not be allowed in the future release.\n"
                 "If you are trying to set a catalog, use `catalog` instead.\n"
             )

--- a/dbt/adapters/databricks/connections.py
+++ b/dbt/adapters/databricks/connections.py
@@ -88,7 +88,7 @@ class DatabricksCredentials(Credentials):
             logger.warning(
                f"The specified schema '{self.schema}' contains '.', which could cause unexpected behavior.\n"
                 "It will not be allowed in the future release.\n"
-                "If you are trying to set a catalog, use `catalog` instead.\n"
+                "If you are trying to set a catalog, please use `catalog` instead.\n"
             )
 
         session_properties = self.session_properties or {}

--- a/dbt/adapters/databricks/connections.py
+++ b/dbt/adapters/databricks/connections.py
@@ -84,6 +84,13 @@ class DatabricksCredentials(Credentials):
         return data
 
     def __post_init__(self) -> None:
+        if "." in self.schema:
+            logger.warning(
+                "The specified schema contains '.', which could cause unexpected behavior.\n"
+                "It will not be allowed in the future release.\n"
+                "If you are trying to set a catalog, use `catalog` instead.\n"
+            )
+
         session_properties = self.session_properties or {}
         if CATALOG_KEY_IN_SESSION_PROPERTIES in session_properties:
             if self.database is None:

--- a/dbt/adapters/databricks/connections.py
+++ b/dbt/adapters/databricks/connections.py
@@ -86,7 +86,8 @@ class DatabricksCredentials(Credentials):
     def __post_init__(self) -> None:
         if "." in self.schema:
             logger.warning(
-               f"The specified schema '{self.schema}' contains '.', which could cause unexpected behavior.\n"
+                f"The specified schema '{self.schema}' contains '.', "
+                "which could cause unexpected behavior.\n"
                 "It will not be allowed in the future release.\n"
                 "If you are trying to set a catalog, please use `catalog` instead.\n"
             )

--- a/dbt/adapters/databricks/impl.py
+++ b/dbt/adapters/databricks/impl.py
@@ -131,13 +131,13 @@ class DatabricksAdapter(SparkAdapter):
                     f'Invalid value from "show table extended ...", '
                     f"got {len(row)} values, expected 4"
                 )
-            _schema, name, _, information = row
+            _, name, _, information = row
             rel_type = RelationType.View if "Type: VIEW" in information else RelationType.Table
             is_delta = "Provider: delta" in information
             is_hudi = "Provider: hudi" in information
             relation = self.Relation.create(
                 database=schema_relation.database,
-                schema=_schema,
+                schema=schema_relation.schema,
                 identifier=name,
                 type=rel_type,
                 information=information,


### PR DESCRIPTION
### Description

Shows and logs a warning when schema contains `'.'`.

As a side work, trying to help more cases where schema contains `'.'` in `list_relations_without_caching`.