### PR TITLE
Add regexp_instr

### DIFF
--- a/dbt/include/databricks/macros/regex/regexp_instr.sql
+++ b/dbt/include/databricks/macros/regex/regexp_instr.sql
@@ -1,0 +1,3 @@
+{% macro databricks__regexp_instr(source_value, regexp, position, occurrence, is_raw) %}
+regexp_instr( {{ source_value }}, "{{ regexp }}")
+{% endmacro %}


### PR DESCRIPTION
### Description

This PR adds an implementation for [regexp_instr](https://learn.microsoft.com/en-us/azure/databricks/sql/language-manual/functions/regexp_instr) as used in [dbt-expections](https://github.com/calogica/dbt-expectations#expect_column_values_to_match_regex).

### Checklist

- [X] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
