### PR TITLE
OAuth support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ test.env
 *.log
 logs/
 .venv
+.venv2

--- a/dbt/adapters/databricks/auth.py
+++ b/dbt/adapters/databricks/auth.py
@@ -1,4 +1,4 @@
-from typing import Dict, List
+from typing import Dict
 from databricks.sdk.oauth import ClientCredentials, Token
 from databricks.sdk.core import CredentialsProvider, HeaderFactory
 
@@ -41,7 +41,7 @@ class m2m_auth(CredentialsProvider):
             client_id=client_id,
             client_secret=client_secret,
             token_url=resp.json()["token_endpoint"],
-            scopes=["all-apis"], # hardcoded for now
+            scopes=["all-apis"],  # hardcoded for now
             use_header=True,
         )
 
@@ -55,9 +55,7 @@ class m2m_auth(CredentialsProvider):
             return {"token": {}}
 
     @staticmethod
-    def from_dict(
-        host: str, client_id: str, client_secret: str, raw: dict
-    ) -> CredentialsProvider:
+    def from_dict(host: str, client_id: str, client_secret: str, raw: dict) -> CredentialsProvider:
         c = m2m_auth(host=host, client_id=client_id, client_secret=client_secret)
         c._token_source._token = Token.from_dict(raw["token"])
         return c

--- a/dbt/adapters/databricks/auth.py
+++ b/dbt/adapters/databricks/auth.py
@@ -6,104 +6,117 @@ import requests
 
 REDIRECT_URL = "http://localhost:8050"
 CLIENT_ID = "dbt-databricks"
-SCOPES = ['all-apis', 'offline_access']
+SCOPES = ["all-apis", "offline_access"]
+
 
 def authenticate(creds) -> CredentialsProvider:
     if creds.token:
         return token_auth(creds.token)
-    
+
     if creds.client_id and creds.client_secret:
         return m2m_auth(creds.host, creds.client_id, creds.client_secret)
-    
-    if (creds.client_id and not creds.client_secret) or (not creds.client_id and creds.client_secret):
+
+    if (creds.client_id and not creds.client_secret) or (
+        not creds.client_id and creds.client_secret
+    ):
         raise "missing credentials"
-    
-    oauth_client = OAuthClient(host=creds.host,
-                           client_id=CLIENT_ID, 
-                           client_secret=None,
-                           redirect_url=REDIRECT_URL,
-                           scopes=SCOPES)
-    
+
+    oauth_client = OAuthClient(
+        host=creds.host,
+        client_id=CLIENT_ID,
+        client_secret=None,
+        redirect_url=REDIRECT_URL,
+        scopes=SCOPES,
+    )
+
     consent = oauth_client.initiate_consent()
 
     return consent.launch_external_browser()
 
+
 def from_dict(creds, raw) -> CredentialsProvider:
     if creds.token:
         return token_auth.from_dict(raw)
-    
+
     if creds.client_id and creds.client_secret:
-        return m2m_auth.from_dict(host=creds.host, client_id=creds.client_id, client_secret=creds.client_secret, raw=raw)
-    
-    if (creds.client_id and not creds.client_secret) or (not creds.client_id and creds.client_secret):
+        return m2m_auth.from_dict(
+            host=creds.host, client_id=creds.client_id, client_secret=creds.client_secret, raw=raw
+        )
+
+    if (creds.client_id and not creds.client_secret) or (
+        not creds.client_id and creds.client_secret
+    ):
         raise "missing credentials"
-    
-    oauth_client = OAuthClient(host=creds.host,
-                        client_id=CLIENT_ID,
-                        client_secret=None,
-                        redirect_url=REDIRECT_URL,
-                        scopes=SCOPES)
-    
+
+    oauth_client = OAuthClient(
+        host=creds.host,
+        client_id=CLIENT_ID,
+        client_secret=None,
+        redirect_url=REDIRECT_URL,
+        scopes=SCOPES,
+    )
+
     return RefreshableCredentials.from_dict(client=oauth_client, raw=raw)
-    
+
 
 class token_auth(CredentialsProvider):
     _token: str
-    
+
     def __init__(self, token) -> None:
         self._token = token
-    
+
     def auth_type(self) -> str:
         return "token"
-    
+
     def as_dict(self) -> dict:
-        return {'token': self._token}
-    
+        return {"token": self._token}
+
     @staticmethod
     def from_dict(raw: dict) -> CredentialsProvider:
         return token_auth(raw["token"])
 
     def __call__(self, *args, **kwargs) -> HeaderFactory:
-        static_credentials = {'Authorization': f'Bearer {self._token}'}
+        static_credentials = {"Authorization": f"Bearer {self._token}"}
 
         def inner() -> Dict[str, str]:
             return static_credentials
+
         return inner
 
-    
+
 class m2m_auth(CredentialsProvider):
     _token_source = None
-    
+
     def __init__(self, host: str, client_id: str, client_secret: str) -> None:
         resp = requests.get(f"https://{host}/oidc/.well-known/oauth-authorization-server")
         if not resp.ok:
             return None
-        self._token_source = ClientCredentials(client_id=client_id,
-                                               client_secret=client_secret,
-                                               token_url=resp.json()["token_endpoint"],
-                                               scopes=SCOPES,
-                                               use_header=True)
+        self._token_source = ClientCredentials(
+            client_id=client_id,
+            client_secret=client_secret,
+            token_url=resp.json()["token_endpoint"],
+            scopes=SCOPES,
+            use_header=True,
+        )
 
     def auth_type(self) -> str:
         return "oauth"
-    
+
     def as_dict(self) -> dict:
         if self._token_source:
-            return {'token': self._token_source.token().as_dict()}
+            return {"token": self._token_source.token().as_dict()}
         else:
-            return {'token': {}}
-    
+            return {"token": {}}
+
     @staticmethod
     def from_dict(host: str, client_id: str, client_secret: str, raw: dict) -> CredentialsProvider:
         c = m2m_auth(host=host, client_id=client_id, client_secret=client_secret)
         c._token_source._token = Token.from_dict(raw["token"])
         return c
 
-    
     def __call__(self, *args, **kwargs) -> HeaderFactory:
-
         def inner() -> Dict[str, str]:
             token = self._token_source.token()
-            return {'Authorization': f'{token.token_type} {token.access_token}'}
+            return {"Authorization": f"{token.token_type} {token.access_token}"}
 
         return inner

--- a/dbt/adapters/databricks/auth.py
+++ b/dbt/adapters/databricks/auth.py
@@ -35,16 +35,14 @@ class m2m_auth(CredentialsProvider):
 
     def __init__(self, host: str, client_id: str, client_secret: str) -> None:
         @credentials_provider("noop", [])
-        def noop_credentials(_: Any):
+        def noop_credentials(_: Any):  # type: ignore
             return lambda: {}
 
         config = Config(host=host, credentials_provider=noop_credentials)
         oidc = config.oidc_endpoints
-        scopes = []
+        scopes = ["offline_access", "all-apis"]
         if not oidc:
             raise ValueError(f"{host} does not support OAuth")
-        if not scopes:
-            scopes = ["offline_access", "all-apis"]
         if config.is_azure:
             # Azure AD only supports full access to Azure Databricks.
             scopes = [f"{config.effective_azure_login_app_id}/.default", "offline_access"]

--- a/dbt/adapters/databricks/auth.py
+++ b/dbt/adapters/databricks/auth.py
@@ -1,4 +1,3 @@
-
 from typing import Dict
 from databricks.sdk.oauth import ClientCredentials, Token
 from databricks.sdk.core import CredentialsProvider, HeaderFactory

--- a/dbt/adapters/databricks/auth.py
+++ b/dbt/adapters/databricks/auth.py
@@ -1,4 +1,4 @@
-from typing import Dict
+from typing import Dict, List
 from databricks.sdk.oauth import ClientCredentials, Token
 from databricks.sdk.core import CredentialsProvider, HeaderFactory
 
@@ -41,7 +41,7 @@ class m2m_auth(CredentialsProvider):
             client_id=client_id,
             client_secret=client_secret,
             token_url=resp.json()["token_endpoint"],
-            scopes=SCOPES,
+            scopes=["all-apis"], # hardcoded for now
             use_header=True,
         )
 
@@ -55,7 +55,9 @@ class m2m_auth(CredentialsProvider):
             return {"token": {}}
 
     @staticmethod
-    def from_dict(host: str, client_id: str, client_secret: str, raw: dict) -> CredentialsProvider:
+    def from_dict(
+        host: str, client_id: str, client_secret: str, raw: dict
+    ) -> CredentialsProvider:
         c = m2m_auth(host=host, client_id=client_id, client_secret=client_secret)
         c._token_source._token = Token.from_dict(raw["token"])
         return c

--- a/dbt/adapters/databricks/auth.py
+++ b/dbt/adapters/databricks/auth.py
@@ -23,7 +23,7 @@ class token_auth(CredentialsProvider):
             return None
         return token_auth(raw["token"])
 
-    def __call__(self, *args: tuple, **kwargs: dict[str, Any]) -> HeaderFactory:
+    def __call__(self, *args: tuple, **kwargs: Dict[str, Any]) -> HeaderFactory:
         static_credentials = {"Authorization": f"Bearer {self._token}"}
 
         def inner() -> Dict[str, str]:
@@ -62,7 +62,7 @@ class m2m_auth(CredentialsProvider):
         c._token_source._token = Token.from_dict(raw["token"])
         return c
 
-    def __call__(self, *args: tuple, **kwargs: dict[str, Any]) -> HeaderFactory:
+    def __call__(self, *args: tuple, **kwargs: Dict[str, Any]) -> HeaderFactory:
         def inner() -> Dict[str, str]:
             token = self._token_source.token()
             return {"Authorization": f"{token.token_type} {token.access_token}"}

--- a/dbt/adapters/databricks/auth.py
+++ b/dbt/adapters/databricks/auth.py
@@ -1,0 +1,109 @@
+from typing import Dict
+from databricks.sdk.oauth import OAuthClient, ClientCredentials, Token, RefreshableCredentials
+from databricks.sdk.core import CredentialsProvider, HeaderFactory
+
+import requests
+
+REDIRECT_URL = "http://localhost:8050"
+CLIENT_ID = "dbt-databricks"
+SCOPES = ['all-apis', 'offline_access']
+
+def authenticate(creds) -> CredentialsProvider:
+    if creds.token:
+        return token_auth(creds.token)
+    
+    if creds.client_id and creds.client_secret:
+        return m2m_auth(creds.host, creds.client_id, creds.client_secret)
+    
+    if (creds.client_id and not creds.client_secret) or (not creds.client_id and creds.client_secret):
+        raise "missing credentials"
+    
+    oauth_client = OAuthClient(host=creds.host,
+                           client_id=CLIENT_ID, 
+                           client_secret=None,
+                           redirect_url=REDIRECT_URL,
+                           scopes=SCOPES)
+    
+    consent = oauth_client.initiate_consent()
+
+    return consent.launch_external_browser()
+
+def from_dict(creds, raw) -> CredentialsProvider:
+    if creds.token:
+        return token_auth.from_dict(raw)
+    
+    if creds.client_id and creds.client_secret:
+        return m2m_auth.from_dict(host=creds.host, client_id=creds.client_id, client_secret=creds.client_secret, raw=raw)
+    
+    if (creds.client_id and not creds.client_secret) or (not creds.client_id and creds.client_secret):
+        raise "missing credentials"
+    
+    oauth_client = OAuthClient(host=creds.host,
+                        client_id=CLIENT_ID,
+                        client_secret=None,
+                        redirect_url=REDIRECT_URL,
+                        scopes=SCOPES)
+    
+    return RefreshableCredentials.from_dict(client=oauth_client, raw=raw)
+    
+
+class token_auth(CredentialsProvider):
+    _token: str
+    
+    def __init__(self, token) -> None:
+        self._token = token
+    
+    def auth_type(self) -> str:
+        return "token"
+    
+    def as_dict(self) -> dict:
+        return {'token': self._token}
+    
+    @staticmethod
+    def from_dict(raw: dict) -> CredentialsProvider:
+        return token_auth(raw["token"])
+
+    def __call__(self, *args, **kwargs) -> HeaderFactory:
+        static_credentials = {'Authorization': f'Bearer {self._token}'}
+
+        def inner() -> Dict[str, str]:
+            return static_credentials
+        return inner
+
+    
+class m2m_auth(CredentialsProvider):
+    _token_source = None
+    
+    def __init__(self, host: str, client_id: str, client_secret: str) -> None:
+        resp = requests.get(f"https://{host}/oidc/.well-known/oauth-authorization-server")
+        if not resp.ok:
+            return None
+        self._token_source = ClientCredentials(client_id=client_id,
+                                               client_secret=client_secret,
+                                               token_url=resp.json()["token_endpoint"],
+                                               scopes=SCOPES,
+                                               use_header=True)
+
+    def auth_type(self) -> str:
+        return "oauth"
+    
+    def as_dict(self) -> dict:
+        if self._token_source:
+            return {'token': self._token_source.token().as_dict()}
+        else:
+            return {'token': {}}
+    
+    @staticmethod
+    def from_dict(host: str, client_id: str, client_secret: str, raw: dict) -> CredentialsProvider:
+        c = m2m_auth(host=host, client_id=client_id, client_secret=client_secret)
+        c._token_source._token = Token.from_dict(raw["token"])
+        return c
+
+    
+    def __call__(self, *args, **kwargs) -> HeaderFactory:
+
+        def inner() -> Dict[str, str]:
+            token = self._token_source.token()
+            return {'Authorization': f'{token.token_type} {token.access_token}'}
+
+        return inner

--- a/dbt/adapters/databricks/auth.py
+++ b/dbt/adapters/databricks/auth.py
@@ -1,62 +1,9 @@
+
 from typing import Dict
-from databricks.sdk.oauth import OAuthClient, ClientCredentials, Token, RefreshableCredentials
+from databricks.sdk.oauth import ClientCredentials, Token
 from databricks.sdk.core import CredentialsProvider, HeaderFactory
 
 import requests
-
-REDIRECT_URL = "http://localhost:8050"
-CLIENT_ID = "dbt-databricks"
-SCOPES = ["all-apis", "offline_access"]
-
-
-def authenticate(creds) -> CredentialsProvider:
-    if creds.token:
-        return token_auth(creds.token)
-
-    if creds.client_id and creds.client_secret:
-        return m2m_auth(creds.host, creds.client_id, creds.client_secret)
-
-    if (creds.client_id and not creds.client_secret) or (
-        not creds.client_id and creds.client_secret
-    ):
-        raise "missing credentials"
-
-    oauth_client = OAuthClient(
-        host=creds.host,
-        client_id=CLIENT_ID,
-        client_secret=None,
-        redirect_url=REDIRECT_URL,
-        scopes=SCOPES,
-    )
-
-    consent = oauth_client.initiate_consent()
-
-    return consent.launch_external_browser()
-
-
-def from_dict(creds, raw) -> CredentialsProvider:
-    if creds.token:
-        return token_auth.from_dict(raw)
-
-    if creds.client_id and creds.client_secret:
-        return m2m_auth.from_dict(
-            host=creds.host, client_id=creds.client_id, client_secret=creds.client_secret, raw=raw
-        )
-
-    if (creds.client_id and not creds.client_secret) or (
-        not creds.client_id and creds.client_secret
-    ):
-        raise "missing credentials"
-
-    oauth_client = OAuthClient(
-        host=creds.host,
-        client_id=CLIENT_ID,
-        client_secret=None,
-        redirect_url=REDIRECT_URL,
-        scopes=SCOPES,
-    )
-
-    return RefreshableCredentials.from_dict(client=oauth_client, raw=raw)
 
 
 class token_auth(CredentialsProvider):

--- a/dbt/adapters/databricks/connections.py
+++ b/dbt/adapters/databricks/connections.py
@@ -566,7 +566,6 @@ class DatabricksConnectionManager(SparkConnectionManager):
             cls.credentials_provider = authenticate(creds)
         creds._credentials_provider = cls.credentials_provider.as_dict()
 
-
         user_agent_entry = f"dbt-databricks/{__version__}"
 
         invocation_env = creds.get_invocation_env()

--- a/dbt/adapters/databricks/connections.py
+++ b/dbt/adapters/databricks/connections.py
@@ -563,8 +563,8 @@ class DatabricksConnectionManager(SparkConnectionManager):
         creds.validate_creds()
         # gotta keep this so we don't prompt users many times
         if not cls.credentials_provider:
-            cls.provider = authenticate(creds)
-            creds._credentials_provider = cls.provider.as_dict()
+            cls.credentials_provider = authenticate(creds)
+        creds._credentials_provider = cls.credentials_provider.as_dict()
 
 
         user_agent_entry = f"dbt-databricks/{__version__}"

--- a/dbt/adapters/databricks/connections.py
+++ b/dbt/adapters/databricks/connections.py
@@ -83,7 +83,7 @@ class DatabricksCredentials(Credentials):
     connect_timeout: Optional[int] = None
     retry_all: bool = False
 
-    _credentials_provider: Optional[dict] = None
+    _credentials_provider: Optional[Dict[str, Any]] = None
     _lock = threading.Lock()  # to avoid concurrent auth
 
     _ALIASES = {

--- a/dbt/adapters/databricks/connections.py
+++ b/dbt/adapters/databricks/connections.py
@@ -80,6 +80,7 @@ class DatabricksCredentials(Credentials):
     client_secret: Optional[str] = None
     session_properties: Optional[Dict[str, Any]] = None
     connection_parameters: Optional[Dict[str, Any]] = None
+    auth_type: Optional[str] = None
 
     connect_retries: int = 1
     connect_timeout: Optional[int] = None
@@ -161,6 +162,13 @@ class DatabricksCredentials(Credentials):
                 raise dbt.exceptions.DbtProfileError(
                     "The config '{}' is required to connect to Databricks".format(key)
                 )
+        if not self.token and self.auth_type != "oauth":
+            raise dbt.exceptions.DbtProfileError(
+                (
+                    "The config `auth_type: oauth` is required when not using access token"
+                )
+            )
+
         if not self.client_id and self.client_secret:
             raise dbt.exceptions.DbtProfileError(
                 (

--- a/dbt/adapters/databricks/connections.py
+++ b/dbt/adapters/databricks/connections.py
@@ -161,11 +161,17 @@ class DatabricksCredentials(Credentials):
                 )
         if self.client_id and not self.client_secret:
             raise dbt.exceptions.DbtProfileError(
-                "The config 'client_secret' is required to connect to Databricks when 'client_id' is present"
+                (
+                    "The config 'client_secret' is required to connect "
+                    "to Databricks when 'client_id' is present"
+                )
             )
         if not self.client_id and self.client_secret:
             raise dbt.exceptions.DbtProfileError(
-                "The config 'client_id' is required to connect to Databricks when 'client_secret' is present"
+                (
+                    "The config 'client_id' is required to connect "
+                    "to Databricks when 'client_secret' is present"
+                )
             )
 
     @classmethod
@@ -270,7 +276,11 @@ class DatabricksCredentials(Credentials):
                 return token_auth(self.token)
 
             if self.client_id and self.client_secret:
-                return m2m_auth(self.host, self.client_id, self.client_secret)
+                return m2m_auth(
+                    host=self.host,
+                    client_id=self.client_id,
+                    client_secret=self.client_secret,
+                )
 
             if (self.client_id and not self.client_secret) or (
                 not self.client_id and self.client_secret

--- a/dbt/adapters/databricks/connections.py
+++ b/dbt/adapters/databricks/connections.py
@@ -164,9 +164,7 @@ class DatabricksCredentials(Credentials):
                 )
         if not self.token and self.auth_type != "oauth":
             raise dbt.exceptions.DbtProfileError(
-                (
-                    "The config `auth_type: oauth` is required when not using access token"
-                )
+                ("The config `auth_type: oauth` is required when not using access token")
             )
 
         if not self.client_id and self.client_secret:

--- a/dbt/adapters/databricks/connections.py
+++ b/dbt/adapters/databricks/connections.py
@@ -62,11 +62,11 @@ DBT_DATABRICKS_INVOCATION_ENV = "DBT_DATABRICKS_INVOCATION_ENV"
 DBT_DATABRICKS_INVOCATION_ENV_REGEX = re.compile("^[A-z0-9\\-]+$")
 EXTRACT_CLUSTER_ID_FROM_HTTP_PATH_REGEX = re.compile(r"/?sql/protocolv1/o/\d+/(.*)")
 DBT_DATABRICKS_HTTP_SESSION_HEADERS = "DBT_DATABRICKS_HTTP_SESSION_HEADERS"
-# CLIENT_ID = "databricks-cli"
 
 REDIRECT_URL = "http://localhost:8020"
 CLIENT_ID = "dbt-databricks"
 SCOPES = ["all-apis", "offline_access"]
+
 
 @dataclass
 class DatabricksCredentials(Credentials):
@@ -84,7 +84,7 @@ class DatabricksCredentials(Credentials):
     retry_all: bool = False
 
     _credentials_provider: dict = None
-    _lock = threading.Lock() # to avoid concurrent auth
+    _lock = threading.Lock()  # to avoid concurrent auth
 
     _ALIASES = {
         "catalog": "database",
@@ -159,11 +159,11 @@ class DatabricksCredentials(Credentials):
                 raise dbt.exceptions.DbtProfileError(
                     "The config '{}' is required to connect to Databricks".format(key)
                 )
-        if (self.client_id and not self.client_secret):
+        if self.client_id and not self.client_secret:
             raise dbt.exceptions.DbtProfileError(
                 "The config 'client_secret' is required to connect to Databricks when 'client_id' is present"
             )
-        if (not self.client_id and self.client_secret):
+        if not self.client_id and self.client_secret:
             raise dbt.exceptions.DbtProfileError(
                 "The config 'client_id' is required to connect to Databricks when 'client_secret' is present"
             )
@@ -287,13 +287,12 @@ class DatabricksCredentials(Credentials):
 
             consent = oauth_client.initiate_consent()
 
-            provider = consent.launch_external_browser() 
+            provider = consent.launch_external_browser()
             self._credentials_provider = provider.as_dict()
             return provider
 
         finally:
             self._lock.release()
-
 
     def _provider_from_dict(self) -> CredentialsProvider:
         if self.token:
@@ -301,7 +300,10 @@ class DatabricksCredentials(Credentials):
 
         if self.client_id and self.client_secret:
             return m2m_auth.from_dict(
-                host=self.host, client_id=self.client_id, client_secret=self.client_secret, raw=self._credentials_provider
+                host=self.host,
+                client_id=self.client_id,
+                client_secret=self.client_secret,
+                raw=self._credentials_provider,
             )
 
         if (self.client_id and not self.client_secret) or (
@@ -639,7 +641,6 @@ class DatabricksConnectionManager(SparkConnectionManager):
 
         # gotta keep this so we don't prompt users many times
         cls.credentials_provider = creds.authenticate(cls.credentials_provider)
-
 
         user_agent_entry = f"dbt-databricks/{__version__}"
 

--- a/dbt/adapters/databricks/python_submissions.py
+++ b/dbt/adapters/databricks/python_submissions.py
@@ -381,6 +381,7 @@ class AllPurposeClusterPythonJobHelper(BaseDatabricksHelper):
 
 from databricks.sdk.core import CredentialsProvider
 
+
 class DbtDatabricksBasePythonJobHelper(BaseDatabricksHelper):
     credentials: DatabricksCredentials  # type: ignore[assignment]
     _credentials_provider: CredentialsProvider = None

--- a/dbt/adapters/databricks/python_submissions.py
+++ b/dbt/adapters/databricks/python_submissions.py
@@ -402,7 +402,7 @@ class DbtDatabricksBasePythonJobHelper(BaseDatabricksHelper):
             connection_parameters.pop("http_headers", {})
         )
         provider = from_dict(credentials, credentials._credentials_provider)
-        header_factory= provider()
+        header_factory = provider()
         headers = header_factory()
 
         self.auth_header.update({"User-Agent": user_agent, **http_headers, **headers})

--- a/dbt/adapters/databricks/python_submissions.py
+++ b/dbt/adapters/databricks/python_submissions.py
@@ -2,6 +2,7 @@ from typing import Any, Dict, Tuple, Optional, Callable
 
 from dbt.adapters.databricks.__version__ import version
 from dbt.adapters.databricks.connections import DatabricksCredentials
+from dbt.adapters.databricks.auth import from_dict
 
 import base64
 import time
@@ -400,8 +401,11 @@ class DbtDatabricksBasePythonJobHelper(BaseDatabricksHelper):
         http_headers: Dict[str, str] = credentials.get_all_http_headers(
             connection_parameters.pop("http_headers", {})
         )
+        provider = from_dict(credentials, credentials._credentials_provider)
+        header_factory= provider()
+        headers = header_factory()
 
-        self.auth_header.update({"User-Agent": user_agent, **http_headers})
+        self.auth_header.update({"User-Agent": user_agent, **http_headers, **headers})
 
     @property
     def cluster_id(self) -> Optional[str]:  # type: ignore[override]

--- a/dbt/adapters/databricks/python_submissions.py
+++ b/dbt/adapters/databricks/python_submissions.py
@@ -12,6 +12,7 @@ from dbt.events import AdapterLogger
 import dbt.exceptions
 from dbt.adapters.base import PythonJobHelper
 from dbt.adapters.spark import __version__
+from databricks.sdk.core import CredentialsProvider
 
 logger = AdapterLogger("Databricks")
 
@@ -377,9 +378,6 @@ class AllPurposeClusterPythonJobHelper(BaseDatabricksHelper):
                     )
             finally:
                 context.destroy(context_id)
-
-
-from databricks.sdk.core import CredentialsProvider
 
 
 class DbtDatabricksBasePythonJobHelper(BaseDatabricksHelper):

--- a/dbt/include/databricks/profile_template.yml
+++ b/dbt/include/databricks/profile_template.yml
@@ -5,9 +5,11 @@ prompts:
     hint: yourorg.databricks.com
   http_path:
     hint: 'HTTP Path'
-  token:
-    hint: 'dapiXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
-    hide_input: true
+  _choose_access_token:
+    'use access token':
+      token:
+        hint: 'dapiXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
+        hide_input: true
   _choose_unity_catalog:
     'use Unity Catalog':
       catalog:

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -23,5 +23,5 @@ tox>=3.2.0
 types-requests
 
 dbt-spark==1.4.*
-dbt-core==1.4.*
-dbt-tests-adapter==1.4.*
+# dbt-core==1.4.*
+dbt-tests-adapter>=1.4.0

--- a/docs/oauth.md
+++ b/docs/oauth.md
@@ -1,0 +1,26 @@
+# Configure OAuth for DBT Databricks
+
+This feature is in [Public Preview](https://docs.databricks.com/release-notes/release-types.html).
+
+Databricks DBT adapter now supports authentication via OAuth in AWS and Azure. This is a much safer method as it enables you to generate short-lived (one hour) OAuth access tokens, which eliminates the risk of accidentally exposing longer-lived tokens such as Databricks personal access tokens through version control checkins or other means. OAuth also enables better server-side session invalidation and scoping.
+
+Once an admin correctly configured OAuth in Databricks, you can simply add the config `auth_type` and set it to `oauth`. Config `token` is no longer necessary. 
+
+For Azure, you admin needs to create a Public AD application for dbt and provide you with its client_id.
+
+``` YAML
+jaffle_shop:
+  outputs:
+    dev:
+      host: <databricks host name>
+      http_path: <http path for warehouse or cluster>
+      catalog: <UC catalog name>
+      schema: <schema name>
+      auth_type: oauth  # new
+      client_id: <azure application ID> # only necessary for Azure
+      type: databricks
+  target: dev
+```
+
+
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 databricks-sql-connector>=2.5.0
 dbt-spark==1.4.*
 databricks-sdk
+keyring==23.13.*

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 databricks-sql-connector>=2.5.0
 dbt-spark>=1.4.0
-databricks-sdk>=0.1.0
+databricks-sdk>=0.1.1
 keyring>=23.13.*

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 databricks-sql-connector>=2.5.0
 dbt-spark==1.4.*
+databricks-sdk

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 databricks-sql-connector>=2.5.0
-dbt-spark==1.4.*
-databricks-sdk
-keyring==23.13.*
+dbt-spark>=1.4.0
+databricks-sdk>=0.1.0
+keyring>=23.13.*

--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,7 @@ setup(
     install_requires=[
         "dbt-spark~={}".format(dbt_spark_version),
         "databricks-sql-connector>=2.5.0",
+        "databricks-sdk",
     ],
     zip_safe=False,
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
     install_requires=[
         "dbt-spark~={}".format(dbt_spark_version),
         "databricks-sql-connector>=2.5.0",
-        "databricks-sdk",
+        "databricks-sdk>=0.1.0",
         "keyring>=23.13.0"
     ],
     zip_safe=False,

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
     install_requires=[
         "dbt-spark~={}".format(dbt_spark_version),
         "databricks-sql-connector>=2.5.0",
-        "databricks-sdk>=0.1.0",
+        "databricks-sdk>=0.1.1",
         "keyring>=23.13.0"
     ],
     zip_safe=False,

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,7 @@ setup(
         "dbt-spark~={}".format(dbt_spark_version),
         "databricks-sql-connector>=2.5.0",
         "databricks-sdk",
+        "keyring>=23.13.0"
     ],
     zip_safe=False,
     classifiers=[

--- a/tests/profiles.py
+++ b/tests/profiles.py
@@ -25,6 +25,8 @@ def _build_databricks_cluster_target(
         "host": os.getenv("DBT_DATABRICKS_HOST_NAME"),
         "http_path": http_path,
         "token": os.getenv("DBT_DATABRICKS_TOKEN"),
+        "client_id": os.getenv("DBT_DATABRICKS_CLIENT_ID"),
+        "client_secret": os.getenv("DBT_DATABRICKS_CLIENT_SECRET"),
         "connect_retries": 3,
         "connect_timeout": 5,
         "retry_all": True,

--- a/tests/profiles.py
+++ b/tests/profiles.py
@@ -30,6 +30,7 @@ def _build_databricks_cluster_target(
         "connect_retries": 3,
         "connect_timeout": 5,
         "retry_all": True,
+        "auth_type": "oauth",
     }
     if catalog is not None:
         profile["catalog"] = catalog

--- a/tests/unit/test_adapter.py
+++ b/tests/unit/test_adapter.py
@@ -348,7 +348,9 @@ class TestDatabricksAdapter(unittest.TestCase):
             self.assertEqual(server_hostname, "yourorg.databricks.com")
             self.assertEqual(http_path, "sql/protocolv1/o/1234567890123456/1234-567890-test123")
             if not (expected_no_token or expected_client_creds):
-                self.assertEqual(credentials_provider._token, "dapiXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX")
+                self.assertEqual(
+                    credentials_provider._token, "dapiXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+                )
             if expected_client_creds:
                 self.assertEqual(kwargs.get("client_id"), "foo")
                 self.assertEqual(kwargs.get("client_secret"), "bar")

--- a/tests/unit/test_adapter.py
+++ b/tests/unit/test_adapter.py
@@ -66,7 +66,7 @@ class TestDatabricksAdapter(unittest.TestCase):
                 "target": "test",
             },
         )
-    
+
     def _get_target_databricks_sql_connector_client_creds(self, project):
         return config_from_parts_or_dicts(
             project,
@@ -326,12 +326,11 @@ class TestDatabricksAdapter(unittest.TestCase):
             connection = adapter.acquire_connection("dummy")
             connection.handle  # trigger lazy-load
 
-
     def _connect_func(
-        self, 
-        *, 
-        expected_catalog=None, 
-        expected_invocation_env=None, 
+        self,
+        *,
+        expected_catalog=None,
+        expected_invocation_env=None,
         expected_http_headers=None,
         expected_no_token=None,
         expected_client_creds=None,

--- a/tests/unit/test_adapter.py
+++ b/tests/unit/test_adapter.py
@@ -338,7 +338,7 @@ class TestDatabricksAdapter(unittest.TestCase):
         def connect(
             server_hostname,
             http_path,
-            access_token,
+            credentials_provider,
             http_headers,
             session_configuration,
             catalog,
@@ -348,7 +348,7 @@ class TestDatabricksAdapter(unittest.TestCase):
             self.assertEqual(server_hostname, "yourorg.databricks.com")
             self.assertEqual(http_path, "sql/protocolv1/o/1234567890123456/1234-567890-test123")
             if not (expected_no_token or expected_client_creds):
-                self.assertEqual(access_token, "dapiXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX")
+                self.assertEqual(credentials_provider._token, "dapiXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX")
             if expected_client_creds:
                 self.assertEqual(kwargs.get("client_id"), "foo")
                 self.assertEqual(kwargs.get("client_secret"), "bar")

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -1,22 +1,21 @@
 import unittest
-import os
-from dbt.adapters.databricks.auth import authenticate, from_dict
 from dbt.adapters.databricks.connections import DatabricksCredentials
+import pytest
 
 
+@pytest.mark.skip(reason="Need to mock requests to OIDC")
 class TestM2MAuth(unittest.TestCase):
     def test_m2m(self):
-        host = os.getenv("DBT_DATABRICKS_HOST_NAME")
-        client_id = os.getenv("DBT_DATABRICKS_CLIENT_ID")
-        client_secret = os.getenv("DBT_DATABRICKS_CLIENT_SECRET")
+        host = "my.cloud.databricks.com"
         creds = DatabricksCredentials(
             host=host,
-            client_id=client_id,
-            client_secret=client_secret,
+            http_path="http://foo",
+            client_id="my-client-id",
+            client_secret="my-client-secret",
             database="andre",
             schema="dbt",
         )
-        provider = authenticate(creds)
+        provider = creds.authenticate(None)
         self.assertIsNotNone(provider)
         headers_fn = provider()
         headers = headers_fn()
@@ -25,17 +24,20 @@ class TestM2MAuth(unittest.TestCase):
         raw = provider.as_dict()
         self.assertIsNotNone(raw)
 
-        provider_b = from_dict(creds, raw)
+        provider_b = creds._provider_from_dict()
         headers_fn2 = provider_b()
         headers2 = headers_fn2()
         self.assertEqual(headers, headers2)
 
 
+@pytest.mark.skip(reason="Need to mock requests to OIDC and mock opening browser")
 class TestU2MAuth(unittest.TestCase):
     def test_u2m(self):
-        host = "e2-dogfood.staging.cloud.databricks.com"
-        creds = DatabricksCredentials(host=host, database="andre", schema="dbt")
-        provider = authenticate(creds)
+        host = "my.cloud.databricks.com"
+        creds = DatabricksCredentials(
+            host=host, database="andre", http_path="http://foo", schema="dbt"
+        )
+        provider = creds.authenticate(None)
         self.assertIsNotNone(provider)
         headers_fn = provider()
         headers = headers_fn()
@@ -44,17 +46,19 @@ class TestU2MAuth(unittest.TestCase):
         raw = provider.as_dict()
         self.assertIsNotNone(raw)
 
-        provider_b = from_dict(creds, raw)
+        provider_b = creds._provider_from_dict()
         headers_fn2 = provider_b()
         headers2 = headers_fn2()
         self.assertEqual(headers, headers2)
 
 
 class TestTokenAuth(unittest.TestCase):
-    def test_u2m(self):
-        host = "e2-dogfood.staging.cloud.databricks.com"
-        creds = DatabricksCredentials(host=host, token="foo", database="andre", schema="dbt")
-        provider = authenticate(creds)
+    def test_token(self):
+        host = "my.cloud.databricks.com"
+        creds = DatabricksCredentials(
+            host=host, token="foo", database="andre", http_path="http://foo", schema="dbt"
+        )
+        provider = creds.authenticate(None)
         self.assertIsNotNone(provider)
         headers_fn = provider()
         headers = headers_fn()
@@ -63,7 +67,7 @@ class TestTokenAuth(unittest.TestCase):
         raw = provider.as_dict()
         self.assertIsNotNone(raw)
 
-        provider_b = from_dict(creds, raw)
+        provider_b = creds._provider_from_dict()
         headers_fn2 = provider_b()
         headers2 = headers_fn2()
         self.assertEqual(headers, headers2)

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -6,10 +6,16 @@ from dbt.adapters.databricks.connections import DatabricksCredentials
 
 class TestM2MAuth(unittest.TestCase):
     def test_m2m(self):
-        host =os.getenv("DBT_DATABRICKS_HOST_NAME")
-        client_id =os.getenv("DBT_DATABRICKS_CLIENT_ID")
-        client_secret =os.getenv("DBT_DATABRICKS_CLIENT_SECRET")
-        creds = DatabricksCredentials(host=host, client_id=client_id, client_secret=client_secret, database="andre", schema="dbt")
+        host = os.getenv("DBT_DATABRICKS_HOST_NAME")
+        client_id = os.getenv("DBT_DATABRICKS_CLIENT_ID")
+        client_secret = os.getenv("DBT_DATABRICKS_CLIENT_SECRET")
+        creds = DatabricksCredentials(
+            host=host,
+            client_id=client_id,
+            client_secret=client_secret,
+            database="andre",
+            schema="dbt",
+        )
         provider = authenticate(creds)
         self.assertIsNotNone(provider)
         headers_fn = provider()

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -1,0 +1,63 @@
+import unittest
+import os
+from dbt.adapters.databricks.auth import authenticate, from_dict
+from dbt.adapters.databricks.connections import DatabricksCredentials
+
+
+class TestM2MAuth(unittest.TestCase):
+    def test_m2m(self):
+        host =os.getenv("DBT_DATABRICKS_HOST_NAME")
+        client_id =os.getenv("DBT_DATABRICKS_CLIENT_ID")
+        client_secret =os.getenv("DBT_DATABRICKS_CLIENT_SECRET")
+        creds = DatabricksCredentials(host=host, client_id=client_id, client_secret=client_secret, database="andre", schema="dbt")
+        provider = authenticate(creds)
+        self.assertIsNotNone(provider)
+        headers_fn = provider()
+        headers = headers_fn()
+        self.assertIsNotNone(headers)
+
+        raw = provider.as_dict()
+        self.assertIsNotNone(raw)
+
+        provider_b = from_dict(creds, raw)
+        headers_fn2 = provider_b()
+        headers2 = headers_fn2()
+        self.assertEqual(headers, headers2)
+
+
+class TestU2MAuth(unittest.TestCase):
+    def test_u2m(self):
+        host = "e2-dogfood.staging.cloud.databricks.com"
+        creds = DatabricksCredentials(host=host, database="andre", schema="dbt")
+        provider = authenticate(creds)
+        self.assertIsNotNone(provider)
+        headers_fn = provider()
+        headers = headers_fn()
+        self.assertIsNotNone(headers)
+
+        raw = provider.as_dict()
+        self.assertIsNotNone(raw)
+
+        provider_b = from_dict(creds, raw)
+        headers_fn2 = provider_b()
+        headers2 = headers_fn2()
+        self.assertEqual(headers, headers2)
+
+
+class TestTokenAuth(unittest.TestCase):
+    def test_u2m(self):
+        host = "e2-dogfood.staging.cloud.databricks.com"
+        creds = DatabricksCredentials(host=host, token="foo", database="andre", schema="dbt")
+        provider = authenticate(creds)
+        self.assertIsNotNone(provider)
+        headers_fn = provider()
+        headers = headers_fn()
+        self.assertIsNotNone(headers)
+
+        raw = provider.as_dict()
+        self.assertIsNotNone(raw)
+
+        provider_b = from_dict(creds, raw)
+        headers_fn2 = provider_b()
+        headers2 = headers_fn2()
+        self.assertEqual(headers, headers2)


### PR DESCRIPTION
### Description
This PR adds support for OAuth: both 3-legged and 2-legged.

From a user perspective, `token` is not mandatory anymore. By default, OAuth with SSO (browser login) will be used.

For automation and CI/CD use cases, `client_id` and `client_secret` are now available as config.

### Usage
#### AWS
It just works as long as admin has enabled `dbt-databricks` as an OAuth application:
```
curl -n -X POST https://accounts.cloud.databricks.com/api/2.0/accounts/<Account ID>/oauth2/published-app-integrations -d '{ "app_id" : "dbt-databricks" }'
```
Profile:
```yaml
  type: databricks
  host: "<your databricks host name>",
  http_path: "<http path for warehouse >",
```

#### Azure
A Public client/ Native Azure AD Application must be created with redirect URL `http://localhost:8020`. For SSO, Azure Application (client) ID must be used for `client_id`.
Profile:
```yaml
  type: databricks
  host: "<your databricks host name>",
  http_path: "<http path for warehouse >",
  client_id: "<Azure AD Application ID>"
```

#### GCP
GCP is not supported at the moment.

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
