### PR TITLE
allow-table-extended-to-handle-more-than-2048-chars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## dbt-databricks 1.5.0 (Release TBD)
 
+### Fixes
+- Fix issue where the show tables extended command is limited to 2048 characters. ([#326](https://github.com/databricks/dbt-databricks/pull/326))
+
 ## dbt-databricks 1.4.2 (February 17, 2023)
 
 ### Fixes

--- a/dbt/adapters/databricks/impl.py
+++ b/dbt/adapters/databricks/impl.py
@@ -400,7 +400,7 @@ class DatabricksAdapter(SparkAdapter):
             schema_relation = self.Relation.create(
                 database=database,
                 schema=schema,
-                identifier="|".join(table_names),
+                identifier=("|".join(table_names) if len("|".join(table_names)) < 2048 else "*"),
                 quote_policy=self.config.quoting,
             )
             for relation, information in self._list_relations_with_information(schema_relation):


### PR DESCRIPTION
<!-- Please review our pull request review process in CONTRIBUTING.md before your proceed. -->

Resolves [#326](https://github.com/databricks/dbt-databricks/pull/326)

<!---
  Include the number of the issue addressed by this PR above if applicable.
  
  Example:
    resolves #1234

  Please review our pull request review process in CONTRIBUTING.md before your proceed.
-->

### Description

This PR allows the adapter to handle strings of more than 2048 characters when running show tables extended in Databricks. This is currently preventing users from being able to run this command when using dbt if they have a large number of tables in any given schema. 

The way this is done is that it will pass the `*` in instances where the string length of the pipe separated tables is more than 2048 chars.

I have successfully tested both unit tests and `tox -e integration-databricks-sql-endpoint`.

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
