### PR TITLE
Auto start cluster for Python models

### DIFF
--- a/dbt/adapters/databricks/python_submissions.py
+++ b/dbt/adapters/databricks/python_submissions.py
@@ -205,7 +205,9 @@ class DBContext:
     def create(self) -> str:
         # https://docs.databricks.com/dev-tools/api/1.2/index.html#create-an-execution-context
 
-        if self.get_cluster_status().get("status") in ["Terminated", "Terminating"]:
+        
+        current_status = self.get_cluster_status().get("state","").upper()
+        if current_status in ["TERMINATED", "TERMINATING"]:
             logger.debug(f"Cluster {self.cluster_id} is not running. Attempting to restart.")
             self.start_cluster()
             logger.debug(f"Cluster {self.cluster_id} is now running.")
@@ -254,7 +256,8 @@ class DBContext:
                 f"Error getting status of cluster.\n {response.content!r}"
             )
 
-        return response.json()
+        json_response = response.json()
+        return json_response
 
     def start_cluster(self) -> None:
         """Send the start command and poll for the cluster status until it shows "Running"

--- a/dbt/adapters/databricks/python_submissions.py
+++ b/dbt/adapters/databricks/python_submissions.py
@@ -283,25 +283,24 @@ class DBCommand:
                 f"Error getting status of command.\n {response.content!r}"
             )
         return response.json()
-    
-    def get_cluster_status(self):
+
+    def get_cluster_status(self) -> Dict:
 
         # https://docs.databricks.com/dev-tools/api/1.2/index.html#get-information-about-a-cluster
 
         response = requests.get(
             f"https://{self.host}/api/1.2/clusters/status",
             headers=self.auth_header,
-            params={
-                "clusterId": self.cluster_id            },
+            params={"clusterId": self.cluster_id},
         )
         if response.status_code != 200:
             raise dbt.exceptions.DbtRuntimeError(
                 f"Error getting status of cluster.\n {response.content!r}"
             )
-        
+
         return response.json()
-    
-    def start_cluster(self):
+
+    def start_cluster(self) -> None:
         """Send the start command and poll for the cluster status until it shows "Running"
 
         Raise an exception if the restart exceeds our timeout.
@@ -314,21 +313,20 @@ class DBCommand:
         response = requests.get(
             f"https://{self.host}/api/1.2/clusters/restart",
             headers=self.auth_header,
-            params={
-                "clusterId": self.cluster_id            },
+            params={"clusterId": self.cluster_id},
         )
         if response.status_code != 200:
             raise dbt.exceptions.DbtRuntimeError(
                 f"Error starting terminated cluster.\n {response.content!r}"
             )
-        
+
         # seconds
-        MAX_CLUSTER_START_TIME = 900 
+        MAX_CLUSTER_START_TIME = 900
         start_time = time.time()
 
-        def get_elapsed():
+        def get_elapsed() -> float:
             return time.time() - start_time
-        
+
         while get_elapsed() < MAX_CLUSTER_START_TIME:
             status_response = self.get_cluster_status()
             if status_response.get("status") == "Running":

--- a/dbt/adapters/databricks/python_submissions.py
+++ b/dbt/adapters/databricks/python_submissions.py
@@ -292,7 +292,9 @@ class DBContext:
             else:
                 time.sleep(5)
 
-        raise dbt.exceptions.DbtRuntimeError(f"Cluster {self.cluster_id} restart timed out after {MAX_CLUSTER_START_TIME} seconds")
+        raise dbt.exceptions.DbtRuntimeError(
+            f"Cluster {self.cluster_id} restart timed out after {MAX_CLUSTER_START_TIME} seconds"
+        )
 
 
 class DBCommand:

--- a/dbt/adapters/databricks/python_submissions.py
+++ b/dbt/adapters/databricks/python_submissions.py
@@ -205,8 +205,7 @@ class DBContext:
     def create(self) -> str:
         # https://docs.databricks.com/dev-tools/api/1.2/index.html#create-an-execution-context
 
-        
-        current_status = self.get_cluster_status().get("state","").upper()
+        current_status = self.get_cluster_status().get("state", "").upper()
         if current_status in ["TERMINATED", "TERMINATING"]:
             logger.debug(f"Cluster {self.cluster_id} is not running. Attempting to restart.")
             self.start_cluster()

--- a/dbt/adapters/databricks/python_submissions.py
+++ b/dbt/adapters/databricks/python_submissions.py
@@ -292,7 +292,7 @@ class DBContext:
             else:
                 time.sleep(5)
 
-        raise dbt.exceptions.DbtRuntimeError(f"Cluster {self.cluster_id} restart timed out")
+        raise dbt.exceptions.DbtRuntimeError(f"Cluster {self.cluster_id} restart timed out after {MAX_CLUSTER_START_TIME} seconds")
 
 
 class DBCommand:

--- a/tests/integration/python/models/basic.py
+++ b/tests/integration/python/models/basic.py
@@ -1,4 +1,4 @@
-import pandas as pd
+import pandas as pd  # type: ignore
 
 
 def model(dbt, spark):

--- a/tests/integration/python/models/basic.py
+++ b/tests/integration/python/models/basic.py
@@ -1,0 +1,11 @@
+import pandas as pd
+
+
+def model(dbt, spark):
+    data = [[1, "Elia"], [2, "Teo"], [3, "Fang"]]
+
+    pdf = pd.DataFrame(data, columns=["id", "name"])
+
+    df = spark.createDataFrame(pdf)
+
+    return df

--- a/tests/integration/python/models/models.yml
+++ b/tests/integration/python/models/models.yml
@@ -1,0 +1,7 @@
+version: 2
+models:
+  - name: basic
+    config:
+      materialized: table
+      tags: [ 'python' ]
+      http_path: '{{ var("http_path") }}'

--- a/tests/integration/python/test_python.py
+++ b/tests/integration/python/test_python.py
@@ -1,0 +1,32 @@
+from tests.integration.base import DBTIntegrationTest, use_profile
+import os, pytest
+
+@pytest.mark.skip(reason="Run manually. Test must start with the Python compute resource in TERMINATED or TERMINATING state")
+class TestPython(DBTIntegrationTest):
+    @property
+    def schema(self):
+        return "python"
+
+    @property
+    def models(self):
+        return "models"
+
+    @property
+    def project_config(self):
+        return {
+            "config-version": 2,
+            "vars":
+                {"http_path": os.getenv("DBT_DATABRICKS_CLUSTER_HTTP_PATH")}
+        }
+
+    def python_exc(self):
+        self.run_dbt(["run"])
+        self.run_dbt(["run"])  # make sure it also run in incremental
+
+    @use_profile("databricks_sql_endpoint")
+    def test_python_databricks_sql_endpoint(self):
+        self.python_exc()
+
+    @use_profile("databricks_uc_sql_endpoint")
+    def test_python_databricks_uc_sql_endpoint(self):
+        self.python_exc()

--- a/tests/integration/python/test_python.py
+++ b/tests/integration/python/test_python.py
@@ -1,7 +1,12 @@
 from tests.integration.base import DBTIntegrationTest, use_profile
-import os, pytest
+import os
+import pytest
 
-@pytest.mark.skip(reason="Run manually. Test must start with the Python compute resource in TERMINATED or TERMINATING state")
+
+@pytest.mark.skip(
+    reason="Run manually. Test must start with the Python compute\
+          resource in TERMINATED or TERMINATING state"
+)
 class TestPython(DBTIntegrationTest):
     @property
     def schema(self):
@@ -15,8 +20,7 @@ class TestPython(DBTIntegrationTest):
     def project_config(self):
         return {
             "config-version": 2,
-            "vars":
-                {"http_path": os.getenv("DBT_DATABRICKS_CLUSTER_HTTP_PATH")}
+            "vars": {"http_path": os.getenv("DBT_DATABRICKS_CLUSTER_HTTP_PATH")},
         }
 
     def python_exc(self):

--- a/tests/integration/python/test_python.py
+++ b/tests/integration/python/test_python.py
@@ -25,7 +25,6 @@ class TestPython(DBTIntegrationTest):
 
     def python_exc(self):
         self.run_dbt(["run"])
-        self.run_dbt(["run"])  # make sure it also run in incremental
 
     @use_profile("databricks_sql_endpoint")
     def test_python_databricks_sql_endpoint(self):


### PR DESCRIPTION
<!-- Please review our pull request review process in CONTRIBUTING.md before your proceed. -->

Resolves #232

<!---
  Include the number of the issue addressed by this PR above if applicable.
  
  Example:
    resolves #1234

  Please review our pull request review process in CONTRIBUTING.md before your proceed.
-->

### Description

This change follows #302, which imported some Databricks-specific code from dbt-spark directly into this repository. In this PR I implemented logic to check whether the cluster for Python models is running, start it if not, and wait for the cluster to start before proceeding.

Testing this change is necessarily manual, for now. The test uses a `dbt` profile that connects to a SQL warehouse and then tells the specific Python model to connect to an all purpose cluster which is in TERMINATED state at the beginning of the test. Our automated integration tests run on shared infrastructure (multiple PRs use the same environment) so we can't guarantee that the all-purpose cluster is TERMINATED automatically.

Therefore the integration test in this PR is skipped automatically. To run it, clone the repository, set `DBT_DATABRICKS_CLUSTER_HTTP_PATH` in `test.env` to a TERMINATED all-purpose cluster, and then run `python` integration test. It should pass and you will see that the cluster is started automatically. 

In a follow-up PR I can mock the cluster status API response and assert that the `start_cluster()` method was called. But a full integration test will require more work from the DECO team.

<!--- Describe the Pull Request here -->

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
