### PR TITLE
Fix: parse vars in unit test utils for dbt==1.5.x

### DIFF
--- a/tests/integration/base.py
+++ b/tests/integration/base.py
@@ -13,7 +13,7 @@ import pytest
 import yaml
 from unittest.mock import patch
 
-import dbt.main as dbt
+import dbt.main as dbt  # type: ignore
 from dbt import flags
 from dbt.deprecations import reset_deprecations
 from dbt.adapters.factory import get_adapter, reset_adapters, register_adapter

--- a/tests/unit/utils.py
+++ b/tests/unit/utils.py
@@ -51,6 +51,7 @@ def profile_from_dict(profile, profile_name, cli_vars="{}"):
     # flags global. This is a bit of a hack, but it's the best way to do it.
     from dbt.flags import set_from_args
     from argparse import Namespace
+
     set_from_args(Namespace(), None)
     return Profile.from_raw_profile_info(
         profile,

--- a/tests/unit/utils.py
+++ b/tests/unit/utils.py
@@ -46,6 +46,12 @@ def profile_from_dict(profile, profile_name, cli_vars="{}"):
         cli_vars = parse_cli_vars(cli_vars)
 
     renderer = ProfileRenderer(cli_vars)
+
+    # in order to call dbt's internal profile rendering, we need to set the
+    # flags global. This is a bit of a hack, but it's the best way to do it.
+    from dbt.flags import set_from_args
+    from argparse import Namespace
+    set_from_args(Namespace(), None)
     return Profile.from_raw_profile_info(
         profile,
         profile_name,
@@ -75,7 +81,11 @@ def project_from_dict(project, profile, packages=None, selectors=None, cli_vars=
 
 def config_from_parts_or_dicts(project, profile, packages=None, selectors=None, cli_vars="{}"):
     from dbt.config import Project, Profile, RuntimeConfig
+    from dbt.config.utils import parse_cli_vars
     from copy import deepcopy
+
+    if not isinstance(cli_vars, dict):
+        cli_vars = parse_cli_vars(cli_vars)
 
     if isinstance(project, Project):
         profile_name = project.profile_name


### PR DESCRIPTION
This is a mirror of dbt-spark#632

<!-- Please review our pull request review process in CONTRIBUTING.md before your proceed. -->

Resolves #

<!---
  Include the number of the issue addressed by this PR above if applicable.
  
  Example:
    resolves #1234

  Please review our pull request review process in CONTRIBUTING.md before your proceed.
-->

### Description

<!--- Describe the Pull Request here -->

This PR applies the same fix from dbt-spark#632 to dbt-databricks so that `tox -e unit` now passes all tests.

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
