### PR TITLE
[feat] Support ZORDER as a model config (#292)

### DIFF
--- a/dbt/adapters/databricks/impl.py
+++ b/dbt/adapters/databricks/impl.py
@@ -59,6 +59,7 @@ class DatabricksConfig(AdapterConfig):
     options: Optional[Dict[str, str]] = None
     merge_update_columns: Optional[str] = None
     tblproperties: Optional[Dict[str, str]] = None
+    zorder: Optional[Union[List[str], str]] = None
 
 
 def check_not_found_error(errmsg: str) -> bool:

--- a/dbt/include/databricks/macros/adapters.sql
+++ b/dbt/include/databricks/macros/adapters.sql
@@ -111,6 +111,37 @@
   {% endif %}
 {% endmacro %}
 
+{% macro optimize(relation) %}
+  {{ return(adapter.dispatch('optimize', 'dbt')(relation)) }}
+{% endmacro %}
+
+{% macro databricks__optimize(relation) %}
+  {% if config.get('zorder', False) and config.get('file_format', 'delta') == 'delta' %}
+    {% if var('DATABRICKS_SKIP_OPTIMIZE', 'false')|lower != 'true' and var('databricks_skip_optimize', 'false')|lower != 'true' %}
+      {% call statement('run_optimize_stmt') %}
+        {{ get_optimize_sql(relation) }}
+      {% endcall %}
+    {% endif %}
+  {% endif %}
+{% endmacro %}
+
+{% macro get_optimize_sql(relation) %}
+  {% if config.get('zorder', False) and config.get('file_format', 'delta') == 'delta' %}
+     {%- set zorder = config.get('zorder', none) -%}
+    optimize {{ relation }}
+    {# TODO: predicates here? WHERE ...  #}
+    {% if zorder is sequence and zorder is not string %}
+      zorder by (
+        {%- for col in zorder -%}
+        {{ col }}{% if not loop.last %}, {% endif %}
+        {%- endfor -%}
+      )
+    {% else %}
+      zorder by ({{zorder}})
+    {% endif %}
+  {% endif %}
+{% endmacro %}
+
 {% macro alter_table_add_constraints(relation, constraints) %}
   {{ return(adapter.dispatch('alter_table_add_constraints', 'dbt')(relation, constraints)) }}
 {% endmacro %}

--- a/dbt/include/databricks/macros/materializations/incremental/incremental.sql
+++ b/dbt/include/databricks/macros/materializations/incremental/incremental.sql
@@ -82,6 +82,8 @@
 
   {% do persist_constraints(target_relation, model) %}
 
+  {% do optimize(target_relation) %}
+
   {{ run_hooks(post_hooks) }}
 
   {{ return({'relations': [target_relation]}) }}

--- a/dbt/include/databricks/macros/materializations/table.sql
+++ b/dbt/include/databricks/macros/materializations/table.sql
@@ -31,6 +31,8 @@
 
   {% do persist_constraints(target_relation, model) %}
 
+  {% do optimize(target_relation) %}
+
   {{ run_hooks(post_hooks) }}
 
   {{ return({'relations': [target_relation]})}}

--- a/tests/integration/zorder/models/multiple_zorder_model.sql
+++ b/tests/integration/zorder/models/multiple_zorder_model.sql
@@ -1,0 +1,5 @@
+{{ config(
+    materialized='incremental',
+    zorder=['id', 'name']
+) }}
+select 1 as id, 'Joe' as name

--- a/tests/integration/zorder/models/single_zorder_model.sql
+++ b/tests/integration/zorder/models/single_zorder_model.sql
@@ -1,0 +1,5 @@
+{{ config(
+    materialized='incremental',
+    zorder="name"
+) }}
+select 1 as id, 'Joe' as name

--- a/tests/integration/zorder/test_zorder.py
+++ b/tests/integration/zorder/test_zorder.py
@@ -1,0 +1,35 @@
+from tests.integration.base import DBTIntegrationTest, use_profile
+
+
+class TestZOrder(DBTIntegrationTest):
+    @property
+    def schema(self):
+        return "zorder"
+
+    @property
+    def models(self):
+        return "models"
+
+    @property
+    def project_config(self):
+        return {"config-version": 2}
+
+    def test_zorder(self):
+        self.run_dbt(["run"])
+        self.run_dbt(["run"])  # make sure it also run in incremental
+
+    @use_profile("databricks_cluster")
+    def test_zorder_databricks_cluster(self):
+        self.test_zorder()
+
+    @use_profile("databricks_uc_cluster")
+    def test_zorder_databricks_uc_cluster(self):
+        self.test_zorder()
+
+    @use_profile("databricks_sql_endpoint")
+    def test_zorder_databricks_sql_endpoint(self):
+        self.test_zorder()
+
+    @use_profile("databricks_uc_sql_endpoint")
+    def test_zorder_databricks_uc_sql_endpoint(self):
+        self.test_zorder()

--- a/tests/unit/test_macros.py
+++ b/tests/unit/test_macros.py
@@ -17,17 +17,21 @@ class TestSparkMacros(unittest.TestCase):
         )
 
         self.config = {}
+        self.var = {}
         self.default_context = {
             "validation": mock.Mock(),
             "model": mock.Mock(),
             "exceptions": mock.Mock(),
             "config": mock.Mock(),
             "adapter": mock.Mock(),
+            "var": mock.Mock(),
             "return": lambda r: r,
         }
         self.default_context["config"].get = lambda key, default=None, **kwargs: self.config.get(
             key, default
         )
+
+        self.default_context["var"] = lambda key, default=None, **kwargs: self.var.get(key, default)
 
     def __get_template(self, template_filename):
         parent = self.parent_jinja_env.get_template(template_filename, globals=self.default_context)
@@ -293,17 +297,21 @@ class TestDatabricksMacros(unittest.TestCase):
         )
 
         self.config = {}
+        self.var = {}
         self.default_context = {
             "validation": mock.Mock(),
             "model": mock.Mock(),
             "exceptions": mock.Mock(),
             "config": mock.Mock(),
+            "statement": lambda r, caller: r,
+            "var": mock.Mock(),
             "adapter": mock.Mock(),
             "return": lambda r: r,
         }
         self.default_context["config"].get = lambda key, default=None, **kwargs: self.config.get(
             key, default
         )
+        self.default_context["var"] = lambda key, default=None, **kwargs: self.var.get(key, default)
 
     def __get_template(self, template_filename):
         parent = self.parent_jinja_env.get_template(template_filename, globals=self.default_context)
@@ -323,8 +331,10 @@ class TestDatabricksMacros(unittest.TestCase):
 
         if temporary is not None:
             value = getattr(template.module, name)(temporary, relation, sql)
-        else:
+        elif sql is not None:
             value = getattr(template.module, name)(relation, sql)
+        else:
+            value = getattr(template.module, name)(relation)
         return re.sub(r"\s\s+", " ", value)
 
     def test_macros_load(self):
@@ -354,3 +364,76 @@ class TestDatabricksMacros(unittest.TestCase):
                 "using delta as select 1"
             ),
         )
+
+    def test_macros_get_optimize_sql(self):
+        template = self.__get_template("adapters.sql")
+        data = {
+            "path": {
+                "database": "some_database",
+                "schema": "some_schema",
+                "identifier": "some_table",
+            },
+            "type": None,
+        }
+        relation = DatabricksRelation.from_dict(data)
+
+        self.config["zorder"] = "foo"
+        sql = self.__run_macro(template, "get_optimize_sql", None, relation, None).strip()
+
+        self.assertEqual(
+            sql,
+            ("optimize " "`some_database`.`some_schema`.`some_table` " "zorder by (foo)"),
+        )
+        self.config["zorder"] = ["foo", "bar"]
+        sql2 = self.__run_macro(template, "get_optimize_sql", None, relation, None).strip()
+
+        self.assertEqual(
+            sql2,
+            ("optimize " "`some_database`.`some_schema`.`some_table` " "zorder by (foo, bar)"),
+        )
+
+    def test_macros_optimize(self):
+        template = self.__get_template("adapters.sql")
+        data = {
+            "path": {
+                "database": "some_database",
+                "schema": "some_schema",
+                "identifier": "some_table",
+            },
+            "type": None,
+        }
+        relation = DatabricksRelation.from_dict(data)
+
+        self.config["zorder"] = ["foo", "bar"]
+        r = self.__run_macro(template, "optimize", None, relation, None).strip()
+
+        self.assertEqual(
+            r,
+            "run_optimize_stmt",
+        )
+
+        self.var["FOO"] = True
+        r = self.__run_macro(template, "optimize", None, relation, None).strip()
+
+        self.assertEqual(
+            r,
+            "run_optimize_stmt",
+        )
+
+        self.var["DATABRICKS_SKIP_OPTIMIZE"] = True
+        r = self.__run_macro(template, "optimize", None, relation, None).strip()
+
+        self.assertEqual(
+            r,
+            "",  # should skip
+        )
+
+        self.var["databricks_skip_optimize"] = True
+        r = self.__run_macro(template, "optimize", None, relation, None).strip()
+
+        self.assertEqual(
+            r,
+            "",  # should skip
+        )
+
+        del self.var["databricks_skip_optimize"]


### PR DESCRIPTION
Resolves #122

### Description
This PR augments the dbt model config with:

```python
config(
    materialized='incremental',
    zorder="column_A" | ["column_A", "column_B"]
)
```
Under the hood, after every model with zorder is build (initial or incremental), we'll run a OPTIMIZE relation ZORDER BY () statement.

A var is available to skip OPTIMIZE if necessary: `databricks_skip_optimize`

One can set it in the dbt-project.yaml or directly in the comman line: `dbt run --models stg_payments --vars "{'databricks_skip_optimize': 'true'}"`

#### Benefits:
This simplifies the project as it requires one less post hook for maintenance operations.

#### Potential improvements
* Add predicates to OPTIMIZE statement. OPTIMIZE table WHERE ... 
* Do not fail model if optimize fails: warn if optimize fails, but not error out

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
