### PR TITLE
Bump pysql to 2.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 
-## dbt-databricks 1.5.2 TBD
+## dbt-databricks 1.5.3 TBD
+
+## dbt-databricks 1.5.2 (June 7, 2023)
 
 ### Features
 - Added support for model contracts ([#336](https://github.com/databricks/dbt-databricks/pull/336))
+- Bump databricks-sql-connector version to 2.6.0 to add HTTP 1.1 support and a default socket timeout.
 
 ## dbt-databricks 1.5.1 (May 9, 2023)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-databricks-sql-connector>=2.6.0
+databricks-sql-connector==2.6.1.dev1
 dbt-spark>=1.5.0
 databricks-sdk>=0.1.7
 keyring>=23.13.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-databricks-sql-connector>=2.5.0
+databricks-sql-connector>=2.6.0
 dbt-spark>=1.5.0
 databricks-sdk>=0.1.7
 keyring>=23.13.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-databricks-sql-connector==2.6.1.dev1
+databricks-sql-connector~=2.6.1
 dbt-spark>=1.5.0
 databricks-sdk>=0.1.7
 keyring>=23.13.0

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "dbt-spark>=1.5.0",
-        "databricks-sql-connector>=2.5.0",
+        "databricks-sql-connector>=2.6.0",
         "databricks-sdk>=0.1.7",
         "keyring>=23.13.0",
     ],

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "dbt-spark>=1.5.0",
-        "databricks-sql-connector>=2.6.0",
+        "databricks-sql-connector==2.6.1.dev1",
         "databricks-sdk>=0.1.7",
         "keyring>=23.13.0",
     ],

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "dbt-spark>=1.5.0",
-        "databricks-sql-connector==2.6.1.dev1",
+        "databricks-sql-connector~=2.6.1",
         "databricks-sdk>=0.1.7",
         "keyring>=23.13.0",
     ],


### PR DESCRIPTION
### Description

Bumping `databricks-sql-connector` to version 2.6.1 will grant performance improvements due to adding support for HTTP 1.1 (keep alive) connections. Also will boost stability by adding a default socket timeout for all thrift rpcs which will benefit dbt cloud users.

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
