### PR TITLE
[feat] Support ZORDER as a model config

### DIFF
--- a/dbt/adapters/databricks/impl.py
+++ b/dbt/adapters/databricks/impl.py
@@ -59,6 +59,7 @@ class DatabricksConfig(AdapterConfig):
     options: Optional[Dict[str, str]] = None
     merge_update_columns: Optional[str] = None
     tblproperties: Optional[Dict[str, str]] = None
+    zorder: Optional[Union[List[str], str]] = None
 
 
 def check_not_found_error(errmsg: str) -> bool:

--- a/dbt/include/databricks/macros/adapters.sql
+++ b/dbt/include/databricks/macros/adapters.sql
@@ -117,9 +117,11 @@
 
 {% macro databricks__optimize(relation) %}
   {% if config.get('zorder', False) and config.get('file_format', 'delta') == 'delta' %}
-    {% call statement('run_optimize_stmt') %}
-      {{ get_optimize_sql(relation) }}
-    {% endcall %}
+    {% if var('DATABRICKS_SKIP_OPTIMIZE', 'false')|lower != 'true' and var('databricks_skip_optimize', 'false')|lower != 'true' %}
+      {% call statement('run_optimize_stmt') %}
+        {{ get_optimize_sql(relation) }}
+      {% endcall %}
+    {% endif %}
   {% endif %}
 {% endmacro %}
 

--- a/dbt/include/databricks/macros/materializations/incremental/incremental.sql
+++ b/dbt/include/databricks/macros/materializations/incremental/incremental.sql
@@ -82,6 +82,8 @@
 
   {% do persist_constraints(target_relation, model) %}
 
+  {% do optimize(target_relation) %}
+
   {{ run_hooks(post_hooks) }}
 
   {{ return({'relations': [target_relation]}) }}

--- a/dbt/include/databricks/macros/materializations/table.sql
+++ b/dbt/include/databricks/macros/materializations/table.sql
@@ -31,6 +31,8 @@
 
   {% do persist_constraints(target_relation, model) %}
 
+  {% do optimze(target_relation) %}
+
   {{ run_hooks(post_hooks) }}
 
   {{ return({'relations': [target_relation]})}}

--- a/dbt/include/databricks/macros/materializations/table.sql
+++ b/dbt/include/databricks/macros/materializations/table.sql
@@ -31,7 +31,7 @@
 
   {% do persist_constraints(target_relation, model) %}
 
-  {% do optimze(target_relation) %}
+  {% do optimize(target_relation) %}
 
   {{ run_hooks(post_hooks) }}
 

--- a/tests/integration/zorder/models/multiple_zorder_model.sql
+++ b/tests/integration/zorder/models/multiple_zorder_model.sql
@@ -1,0 +1,5 @@
+{{ config(
+    materialized='incremental',
+    zorder=['id', 'name']
+) }}
+select 1 as id, 'Joe' as name

--- a/tests/integration/zorder/models/single_zorder_model.sql
+++ b/tests/integration/zorder/models/single_zorder_model.sql
@@ -1,0 +1,5 @@
+{{ config(
+    materialized='incremental',
+    zorder="name"
+) }}
+select 1 as id, 'Joe' as name

--- a/tests/integration/zorder/test_zorder.py
+++ b/tests/integration/zorder/test_zorder.py
@@ -1,7 +1,4 @@
 from tests.integration.base import DBTIntegrationTest, use_profile
-from dbt.tests.util import (
-    run_dbt_and_capture,
-)
 
 
 class TestZOrder(DBTIntegrationTest):

--- a/tests/integration/zorder/test_zorder.py
+++ b/tests/integration/zorder/test_zorder.py
@@ -1,0 +1,39 @@
+from tests.integration.base import DBTIntegrationTest, use_profile
+from dbt.tests.util import (
+    run_dbt_and_capture,
+)
+
+
+class TestZOrder(DBTIntegrationTest):
+    @property
+    def schema(self):
+        return "zorder"
+
+    @property
+    def models(self):
+        return "models"
+
+    @property
+    def project_config(self):
+        return {"config-version": 2}
+
+    def test_zorder(self):
+        self.run_dbt(["run"])
+        self.run_dbt(["run"]) # make sure it also run in incremental
+        
+
+    @use_profile("databricks_cluster")
+    def test_zorder_databricks_cluster(self):
+        self.test_zorder()
+
+    @use_profile("databricks_uc_cluster")
+    def test_zorder_databricks_uc_cluster(self):
+        self.test_zorder()
+
+    @use_profile("databricks_sql_endpoint")
+    def test_zorder_databricks_sql_endpoint(self):
+        self.test_zorder()
+
+    @use_profile("databricks_uc_sql_endpoint")
+    def test_zorder_databricks_uc_sql_endpoint(self):
+        self.test_zorder()

--- a/tests/integration/zorder/test_zorder.py
+++ b/tests/integration/zorder/test_zorder.py
@@ -12,7 +12,7 @@ class TestZOrder(DBTIntegrationTest):
 
     @property
     def project_config(self):
-        return {"config-version": 2, "vars": {"databricks_skip_optimize": "True"}}
+        return {"config-version": 2}
 
     def test_zorder(self):
         self.run_dbt(["run"])

--- a/tests/integration/zorder/test_zorder.py
+++ b/tests/integration/zorder/test_zorder.py
@@ -19,8 +19,7 @@ class TestZOrder(DBTIntegrationTest):
 
     def test_zorder(self):
         self.run_dbt(["run"])
-        self.run_dbt(["run"]) # make sure it also run in incremental
-        
+        self.run_dbt(["run"])  # make sure it also run in incremental
 
     @use_profile("databricks_cluster")
     def test_zorder_databricks_cluster(self):

--- a/tests/integration/zorder/test_zorder.py
+++ b/tests/integration/zorder/test_zorder.py
@@ -12,7 +12,10 @@ class TestZOrder(DBTIntegrationTest):
 
     @property
     def project_config(self):
-        return {"config-version": 2}
+        return {
+            "config-version": 2,
+            "vars": {"databricks_skip_optimize": "True"}
+        }
 
     def test_zorder(self):
         self.run_dbt(["run"])

--- a/tests/integration/zorder/test_zorder.py
+++ b/tests/integration/zorder/test_zorder.py
@@ -12,10 +12,7 @@ class TestZOrder(DBTIntegrationTest):
 
     @property
     def project_config(self):
-        return {
-            "config-version": 2,
-            "vars": {"databricks_skip_optimize": "True"}
-        }
+        return {"config-version": 2, "vars": {"databricks_skip_optimize": "True"}}
 
     def test_zorder(self):
         self.run_dbt(["run"])

--- a/tests/unit/test_macros.py
+++ b/tests/unit/test_macros.py
@@ -31,9 +31,7 @@ class TestSparkMacros(unittest.TestCase):
             key, default
         )
 
-        self.default_context["var"] = lambda key, default=None, **kwargs: self.var.get(
-            key, default
-        )
+        self.default_context["var"] = lambda key, default=None, **kwargs: self.var.get(key, default)
 
     def __get_template(self, template_filename):
         parent = self.parent_jinja_env.get_template(template_filename, globals=self.default_context)
@@ -313,10 +311,7 @@ class TestDatabricksMacros(unittest.TestCase):
         self.default_context["config"].get = lambda key, default=None, **kwargs: self.config.get(
             key, default
         )
-        self.default_context["var"] = lambda key, default=None, **kwargs: self.var.get(
-            key, default
-        )
-
+        self.default_context["var"] = lambda key, default=None, **kwargs: self.var.get(key, default)
 
     def __get_template(self, template_filename):
         parent = self.parent_jinja_env.get_template(template_filename, globals=self.default_context)
@@ -397,7 +392,6 @@ class TestDatabricksMacros(unittest.TestCase):
             ("optimize " "`some_database`.`some_schema`.`some_table` " "zorder by (foo, bar)"),
         )
 
-
     def test_macros_optimize(self):
         template = self.__get_template("adapters.sql")
         data = {
@@ -415,7 +409,7 @@ class TestDatabricksMacros(unittest.TestCase):
 
         self.assertEqual(
             r,
-            'run_optimize_stmt',
+            "run_optimize_stmt",
         )
 
         self.var["FOO"] = True
@@ -423,7 +417,7 @@ class TestDatabricksMacros(unittest.TestCase):
 
         self.assertEqual(
             r,
-            'run_optimize_stmt',
+            "run_optimize_stmt",
         )
 
         self.var["DATABRICKS_SKIP_OPTIMIZE"] = True
@@ -431,7 +425,7 @@ class TestDatabricksMacros(unittest.TestCase):
 
         self.assertEqual(
             r,
-            '', # should skip
+            "",  # should skip
         )
 
         self.var["databricks_skip_optimize"] = True
@@ -439,8 +433,7 @@ class TestDatabricksMacros(unittest.TestCase):
 
         self.assertEqual(
             r,
-            '', # should skip
+            "",  # should skip
         )
 
         del self.var["databricks_skip_optimize"]
-

--- a/tests/unit/test_macros.py
+++ b/tests/unit/test_macros.py
@@ -367,17 +367,19 @@ class TestDatabricksMacros(unittest.TestCase):
             },
             "type": None,
         }
-        self.config["zorder"] = "foo"
         relation = DatabricksRelation.from_dict(data)
-        sql = self.__run_macro(
-            template, "get_optimize_sql", None, relation, None
-        ).strip()
+
+        self.config["zorder"] = "foo"
+        sql = self.__run_macro(template, "get_optimize_sql", None, relation, None).strip()
 
         self.assertEqual(
             sql,
-            (
-                "optimize "
-                "`some_database`.`some_schema`.`some_table` "
-                "zorder by (foo)"
-            ),
+            ("optimize " "`some_database`.`some_schema`.`some_table` " "zorder by (foo)"),
+        )
+        self.config["zorder"] = ["foo", "bar"]
+        sql2 = self.__run_macro(template, "get_optimize_sql", None, relation, None).strip()
+
+        self.assertEqual(
+            sql2,
+            ("optimize " "`some_database`.`some_schema`.`some_table` " "zorder by (foo, bar)"),
         )


### PR DESCRIPTION
<!-- Please review our pull request review process in CONTRIBUTING.md before your proceed. -->

Resolves #122

### Description
This PR augments the dbt model config with:
```python
config(
    materialized='incremental',
    zorder="column_A" | ["column_A", "column_B"]
)
```

Under the hood, after every model with zorder is build (initial or incremental), we'll run a `OPTIMIZE relation ZORDER BY ()` statement.

A var is available to skip OPTIMIZE if necessary: `databricks_skip_optimize`

One can set it in the `dbt-project.yaml` or directly in the comman line: `dbt run --models stg_payments --vars "{'databricks_skip_optimize': 'true'}"`

**Benefits:**
This simplifies the project as it requires one less post hook for maintenance operations.

#### Potential improvements
* Add predicates to OPTIMIZE statement. `OPTIMIZE table WHERE ...`
* Do not fail model if optimize fails: warn if optimize fails, but not error our

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
