### PR TITLE
Raise exception on unexpected error of list relations

### DIFF
--- a/dbt/adapters/databricks/impl.py
+++ b/dbt/adapters/databricks/impl.py
@@ -132,7 +132,7 @@ class DatabricksAdapter(SparkAdapter):
             else:
                 description = "Error while retrieving information about"
                 logger.debug(f"{description} {schema_relation}: {e.msg}")
-                return []
+                raise e
 
         return [
             self.Relation.create(
@@ -165,7 +165,7 @@ class DatabricksAdapter(SparkAdapter):
             else:
                 description = "Error while retrieving information about"
                 logger.debug(f"{description} {schema_relation.without_identifier()}: {e.msg}")
-                results = []
+                raise e
 
         relations: List[Tuple[DatabricksRelation, str]] = []
         for row in results:


### PR DESCRIPTION
### Description
Because of a [AWS Glue issue](https://github.com/dbt-labs/dbt-spark/pull/54), it was set to handle any exception and returning empty list of tables. The problem is that further logic decides to create or replace table, which leads to table being overwritten and all previous partitions are lost.

I believe that the problem the previous fix solves is no where near as important to Databricks, and the problem it causes is very bad.

resolves #266
