### PR TITLE
Fix copy into macro when passing expression_list.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
     - Containing a catalog in `schema` is not allowed anymore.
     - Need to explicitly use `catalog` instead.
 
+## dbt-databricks 1.3.2 (Release TBD)
+
+### Fixes
+- Fix copy into macro when passing `expression_list`. ([#223](https://github.com/databricks/dbt-databricks/pull/223))
+
 ## dbt-databricks 1.3.1 (November 1, 2022)
 
 ### Under the hood

--- a/dbt/include/databricks/macros/copy_into.sql
+++ b/dbt/include/databricks/macros/copy_into.sql
@@ -18,7 +18,7 @@
 
   {%- set source_clause -%}
     {%- if expression_list -%}
-      select {{ expression_list }} from '{{ source }}'
+      ( select {{ expression_list }} from '{{ source }}' )
     {%- else -%}
       '{{ source }}'
     {%- endif -%}

--- a/tests/integration/copy_into/models/expected_target_with_expression_list.sql
+++ b/tests/integration/copy_into/models/expected_target_with_expression_list.sql
@@ -1,0 +1,7 @@
+{{config(materialized='table')}}
+
+select * from values
+    (0, 'Zero', '2022-01-01'),
+    (1, 'Alice', null),
+    (2, 'Bob', null)
+    as t(id, name, date)

--- a/tests/integration/copy_into/models/target_with_expression_list.sql
+++ b/tests/integration/copy_into/models/target_with_expression_list.sql
@@ -1,0 +1,4 @@
+{{config(materialized='table')}}
+
+select * from values
+    (0, 'Zero', '2022-01-01') as t(id, name, date)


### PR DESCRIPTION
### Description

Fixes copy into macro when passing `expression_list`.

```
Encountered an error while running operation: Runtime Error
  Runtime Error

    [PARSE_SYNTAX_ERROR] Syntax error at or near 'select'(line 5, pos 9)

    == SQL ==
    /* ... */


        copy into test16673467754364144015_copy_into.target_with_expression_list
        from select id, name from '/path/to/source'
    ---------^^^
        fileformat = parquet


        format_options ('mergeSchema' = 'true')
        copy_options ('mergeSchema' = 'true')
```

There should be parenthesis surrounding `select id, name from '/path/to/source'`.