### PR TITLE
[feat] OAuth support (#307)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ test.env
 *.log
 logs/
 .venv
+.venv2

--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,4 @@ test.env
 .vscode
 *.log
 logs/
-.venv
-.venv2
+.venv*

--- a/dbt/adapters/databricks/auth.py
+++ b/dbt/adapters/databricks/auth.py
@@ -1,0 +1,78 @@
+from typing import Any, Dict, Optional
+from databricks.sdk.oauth import ClientCredentials, Token, TokenSource
+from databricks.sdk.core import CredentialsProvider, HeaderFactory, Config, credentials_provider
+
+
+class token_auth(CredentialsProvider):
+    _token: str
+
+    def __init__(self, token: str) -> None:
+        self._token = token
+
+    def auth_type(self) -> str:
+        return "token"
+
+    def as_dict(self) -> dict:
+        return {"token": self._token}
+
+    @staticmethod
+    def from_dict(raw: Optional[dict]) -> CredentialsProvider:
+        if not raw:
+            return None
+        return token_auth(raw["token"])
+
+    def __call__(self, *args: tuple, **kwargs: Dict[str, Any]) -> HeaderFactory:
+        static_credentials = {"Authorization": f"Bearer {self._token}"}
+
+        def inner() -> Dict[str, str]:
+            return static_credentials
+
+        return inner
+
+
+class m2m_auth(CredentialsProvider):
+    _token_source: TokenSource = None
+
+    def __init__(self, host: str, client_id: str, client_secret: str) -> None:
+        @credentials_provider("noop", [])
+        def noop_credentials(_: Any):  # type: ignore
+            return lambda: {}
+
+        config = Config(host=host, credentials_provider=noop_credentials)
+        oidc = config.oidc_endpoints
+        scopes = ["offline_access", "all-apis"]
+        if not oidc:
+            raise ValueError(f"{host} does not support OAuth")
+        if config.is_azure:
+            # Azure AD only supports full access to Azure Databricks.
+            scopes = [f"{config.effective_azure_login_app_id}/.default", "offline_access"]
+        self._token_source = ClientCredentials(
+            client_id=client_id,
+            client_secret=client_secret,
+            token_url=oidc.token_endpoint,
+            scopes=scopes,
+            use_header="microsoft" not in oidc.token_endpoint,
+            use_params="microsoft" in oidc.token_endpoint,
+        )
+
+    def auth_type(self) -> str:
+        return "oauth"
+
+    def as_dict(self) -> dict:
+        if self._token_source:
+            return {"token": self._token_source.token().as_dict()}
+        else:
+            return {"token": {}}
+
+    @staticmethod
+    def from_dict(host: str, client_id: str, client_secret: str, raw: dict) -> CredentialsProvider:
+        c = m2m_auth(host=host, client_id=client_id, client_secret=client_secret)
+        c._token_source._token = Token.from_dict(raw["token"])
+        return c
+
+    def __call__(self, *args: tuple, **kwargs: Dict[str, Any]) -> HeaderFactory:
+        def inner() -> Dict[str, str]:
+            token = self._token_source.token()
+            return {"Authorization": f"{token.token_type} {token.access_token}"}
+
+        return inner

--- a/dbt/include/databricks/profile_template.yml
+++ b/dbt/include/databricks/profile_template.yml
@@ -5,9 +5,11 @@ prompts:
     hint: yourorg.databricks.com
   http_path:
     hint: 'HTTP Path'
-  token:
-    hint: 'dapiXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
-    hide_input: true
+  _choose_access_token:
+    'use access token':
+      token:
+        hint: 'dapiXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
+        hide_input: true
   _choose_unity_catalog:
     'use Unity Catalog':
       catalog:

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -23,5 +23,5 @@ tox>=3.2.0
 types-requests
 
 dbt-spark==1.4.*
-dbt-core==1.4.*
-dbt-tests-adapter==1.4.*
+# dbt-core==1.4.*
+dbt-tests-adapter>=1.4.0

--- a/docs/oauth.md
+++ b/docs/oauth.md
@@ -1,0 +1,26 @@
+# Configure OAuth for DBT Databricks
+
+This feature is in [Public Preview](https://docs.databricks.com/release-notes/release-types.html).
+
+Databricks DBT adapter now supports authentication via OAuth in AWS and Azure. This is a much safer method as it enables you to generate short-lived (one hour) OAuth access tokens, which eliminates the risk of accidentally exposing longer-lived tokens such as Databricks personal access tokens through version control checkins or other means. OAuth also enables better server-side session invalidation and scoping.
+
+Once an admin correctly configured OAuth in Databricks, you can simply add the config `auth_type` and set it to `oauth`. Config `token` is no longer necessary. 
+
+For Azure, you admin needs to create a Public AD application for dbt and provide you with its client_id.
+
+``` YAML
+jaffle_shop:
+  outputs:
+    dev:
+      host: <databricks host name>
+      http_path: <http path for warehouse or cluster>
+      catalog: <UC catalog name>
+      schema: <schema name>
+      auth_type: oauth  # new
+      client_id: <azure application ID> # only necessary for Azure
+      type: databricks
+  target: dev
+```
+
+
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 databricks-sql-connector>=2.5.0
-dbt-spark==1.4.*
+dbt-spark>=1.4.0
+databricks-sdk>=0.1.1
+keyring>=23.13.*

--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,8 @@ setup(
     install_requires=[
         "dbt-spark~={}".format(dbt_spark_version),
         "databricks-sql-connector>=2.5.0",
+        "databricks-sdk>=0.1.1",
+        "keyring>=23.13.0"
     ],
     zip_safe=False,
     classifiers=[

--- a/tests/profiles.py
+++ b/tests/profiles.py
@@ -25,9 +25,12 @@ def _build_databricks_cluster_target(
         "host": os.getenv("DBT_DATABRICKS_HOST_NAME"),
         "http_path": http_path,
         "token": os.getenv("DBT_DATABRICKS_TOKEN"),
+        "client_id": os.getenv("DBT_DATABRICKS_CLIENT_ID"),
+        "client_secret": os.getenv("DBT_DATABRICKS_CLIENT_SECRET"),
         "connect_retries": 3,
         "connect_timeout": 5,
         "retry_all": True,
+        "auth_type": "oauth",
     }
     if catalog is not None:
         profile["catalog"] = catalog

--- a/tests/unit/test_adapter.py
+++ b/tests/unit/test_adapter.py
@@ -50,6 +50,42 @@ class TestDatabricksAdapter(unittest.TestCase):
             },
         )
 
+    def _get_target_databricks_sql_connector_no_token(self, project):
+        return config_from_parts_or_dicts(
+            project,
+            {
+                "outputs": {
+                    "test": {
+                        "type": "databricks",
+                        "schema": "analytics",
+                        "host": "yourorg.databricks.com",
+                        "http_path": "sql/protocolv1/o/1234567890123456/1234-567890-test123",
+                        "session_properties": {"spark.sql.ansi.enabled": "true"},
+                    }
+                },
+                "target": "test",
+            },
+        )
+
+    def _get_target_databricks_sql_connector_client_creds(self, project):
+        return config_from_parts_or_dicts(
+            project,
+            {
+                "outputs": {
+                    "test": {
+                        "type": "databricks",
+                        "schema": "analytics",
+                        "host": "yourorg.databricks.com",
+                        "http_path": "sql/protocolv1/o/1234567890123456/1234-567890-test123",
+                        "client_id": "foo",
+                        "client_secret": "bar",
+                        "session_properties": {"spark.sql.ansi.enabled": "true"},
+                    }
+                },
+                "target": "test",
+            },
+        )
+
     def _get_target_databricks_sql_connector_catalog(self, project):
         return config_from_parts_or_dicts(
             project,
@@ -264,21 +300,60 @@ class TestDatabricksAdapter(unittest.TestCase):
                 connection = adapter.acquire_connection("dummy")
                 connection.handle  # trigger lazy-load
 
+    @unittest.skip("not ready")
+    def test_oauth_settings(self):
+        config = self._get_target_databricks_sql_connector_no_token(self.project_cfg)
+
+        adapter = DatabricksAdapter(config)
+
+        with mock.patch(
+            "dbt.adapters.databricks.connections.dbsql.connect",
+            new=self._connect_func(expected_no_token=True),
+        ):
+            connection = adapter.acquire_connection("dummy")
+            connection.handle  # trigger lazy-load
+
+    @unittest.skip("not ready")
+    def test_client_creds_settings(self):
+        config = self._get_target_databricks_sql_connector_client_creds(self.project_cfg)
+
+        adapter = DatabricksAdapter(config)
+
+        with mock.patch(
+            "dbt.adapters.databricks.connections.dbsql.connect",
+            new=self._connect_func(expected_client_creds=True),
+        ):
+            connection = adapter.acquire_connection("dummy")
+            connection.handle  # trigger lazy-load
+
     def _connect_func(
-        self, *, expected_catalog=None, expected_invocation_env=None, expected_http_headers=None
+        self,
+        *,
+        expected_catalog=None,
+        expected_invocation_env=None,
+        expected_http_headers=None,
+        expected_no_token=None,
+        expected_client_creds=None,
     ):
         def connect(
             server_hostname,
             http_path,
-            access_token,
+            credentials_provider,
             http_headers,
             session_configuration,
             catalog,
             _user_agent_entry,
+            **kwargs,
         ):
             self.assertEqual(server_hostname, "yourorg.databricks.com")
             self.assertEqual(http_path, "sql/protocolv1/o/1234567890123456/1234-567890-test123")
-            self.assertEqual(access_token, "dapiXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX")
+            if not (expected_no_token or expected_client_creds):
+                self.assertEqual(
+                    credentials_provider._token, "dapiXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+                )
+            if expected_client_creds:
+                self.assertEqual(kwargs.get("client_id"), "foo")
+                self.assertEqual(kwargs.get("client_secret"), "bar")
             self.assertEqual(session_configuration["spark.sql.ansi.enabled"], "true")
             if expected_catalog is None:
                 self.assertIsNone(catalog)

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -1,0 +1,73 @@
+import unittest
+from dbt.adapters.databricks.connections import DatabricksCredentials
+import pytest
+
+
+@pytest.mark.skip(reason="Need to mock requests to OIDC")
+class TestM2MAuth(unittest.TestCase):
+    def test_m2m(self):
+        host = "my.cloud.databricks.com"
+        creds = DatabricksCredentials(
+            host=host,
+            http_path="http://foo",
+            client_id="my-client-id",
+            client_secret="my-client-secret",
+            database="andre",
+            schema="dbt",
+        )
+        provider = creds.authenticate(None)
+        self.assertIsNotNone(provider)
+        headers_fn = provider()
+        headers = headers_fn()
+        self.assertIsNotNone(headers)
+
+        raw = provider.as_dict()
+        self.assertIsNotNone(raw)
+
+        provider_b = creds._provider_from_dict()
+        headers_fn2 = provider_b()
+        headers2 = headers_fn2()
+        self.assertEqual(headers, headers2)
+
+
+@pytest.mark.skip(reason="Need to mock requests to OIDC and mock opening browser")
+class TestU2MAuth(unittest.TestCase):
+    def test_u2m(self):
+        host = "my.cloud.databricks.com"
+        creds = DatabricksCredentials(
+            host=host, database="andre", http_path="http://foo", schema="dbt"
+        )
+        provider = creds.authenticate(None)
+        self.assertIsNotNone(provider)
+        headers_fn = provider()
+        headers = headers_fn()
+        self.assertIsNotNone(headers)
+
+        raw = provider.as_dict()
+        self.assertIsNotNone(raw)
+
+        provider_b = creds._provider_from_dict()
+        headers_fn2 = provider_b()
+        headers2 = headers_fn2()
+        self.assertEqual(headers, headers2)
+
+
+class TestTokenAuth(unittest.TestCase):
+    def test_token(self):
+        host = "my.cloud.databricks.com"
+        creds = DatabricksCredentials(
+            host=host, token="foo", database="andre", http_path="http://foo", schema="dbt"
+        )
+        provider = creds.authenticate(None)
+        self.assertIsNotNone(provider)
+        headers_fn = provider()
+        headers = headers_fn()
+        self.assertIsNotNone(headers)
+
+        raw = provider.as_dict()
+        self.assertIsNotNone(raw)
+
+        provider_b = creds._provider_from_dict()
+        headers_fn2 = provider_b()
+        headers2 = headers_fn2()
+        self.assertEqual(headers, headers2)


### PR DESCRIPTION
### Description
This PR adds support for OAuth: both 3-legged and 2-legged.

From a user perspective, `token` is not mandatory anymore. OAuth with SSO (browser login) will be used if `auth_type: oauth` is defined.

For automation and CI/CD use cases, `client_id` and `client_secret` are now available as config.

### Usage
#### AWS
It just works as long as admin has enabled `dbt-databricks` as an OAuth application:
```
curl -n -X POST https://accounts.cloud.databricks.com/api/2.0/accounts/<Account ID>/oauth2/published-app-integrations -d '{ "app_id" : "dbt-databricks" }'
```
Profile:
```yaml
  type: databricks
  host: "<your databricks host name>"
  http_path: "<http path for warehouse >"
  auth_type: "oauth"
```

#### Azure
A Public client/ Native Azure AD Application must be created with redirect URL `http://localhost:8020`. For SSO, Azure Application (client) ID must be used for `client_id`.
Profile:
```yaml
  type: databricks
  host: "<your databricks host name>"
  http_path: "<http path for warehouse >"
  client_id: "<Azure AD Application ID>"
  auth_type: "oauth"
```

#### GCP
GCP is not supported at the moment.

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
