### PR TITLE
Ignore case sensitivity in relation matches method

### DIFF
--- a/dbt/adapters/databricks/relation.py
+++ b/dbt/adapters/databricks/relation.py
@@ -91,8 +91,4 @@ class DatabricksRelation(BaseRelation):
             ):
                 match = False
 
-        if not match:
-            target = self.create(database=database, schema=schema, identifier=identifier)
-            raise ApproximateMatchError(target, self)
-
         return match

--- a/dbt/adapters/databricks/relation.py
+++ b/dbt/adapters/databricks/relation.py
@@ -8,7 +8,7 @@ from dbt.adapters.spark.impl import KEY_TABLE_OWNER, KEY_TABLE_STATISTICS
 
 from dbt.adapters.databricks.utils import remove_undefined
 from dbt.utils import filter_null_values
-from dbt.exceptions import ApproximateMatchError, DbtRuntimeError
+from dbt.exceptions import DbtRuntimeError
 
 KEY_TABLE_PROVIDER = "Provider"
 

--- a/dbt/adapters/databricks/relation.py
+++ b/dbt/adapters/databricks/relation.py
@@ -89,7 +89,7 @@ class DatabricksRelation(BaseRelation):
             if str(self.path.get_lowered_part(k)).strip(self.quote_character) != v.lower().strip(
                 self.quote_character
             ):
-                match = False  # type: ignore[union-attr]
+                match = False
 
         if not match:
             target = self.create(database=database, schema=schema, identifier=identifier)

--- a/dbt/adapters/databricks/relation.py
+++ b/dbt/adapters/databricks/relation.py
@@ -1,11 +1,14 @@
 from dataclasses import dataclass, field
 from typing import Any, Dict, Optional
-
+from dbt.contracts.relation import (
+    ComponentName,
+)
 from dbt.adapters.base.relation import BaseRelation, Policy
 from dbt.adapters.spark.impl import KEY_TABLE_OWNER, KEY_TABLE_STATISTICS
 
 from dbt.adapters.databricks.utils import remove_undefined
-
+from dbt.utils import filter_null_values
+from dbt.exceptions import ApproximateMatchError, DbtRuntimeError
 
 KEY_TABLE_PROVIDER = "Provider"
 
@@ -61,3 +64,35 @@ class DatabricksRelation(BaseRelation):
     @property
     def stats(self) -> Optional[str]:
         return self.metadata.get(KEY_TABLE_STATISTICS) if self.metadata is not None else None
+
+    def matches(
+        self,
+        database: Optional[str] = None,
+        schema: Optional[str] = None,
+        identifier: Optional[str] = None,
+    ) -> bool:
+        search = filter_null_values(
+            {
+                ComponentName.Database: database,
+                ComponentName.Schema: schema,
+                ComponentName.Identifier: identifier,
+            }
+        )
+
+        if not search:
+            # nothing was passed in
+            raise DbtRuntimeError("Tried to match relation, but no search path was passed!")
+
+        match = True
+
+        for k, v in search.items():
+            if str(self.path.get_lowered_part(k)).strip(self.quote_character) != v.lower().strip(
+                self.quote_character
+            ):
+                match = False  # type: ignore[union-attr]
+
+        if not match:
+            target = self.create(database=database, schema=schema, identifier=identifier)
+            raise ApproximateMatchError(target, self)
+
+        return match

--- a/tests/unit/test_relation.py
+++ b/tests/unit/test_relation.py
@@ -4,8 +4,6 @@ from jinja2.runtime import Undefined
 
 from dbt.adapters.databricks.relation import DatabricksRelation, DatabricksQuotePolicy
 
-from dbt.exceptions import ApproximateMatchError
-
 
 class TestDatabricksRelation(unittest.TestCase):
     def test_pre_deserialize(self):

--- a/tests/unit/test_relation.py
+++ b/tests/unit/test_relation.py
@@ -166,8 +166,7 @@ class TestDatabricksRelation(unittest.TestCase):
         }
 
         relation = DatabricksRelation.from_dict(data)
-        with self.assertRaises(ApproximateMatchError):
-            relation.matches("SOME_DATABASE", "SOME_SCHEMA", "TABLE")
+        self.assertFalse(relation.matches("SOME_DATABASE", "SOME_SCHEMA", "TABLE"))
 
         data = {
             "path": {
@@ -179,5 +178,4 @@ class TestDatabricksRelation(unittest.TestCase):
         }
 
         relation = DatabricksRelation.from_dict(data)
-        with self.assertRaises(ApproximateMatchError):
-            relation.matches("some_database", "some_schema", "table")
+        self.assertFalse(relation.matches("some_database", "some_schema", "table"))


### PR DESCRIPTION
### Description
If an user has a model name such as models/mf/sf/TNAME.sql, the second dbt run will fail with:
```
When searching for a relation, dbt found an approximate match. Instead of guessing 
12:24:19    which relation to use, dbt will move on. Please delete `cname`.`sname`.`tname`, or rename it to be less ambiguous.
12:24:19    Searched for: `cname`.`sname`.`TNAME`
12:24:19    Found: `cname`.`sname`.`tname`
12:24:19    
12:24:19    > in macro materialization_incremental_databricks (macros/materializations/incremental/incremental.sql)
12:24:19    > called by model TNAME (models/mf/sf/TNAME.sql)
```

This PR overwrites the relation.matches method and removes case sensitive checks.

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
