### PR TITLE
feat: bump databricks-sdk v0.1.7 and rename RefreshableCredentials to SessionCredentials

### DIFF
--- a/dbt/adapters/databricks/connections.py
+++ b/dbt/adapters/databricks/connections.py
@@ -51,7 +51,7 @@ from dbt.adapters.databricks.__version__ import version as __version__
 from dbt.adapters.databricks.utils import redact_credentials
 
 from databricks.sdk.core import CredentialsProvider
-from databricks.sdk.oauth import OAuthClient, RefreshableCredentials
+from databricks.sdk.oauth import OAuthClient, SessionCredentials
 from dbt.adapters.databricks.auth import token_auth, m2m_auth
 
 import keyring
@@ -302,7 +302,7 @@ class DatabricksCredentials(Credentials):
                 credsdict = keyring.get_password("dbt-databricks", host)
 
                 if credsdict:
-                    provider = RefreshableCredentials.from_dict(oauth_client, json.loads(credsdict))
+                    provider = SessionCredentials.from_dict(oauth_client, json.loads(credsdict))
                     # if refresh token is expired, this will throw
                     try:
                         if provider.token().valid:
@@ -355,7 +355,7 @@ class DatabricksCredentials(Credentials):
             scopes=SCOPES,
         )
 
-        return RefreshableCredentials.from_dict(client=oauth_client, raw=self._credentials_provider)
+        return SessionCredentials.from_dict(client=oauth_client, raw=self._credentials_provider)
 
 
 class DatabricksSQLConnectionWrapper:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 databricks-sql-connector>=2.5.0
 dbt-spark>=1.5.0
-databricks-sdk>=0.1.1
+databricks-sdk>=0.1.7
 keyring>=23.13.0

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(
     install_requires=[
         "dbt-spark>=1.5.0",
         "databricks-sql-connector>=2.5.0",
-        "databricks-sdk>=0.1.1",
+        "databricks-sdk>=0.1.7",
         "keyring>=23.13.0",
     ],
     zip_safe=False,


### PR DESCRIPTION
<!-- Please review our pull request review process in CONTRIBUTING.md before your proceed. -->

This resolves this issue I raised recently https://github.com/databricks/dbt-databricks/issues/348

Root cause is due to the renaming done in this PR: https://github.com/databricks/databricks-sdk-py/pull/116

These types of breaking changes are normal and part of life. Would like to see this get pushed through ASAP though.


### Description
* Bump to the `databricks-sdk` to use the latest version. 
* Rename the `RefreshableCredentials` references to `SessionCredentials`

It would be failing for anyone trying to connect to databricks using `dbt-core` and the `dbt-databricks` adapter if I'm not mistaken.

### Checklist

- [ ] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
