### PR TITLE
Raise an exception when schema contains '.'.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## dbt-databricks 1.4.0 (Release TBD)
 
+### Breaking changes
+- Raise an exception when schema contains '.'. ([#222](https://github.com/databricks/dbt-databricks/pull/222))
+    - Containing a catalog in `schema` is not allowed anymore.
+    - Need to explicitly use `catalog` instead.
+
 ## dbt-databricks 1.3.1 (Release TBD)
 
 ### Under the hood

--- a/dbt/adapters/databricks/connections.py
+++ b/dbt/adapters/databricks/connections.py
@@ -85,10 +85,8 @@ class DatabricksCredentials(Credentials):
 
     def __post_init__(self) -> None:
         if "." in self.schema:
-            logger.warning(
-                f"The specified schema '{self.schema}' contains '.', "
-                "which could cause unexpected behavior.\n"
-                "It will not be allowed in the future release.\n"
+            raise dbt.exceptions.ValidationException(
+                f"The schema should not contain '.': {self.schema}\n"
                 "If you are trying to set a catalog, please use `catalog` instead.\n"
             )
 


### PR DESCRIPTION
### Description

Raises an exception when schema contains `'.'`.

This is a breaking change since `1.4.0` to disallow a workaround using `schema` to set a catalog for the older versions.