### PR TITLE
Add option to install Python packages on Databricks clusters from a c…

### DIFF
--- a/dbt/adapters/databricks/python_submissions.py
+++ b/dbt/adapters/databricks/python_submissions.py
@@ -92,11 +92,13 @@ class BaseDatabricksHelper(PythonJobHelper):
         job_spec.update(cluster_spec)  # updates 'new_cluster' config
         # PYPI packages
         packages = self.parsed_model["config"].get("packages", [])
+        # custom index URL or default
+        index_url = self.parsed_model["config"].get("index_url", "https://pypi.org/simple")
         # additional format of packages
         additional_libs = self.parsed_model["config"].get("additional_libs", [])
         libraries = []
         for package in packages:
-            libraries.append({"pypi": {"package": package}})
+            libraries.append({"pypi": {"package": package}, "repo": index_url})
         for lib in additional_libs:
             libraries.append(lib)
         job_spec.update({"libraries": libraries})  # type: ignore


### PR DESCRIPTION
Resolves #362 

### Description
Added the option to provide a custom index_url from which to install Python libraries on the Databricks cluster. This enables developers at enterprise organizations that are required to install libraries from their own index to provide this URL. Also, it's must easier to implement shared logic over different Python models when the need arises (if SQL really is no option).

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
