### PR TITLE
fix database not found error matching

### DIFF
--- a/dbt/adapters/databricks/impl.py
+++ b/dbt/adapters/databricks/impl.py
@@ -61,10 +61,11 @@ class DatabricksConfig(AdapterConfig):
     tblproperties: Optional[Dict[str, str]] = None
 
 
-def check_not_found_error(errmsg) -> bool:
+def check_not_found_error(errmsg: str) -> bool:
     new_error = "[SCHEMA_NOT_FOUND]" in errmsg
     old_error = re.match(r".*(Database).*(not found).*", errmsg, re.DOTALL)
-    return new_error or old_error
+    return new_error or old_error is not None
+
 
 @undefined_proof
 class DatabricksAdapter(SparkAdapter):
@@ -129,7 +130,7 @@ class DatabricksAdapter(SparkAdapter):
             results = self.execute_macro(LIST_RELATIONS_MACRO_NAME, kwargs=kwargs)
         except dbt.exceptions.DbtRuntimeError as e:
             errmsg = getattr(e, "msg", "")
-            if (check_not_found_error(errmsg)):
+            if check_not_found_error(errmsg):
                 return []
             else:
                 description = "Error while retrieving information about"
@@ -159,7 +160,7 @@ class DatabricksAdapter(SparkAdapter):
                 results = list(self.execute_macro(SHOW_TABLE_EXTENDED_MACRO_NAME, kwargs=kwargs))
         except dbt.exceptions.DbtRuntimeError as e:
             errmsg = getattr(e, "msg", "")
-            if (check_not_found_error(errmsg)):
+            if check_not_found_error(errmsg):
                 results = []
             else:
                 description = "Error while retrieving information about"

--- a/dbt/adapters/databricks/impl.py
+++ b/dbt/adapters/databricks/impl.py
@@ -61,6 +61,11 @@ class DatabricksConfig(AdapterConfig):
     tblproperties: Optional[Dict[str, str]] = None
 
 
+def check_not_found_error(errmsg) -> bool:
+    new_error = "[SCHEMA_NOT_FOUND]" in errmsg
+    old_error = re.match(r".*(Database).*(not found).*", errmsg, re.DOTALL)
+    return new_error or old_error
+
 @undefined_proof
 class DatabricksAdapter(SparkAdapter):
 
@@ -124,10 +129,7 @@ class DatabricksAdapter(SparkAdapter):
             results = self.execute_macro(LIST_RELATIONS_MACRO_NAME, kwargs=kwargs)
         except dbt.exceptions.DbtRuntimeError as e:
             errmsg = getattr(e, "msg", "")
-            if (
-                "[SCHEMA_NOT_FOUND]" in errmsg
-                or f"Database '{schema_relation}' not found" in errmsg
-            ):
+            if (check_not_found_error(errmsg)):
                 return []
             else:
                 description = "Error while retrieving information about"
@@ -157,10 +159,7 @@ class DatabricksAdapter(SparkAdapter):
                 results = list(self.execute_macro(SHOW_TABLE_EXTENDED_MACRO_NAME, kwargs=kwargs))
         except dbt.exceptions.DbtRuntimeError as e:
             errmsg = getattr(e, "msg", "")
-            if (
-                "[SCHEMA_NOT_FOUND]" in errmsg
-                or f"Database '{schema_relation.without_identifier()}' not found" in errmsg
-            ):
+            if (check_not_found_error(errmsg)):
                 results = []
             else:
                 description = "Error while retrieving information about"

--- a/tests/unit/test_adapter.py
+++ b/tests/unit/test_adapter.py
@@ -862,8 +862,8 @@ class TestDatabricksAdapter(unittest.TestCase):
             },
         )
 
-class TestCheckNotFound(unittest.TestCase):
 
+class TestCheckNotFound(unittest.TestCase):
     def test_prefix(self):
         self.assertTrue(check_not_found_error("Runtime error \n Database 'dbt' not found"))
 

--- a/tests/unit/test_adapter.py
+++ b/tests/unit/test_adapter.py
@@ -7,6 +7,7 @@ import dbt.exceptions
 
 from dbt.adapters.databricks import __version__
 from dbt.adapters.databricks import DatabricksAdapter, DatabricksRelation
+from dbt.adapters.databricks.impl import check_not_found_error
 from dbt.adapters.databricks.connections import (
     CATALOG_KEY_IN_SESSION_PROPERTIES,
     DBT_DATABRICKS_INVOCATION_ENV,
@@ -860,3 +861,25 @@ class TestDatabricksAdapter(unittest.TestCase):
                 "stats:rows:value": 12345678,
             },
         )
+
+class TestCheckNotFound(unittest.TestCase):
+
+    def test_prefix(self):
+        self.assertTrue(check_not_found_error("Runtime error \n Database 'dbt' not found"))
+
+    def test_no_prefix_or_suffix(self):
+        self.assertTrue(check_not_found_error("Database not found"))
+
+    def test_quotes(self):
+        self.assertTrue(check_not_found_error("Database '`dbt`' not found"))
+
+    def test_suffix(self):
+        self.assertTrue(check_not_found_error("Database not found and \n foo"))
+
+    def test_error_condition(self):
+        self.assertTrue(check_not_found_error("[SCHEMA_NOT_FOUND]"))
+
+    def test_unexpected_error(self):
+        self.assertFalse(check_not_found_error("[DATABASE_NOT_FOUND]"))
+        self.assertFalse(check_not_found_error("Schema foo not found"))
+        self.assertFalse(check_not_found_error("Database 'foo' not there"))


### PR DESCRIPTION
resolves #277 


### Description

When not using Unity Catalog, and on an older DBR version, we were matching the wrong error message.
`Database `foo` not found` was expected but we got ```Database '`foo`' not found```

I moved the code checking the message into its own function and added some unit tests.

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
