### PR TITLE
Specific dbt dependencies

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence, these
+# users will be requested for review when someone opens a
+# pull request.
+*       @andrefurlan-db @susodapop @ueshin

--- a/dbt/adapters/databricks/__version__.py
+++ b/dbt/adapters/databricks/__version__.py
@@ -1,1 +1,1 @@
-version: str = "1.5.0a1"
+version: str = "1.4.1"

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,11 +1,11 @@
 # install latest changes in dbt-core
 # TODO: how to automate switching from develop to version branches?
-git+https://github.com/dbt-labs/dbt-core.git#egg=dbt-core&subdirectory=core
-git+https://github.com/dbt-labs/dbt-core.git#egg=dbt-tests-adapter&subdirectory=tests/adapter
+# git+https://github.com/dbt-labs/dbt-core.git#egg=dbt-core&subdirectory=core
+# git+https://github.com/dbt-labs/dbt-core.git#egg=dbt-tests-adapter&subdirectory=tests/adapter
 
 # install latest changes in dbt-spark
 # TODO: how to automate switching from develop to version branches?
-git+https://github.com/dbt-labs/dbt-spark.git#egg=dbt-spark
+# git+https://github.com/dbt-labs/dbt-spark.git#egg=dbt-spark
 
 black==22.12.0
 flake8
@@ -21,3 +21,7 @@ pytest>=6.0.2
 pytz
 tox>=3.2.0
 types-requests
+
+dbt-spark==1.4.*
+dbt-core==1.4.*
+dbt-tests-adapter==1.4.*

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 databricks-sql-connector>=2.2.2
-dbt-spark~=1.5.0a1
+dbt-spark==1.4.*

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ def _get_plugin_version():
 
 package_name = "dbt-databricks"
 package_version = _get_plugin_version()
-dbt_spark_version = "1.5.0a1"
+dbt_spark_version = "1.4.1"
 description = """The Databricks adapter plugin for dbt"""
 
 setup(

--- a/tox.ini
+++ b/tox.ini
@@ -5,8 +5,8 @@ envlist = linter, unit
 [testenv:linter]
 basepython = python3
 commands =
-  {envpython} -m black --config black.ini --check .
-  {envpython} -m flake8 --select=E,W,F --ignore=E203,W503 --max-line-length=100 .
+  {envpython} -m black --config black.ini --check dbt tests
+  {envpython} -m flake8 --select=E,W,F --ignore=E203,W503 --max-line-length=100 dbt tests
   {envpython} -m mypy --config-file mypy.ini --explicit-package-bases dbt tests
 passenv =
   DBT_*


### PR DESCRIPTION
### Description

Given changes from 1.4 to 1.5 in dbt, we need to be able to maintain specific dependency versions in order to run tests

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
