### PR TITLE
Fix test_grants to use the error class to check the error.

### DIFF
--- a/tests/functional/adapter/test_grants.py
+++ b/tests/functional/adapter/test_grants.py
@@ -43,4 +43,4 @@ class TestInvalidGrantsDatabricks(BaseInvalidGrants):
         return "PRINCIPAL_DOES_NOT_EXIST"
 
     def privilege_does_not_exist_error(self):
-        return "FAKE_PRIVILEGE"
+        return "INVALID_PARAMETER_VALUE"


### PR DESCRIPTION
### Description

Fixes `test_grants` to use the error class to check the error.

There was a change on the error message when the specified privilege doesn't exist.
We should use the error class `INVALID_PARAMETER_VALUE` that is contained in the error message and more stable.