### PR TITLE
Disable integration test

### DIFF
--- a/tests/integration/model_contract/test_model_contract.py
+++ b/tests/integration/model_contract/test_model_contract.py
@@ -1,4 +1,5 @@
 import os
+import pytest
 from tests.integration.base import DBTIntegrationTest, use_profile
 from typing import Dict
 from dbt.contracts.results import RunResult, RunStatus
@@ -272,6 +273,7 @@ class TestModelLevelForeignKey(TestModelContract):
         self.test_table_constraints()
 
 
+@pytest.mark.skip(reason="test needs redesign")
 class TestModelContractNotDelta(TestModelContract):
     def test_table_constraints(self):
         self.run_dbt(["seed"])


### PR DESCRIPTION
Disable TestModelContractNotDelta until it can be redesigned


- [X] I have run this code in development and it appears to resolve the stated issue
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.

Signed-off-by: Raymond Cypher <raymond.cypher@databricks.com>