### PR TITLE
Fix linter errors.

### DIFF
--- a/dbt/adapters/databricks/impl.py
+++ b/dbt/adapters/databricks/impl.py
@@ -141,7 +141,7 @@ class DatabricksAdapter(SparkAdapter):
                 identifier=name,
                 type=self.Relation.get_relation_type(kind),
             )
-            for database, schema, name, kind in results.select(
+            for database, schema, name, kind in results.select(  # type: ignore[attr-defined]
                 ["database_name", "schema_name", "name", "kind"]
             )
         ]
@@ -149,11 +149,12 @@ class DatabricksAdapter(SparkAdapter):
     def _list_relations_with_information(
         self, schema_relation: DatabricksRelation
     ) -> List[Tuple[DatabricksRelation, str]]:
+        results: List[Row]
         kwargs = {"schema_relation": schema_relation}
         try:
             # The catalog for `show table extended` needs to match the current catalog.
             with self._catalog(schema_relation.database):
-                results = self.execute_macro(SHOW_TABLE_EXTENDED_MACRO_NAME, kwargs=kwargs)
+                results = list(self.execute_macro(SHOW_TABLE_EXTENDED_MACRO_NAME, kwargs=kwargs))
         except dbt.exceptions.DbtRuntimeError as e:
             errmsg = getattr(e, "msg", "")
             if (
@@ -211,7 +212,7 @@ class DatabricksAdapter(SparkAdapter):
             with self._catalog(relation.database):
                 views = self.execute_macro(SHOW_VIEWS_MACRO_NAME, kwargs=kwargs)
 
-            view_names = set(views.columns["viewName"].values())
+            view_names = set(views.columns["viewName"].values())  # type: ignore[attr-defined]
             new_rows = [
                 (
                     row[0],
@@ -284,8 +285,10 @@ class DatabricksAdapter(SparkAdapter):
         self, relation: DatabricksRelation
     ) -> Tuple[DatabricksRelation, List[DatabricksColumn]]:
         try:
-            rows = self.execute_macro(
-                GET_COLUMNS_IN_RELATION_RAW_MACRO_NAME, kwargs={"relation": relation}
+            rows: List[Row] = list(
+                self.execute_macro(
+                    GET_COLUMNS_IN_RELATION_RAW_MACRO_NAME, kwargs={"relation": relation}
+                )
             )
             metadata, columns = self.parse_describe_extended(relation, rows)
         except dbt.exceptions.DbtRuntimeError as e:


### PR DESCRIPTION
### Description

Fixes linter errors caused by the upstream changes https://github.com/dbt-labs/dbt-core/commit/17014bfad3e204279c94c6a0285f784fc10711eb.

```
dbt/adapters/databricks/impl.py:144: error: "AttrDict" has no attribute "select"  [attr-defined]
dbt/adapters/databricks/impl.py:163: error: Incompatible types in assignment (expression has type "List[<nothing>]", variable has type "AttrDict")  [assignment]
dbt/adapters/databricks/impl.py:167: error: Incompatible types in assignment (expression has type "List[<nothing>]", variable has type "AttrDict")  [assignment]
dbt/adapters/databricks/impl.py:214: error: "AttrDict" has no attribute "columns"  [attr-defined]
dbt/adapters/databricks/impl.py:290: error: Argument 2 to "parse_describe_extended" of "DatabricksAdapter" has incompatible type "AttrDict"; expected "List[Any]"  [arg-type]
Found 5 errors in 1 file (checked 49 source files)
```