### PR TITLE
Enable quotes by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ test.env
 .vscode
 *.log
 logs/
+.venv

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Support Python 3.11 ([#233](https://github.com/databricks/dbt-databricks/pull/233))
 - Support `incremental_predicates` ([#161](https://github.com/databricks/dbt-databricks/pull/161))
 - Apply connection retry refactor, add defaults with exponential backoff ([#137](https://github.com/databricks/dbt-databricks/pull/137))
+- Quote by Default ([#241](https://github.com/databricks/dbt-databricks/pull/241))
 
 ## dbt-databricks 1.3.3 (Release TBD)
 

--- a/dbt/adapters/databricks/relation.py
+++ b/dbt/adapters/databricks/relation.py
@@ -12,9 +12,9 @@ KEY_TABLE_PROVIDER = "Provider"
 
 @dataclass
 class DatabricksQuotePolicy(Policy):
-    database: bool = False
-    schema: bool = False
-    identifier: bool = False
+    database: bool = True
+    schema: bool = True
+    identifier: bool = True
 
 
 @dataclass

--- a/tests/unit/test_macros.py
+++ b/tests/unit/test_macros.py
@@ -345,8 +345,9 @@ class TestDatabricksMacros(unittest.TestCase):
         sql = self.__run_macro(
             template, "databricks__create_table_as", False, relation, "select 1"
         ).strip()
+        exp = "create or replace table `some_database`.`some_schema`.`some_table` using delta as select 1"
 
         self.assertEqual(
             sql,
-            "create or replace table `some_database`.`some_schema`.`some_table` using delta as select 1",
+            exp,
         )

--- a/tests/unit/test_macros.py
+++ b/tests/unit/test_macros.py
@@ -345,9 +345,12 @@ class TestDatabricksMacros(unittest.TestCase):
         sql = self.__run_macro(
             template, "databricks__create_table_as", False, relation, "select 1"
         ).strip()
-        exp = "create or replace table `some_database`.`some_schema`.`some_table` using delta as select 1"
 
         self.assertEqual(
             sql,
-            exp,
+            (
+                "create or replace table "
+                "`some_database`.`some_schema`.`some_table` "
+                "using delta as select 1"
+            ),
         )

--- a/tests/unit/test_macros.py
+++ b/tests/unit/test_macros.py
@@ -2,15 +2,18 @@ import unittest
 from unittest import mock
 import re
 from jinja2 import Environment, FileSystemLoader, PackageLoader
+from dbt.adapters.databricks.relation import DatabricksRelation
 
 
 class TestSparkMacros(unittest.TestCase):
     def setUp(self):
         self.parent_jinja_env = Environment(
-            loader=PackageLoader("dbt.include.spark", "macros"), extensions=["jinja2.ext.do"]
+            loader=PackageLoader("dbt.include.spark", "macros"),
+            extensions=["jinja2.ext.do"],
         )
         self.jinja_env = Environment(
-            loader=FileSystemLoader("dbt/include/databricks/macros"), extensions=["jinja2.ext.do"]
+            loader=FileSystemLoader("dbt/include/databricks/macros"),
+            extensions=["jinja2.ext.do"],
         )
 
         self.config = {}
@@ -92,7 +95,8 @@ class TestSparkMacros(unittest.TestCase):
             template, "databricks__create_table_as", False, "my_table", "select 1"
         ).strip()
         self.assertEqual(
-            sql, 'create table my_table using hudi options (compression "gzip" ) as select 1'
+            sql,
+            'create table my_table using hudi options (compression "gzip" ) as select 1',
         )
 
     def test_macros_create_table_as_hudi_options(self):
@@ -104,7 +108,8 @@ class TestSparkMacros(unittest.TestCase):
             template, "databricks__create_table_as", False, "my_table", "select 1 as id"
         ).strip()
         self.assertEqual(
-            sql, 'create table my_table using hudi options (primaryKey "id" ) as select 1 as id'
+            sql,
+            'create table my_table using hudi options (primaryKey "id" ) as select 1 as id',
         )
 
         self.config["file_format"] = "hudi"
@@ -114,7 +119,8 @@ class TestSparkMacros(unittest.TestCase):
             template, "databricks__create_table_as", False, "my_table", "select 1 as id"
         ).strip()
         self.assertEqual(
-            sql, 'create table my_table using hudi options (primaryKey "id" ) as select 1 as id'
+            sql,
+            'create table my_table using hudi options (primaryKey "id" ) as select 1 as id',
         )
 
         self.config["file_format"] = "hudi"
@@ -272,4 +278,75 @@ class TestSparkMacros(unittest.TestCase):
             sql,
             "create or replace view my_table "
             "tblproperties ('tblproperties_to_view' = 'true' ) as select 1",
+        )
+
+
+class TestDatabricksMacros(unittest.TestCase):
+    def setUp(self):
+        self.parent_jinja_env = Environment(
+            loader=PackageLoader("dbt.include.spark", "macros"),
+            extensions=["jinja2.ext.do"],
+        )
+        self.jinja_env = Environment(
+            loader=FileSystemLoader("dbt/include/databricks/macros"),
+            extensions=["jinja2.ext.do"],
+        )
+
+        self.config = {}
+        self.default_context = {
+            "validation": mock.Mock(),
+            "model": mock.Mock(),
+            "exceptions": mock.Mock(),
+            "config": mock.Mock(),
+            "adapter": mock.Mock(),
+            "return": lambda r: r,
+        }
+        self.default_context["config"].get = lambda key, default=None, **kwargs: self.config.get(
+            key, default
+        )
+
+    def __get_template(self, template_filename):
+        parent = self.parent_jinja_env.get_template(template_filename, globals=self.default_context)
+        self.default_context.update(parent.module.__dict__)
+        return self.jinja_env.get_template(template_filename, globals=self.default_context)
+
+    def __run_macro(self, template, name, temporary, relation, sql):
+        self.default_context["model"].alias = relation
+
+        def dispatch(macro_name, macro_namespace=None, packages=None):
+            if hasattr(template.module, f"databricks__{macro_name}"):
+                return getattr(template.module, f"databricks__{macro_name}")
+            else:
+                return self.default_context[f"spark__{macro_name}"]
+
+        self.default_context["adapter"].dispatch = dispatch
+
+        if temporary is not None:
+            value = getattr(template.module, name)(temporary, relation, sql)
+        else:
+            value = getattr(template.module, name)(relation, sql)
+        return re.sub(r"\s\s+", " ", value)
+
+    def test_macros_load(self):
+        self.jinja_env.get_template("adapters.sql")
+
+    def test_macros_create_table_as(self):
+        template = self.__get_template("adapters.sql")
+        data = {
+            "path": {
+                "database": "some_database",
+                "schema": "some_schema",
+                "identifier": "some_table",
+            },
+            "type": None,
+        }
+
+        relation = DatabricksRelation.from_dict(data)
+        sql = self.__run_macro(
+            template, "databricks__create_table_as", False, relation, "select 1"
+        ).strip()
+
+        self.assertEqual(
+            sql,
+            "create or replace table `some_database`.`some_schema`.`some_table` using delta as select 1",
         )

--- a/tests/unit/test_relation.py
+++ b/tests/unit/test_relation.py
@@ -2,7 +2,7 @@ import unittest
 
 from jinja2.runtime import Undefined
 
-from dbt.adapters.databricks.relation import DatabricksRelation
+from dbt.adapters.databricks.relation import DatabricksRelation, DatabricksQuotePolicy
 
 
 class TestDatabricksRelation(unittest.TestCase):
@@ -65,3 +65,30 @@ class TestDatabricksRelation(unittest.TestCase):
         self.assertIsNone(relation.database)
         self.assertEqual(relation.schema, "some_schema")
         self.assertEqual(relation.identifier, "some_table")
+
+    def test_render(self):
+        data = {
+            "path": {
+                "database": "some_database",
+                "schema": "some_schema",
+                "identifier": "some_table",
+            },
+            "type": None,
+        }
+
+        relation = DatabricksRelation.from_dict(data)
+        self.assertEqual(
+            relation.get_default_quote_policy(), DatabricksQuotePolicy(True, True, True)
+        )
+        self.assertEqual(relation.render(), "`some_database`.`some_schema`.`some_table`")
+
+        data = {
+            "path": {
+                "schema": "some_schema",
+                "identifier": "some_table",
+            },
+            "type": None,
+        }
+
+        relation = DatabricksRelation.from_dict(data)
+        self.assertEqual(relation.render(), "`some_schema`.`some_table`")


### PR DESCRIPTION
### Description

When working with the Unity Catalog, it is very convenient to quote catalog, schema, or identifiers so generated catalog and schema names work without extra configuration.  

resolves #240 

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
