### PR TITLE
Bump databricks-sql-connector to 2.5.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-databricks-sql-connector>=2.2.2
+databricks-sql-connector>=2.5.0
 dbt-spark==1.4.*

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "dbt-spark~={}".format(dbt_spark_version),
-        "databricks-sql-connector>=2.2.2",
+        "databricks-sql-connector>=2.5.0",
     ],
     zip_safe=False,
     classifiers=[


### PR DESCRIPTION
<!-- Please review our pull request review process in CONTRIBUTING.md before your proceed. -->

Resolves #111 

<!---
  Include the number of the issue addressed by this PR above if applicable.
  
  Example:
    resolves #1234

  Please review our pull request review process in CONTRIBUTING.md before your proceed.
-->

### Description

<!--- Describe the Pull Request here -->

Version 2.5.0 of databricks-sql-connector should allow dbt-databricks to run connect to Databricks through a proxy using the standard Python convention. The updated release also adds a saner retry policy when thrift commands fail because of a connection timeout.

### Checklist

- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
