### PR TITLE
Partially revert to fix the case where schema config contains uppercase letters.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixes
 - Fix copy into macro when passing `expression_list`. ([#223](https://github.com/databricks/dbt-databricks/pull/223))
+- Partially revert to fix the case where schema config contains uppercase letters. ([#224](https://github.com/databricks/dbt-databricks/pull/224))
 
 ## dbt-databricks 1.3.1 (November 1, 2022)
 

--- a/dbt/adapters/databricks/impl.py
+++ b/dbt/adapters/databricks/impl.py
@@ -131,13 +131,13 @@ class DatabricksAdapter(SparkAdapter):
                     f'Invalid value from "show table extended ...", '
                     f"got {len(row)} values, expected 4"
                 )
-            _, name, _, information = row
+            _schema, name, _, information = row
             rel_type = RelationType.View if "Type: VIEW" in information else RelationType.Table
             is_delta = "Provider: delta" in information
             is_hudi = "Provider: hudi" in information
             relation = self.Relation.create(
                 database=schema_relation.database,
-                schema=schema_relation.schema,
+                schema=_schema,
                 identifier=name,
                 type=rel_type,
                 information=information,

--- a/dbt/adapters/databricks/impl.py
+++ b/dbt/adapters/databricks/impl.py
@@ -137,6 +137,8 @@ class DatabricksAdapter(SparkAdapter):
             is_hudi = "Provider: hudi" in information
             relation = self.Relation.create(
                 database=schema_relation.database,
+                # Use `_schema` retrieved from the cluster to avoid mismatched case
+                # between the profile and the cluster.
                 schema=_schema,
                 identifier=name,
                 type=rel_type,


### PR DESCRIPTION
### Description

Partially reverts #221 to fix the case where `schema` config contains uppercase letters.

```
Compilation Error in model test (models/test.sql)
  When searching for a relation, dbt found an approximate match. Instead of guessing
  which relation to use, dbt will move on. Please delete DBT_TEST.test, or rename it to be less ambiguous.
  Searched for: dbt_test.test
  Found: DBT_TEST.test

  > in macro load_cached_relation (macros/adapters/relation.sql)
  > called by macro load_relation (macros/adapters/relation.sql)
  > called by macro materialization_incremental_databricks (macros/materializations/incremental/incremental.sql)
  > called by model test (models/test.sql)
```