### PR TITLE
Support 3 legged OAuth as authentication type

### DIFF
--- a/dbt/include/databricks/profile_template.yml
+++ b/dbt/include/databricks/profile_template.yml
@@ -5,9 +5,14 @@ prompts:
     hint: yourorg.databricks.com
   http_path:
     hint: 'HTTP Path'
-  token:
-    hint: 'dapiXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
-    hide_input: true
+  _choose_authentication_type:
+    oauth:
+      _fixed_auth_type: 'oauth'
+    token:
+      _fixed_auth_type: 'oauth'
+      token:
+        hint: 'dapiXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
+        hide_input: true
   _choose_unity_catalog:
     'use Unity Catalog':
       catalog:


### PR DESCRIPTION
### Description

Support 3 legged OAuth authentication in dbt core.  User can set `auth_type` as `oauth` in dbt profile and login Databricks via 3 legged OAuth flow when running `dbt`

#### Prerequisite
 - Databricks E2 Account in AWS
 - OAuth is enrolled in the Databricks account
 - OAuth Client `dbt-databricks` is registered in the Databricks account

#### Example

```
your_profile_name:
  target: dev
  outputs:
    dev:
      type: databricks
      auth_type: oauth
      catalog: [optional catalog name, if you are using Unity Catalog, only available in dbt-databricks>=1.1.1]
      schema: [database/schema name]
      host: [your.databrickshost.com]
      http_path: [/sql/your/http/path]
```

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
