### PR TITLE
Install Python libraries from a custom index

### DIFF
--- a/dbt/adapters/databricks/auth.py
+++ b/dbt/adapters/databricks/auth.py
@@ -1,6 +1,11 @@
 from typing import Any, Dict, Optional
 from databricks.sdk.oauth import ClientCredentials, Token, TokenSource
-from databricks.sdk.core import CredentialsProvider, HeaderFactory, Config, credentials_provider
+from databricks.sdk.core import (
+    CredentialsProvider,
+    HeaderFactory,
+    Config,
+    credentials_provider,
+)
 
 
 class token_auth(CredentialsProvider):
@@ -45,7 +50,10 @@ class m2m_auth(CredentialsProvider):
             raise ValueError(f"{host} does not support OAuth")
         if config.is_azure:
             # Azure AD only supports full access to Azure Databricks.
-            scopes = [f"{config.effective_azure_login_app_id}/.default", "offline_access"]
+            scopes = [
+                f"{config.effective_azure_login_app_id}/.default",
+                "offline_access",
+            ]
         self._token_source = ClientCredentials(
             client_id=client_id,
             client_secret=client_secret,
@@ -65,7 +73,9 @@ class m2m_auth(CredentialsProvider):
             return {"token": {}}
 
     @staticmethod
-    def from_dict(host: str, client_id: str, client_secret: str, raw: dict) -> CredentialsProvider:
+    def from_dict(
+        host: str, client_id: str, client_secret: str, raw: dict
+    ) -> CredentialsProvider:
         c = m2m_auth(host=host, client_id=client_id, client_secret=client_secret)
         c._token_source._token = Token.from_dict(raw["token"])
         return c

--- a/dbt/adapters/databricks/python_submissions.py
+++ b/dbt/adapters/databricks/python_submissions.py
@@ -92,11 +92,13 @@ class BaseDatabricksHelper(PythonJobHelper):
         job_spec.update(cluster_spec)  # updates 'new_cluster' config
         # PYPI packages
         packages = self.parsed_model["config"].get("packages", [])
+        # custom index URL or default
+        index_url = self.parsed_model["config"].get("index_url", "https://pypi.org/simple")
         # additional format of packages
         additional_libs = self.parsed_model["config"].get("additional_libs", [])
         libraries = []
         for package in packages:
-            libraries.append({"pypi": {"package": package}})
+            libraries.append({"pypi":  {"package": package, "repo": index_url}})
         for lib in additional_libs:
             libraries.append(lib)
         job_spec.update({"libraries": libraries})  # type: ignore

--- a/dbt/adapters/databricks/relation.py
+++ b/dbt/adapters/databricks/relation.py
@@ -63,7 +63,11 @@ class DatabricksRelation(BaseRelation):
 
     @property
     def stats(self) -> Optional[str]:
-        return self.metadata.get(KEY_TABLE_STATISTICS) if self.metadata is not None else None
+        return (
+            self.metadata.get(KEY_TABLE_STATISTICS)
+            if self.metadata is not None
+            else None
+        )
 
     def matches(
         self,
@@ -81,14 +85,16 @@ class DatabricksRelation(BaseRelation):
 
         if not search:
             # nothing was passed in
-            raise DbtRuntimeError("Tried to match relation, but no search path was passed!")
+            raise DbtRuntimeError(
+                "Tried to match relation, but no search path was passed!"
+            )
 
         match = True
 
         for k, v in search.items():
-            if str(self.path.get_lowered_part(k)).strip(self.quote_character) != v.lower().strip(
+            if str(self.path.get_lowered_part(k)).strip(
                 self.quote_character
-            ):
+            ) != v.lower().strip(self.quote_character):
                 match = False
 
         return match

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,9 @@ try:
 except ImportError:
     # the user has a downlevel version of setuptools.
     print("Error: dbt requires setuptools v40.1.0 or higher.")
-    print('Please upgrade setuptools with "pip install --upgrade setuptools" and try again')
+    print(
+        'Please upgrade setuptools with "pip install --upgrade setuptools" and try again'
+    )
     sys.exit(1)
 
 
@@ -29,12 +31,16 @@ with open(os.path.join(this_directory, "README.md"), "r", encoding="utf8") as f:
 
 # get this package's version from dbt/adapters/<name>/__version__.py
 def _get_plugin_version():
-    _version_path = os.path.join(this_directory, "dbt", "adapters", "databricks", "__version__.py")
+    _version_path = os.path.join(
+        this_directory, "dbt", "adapters", "databricks", "__version__.py"
+    )
     try:
         exec(open(_version_path).read())
         return locals()["version"]
     except IOError:
-        print("Failed to load dbt-databricks version file for packaging.", file=sys.stderr)
+        print(
+            "Failed to load dbt-databricks version file for packaging.", file=sys.stderr
+        )
         sys.exit(-1)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,9 @@ pytest_plugins = ["dbt.tests.fixtures.project"]
 
 
 def pytest_addoption(parser):
-    parser.addoption("--profile", action="store", default="databricks_cluster", type=str)
+    parser.addoption(
+        "--profile", action="store", default="databricks_cluster", type=str
+    )
 
 
 # Using @pytest.mark.skip_profile('databricks_cluster') uses the 'skip_by_adapter_type'

--- a/tests/functional/adapter/test_basic.py
+++ b/tests/functional/adapter/test_basic.py
@@ -8,15 +8,23 @@ from dbt.tests.util import AnyInteger, AnyString
 
 from dbt.tests.adapter.basic.test_base import BaseSimpleMaterializations
 from dbt.tests.adapter.basic.test_singular_tests import BaseSingularTests
-from dbt.tests.adapter.basic.test_singular_tests_ephemeral import BaseSingularTestsEphemeral
+from dbt.tests.adapter.basic.test_singular_tests_ephemeral import (
+    BaseSingularTestsEphemeral,
+)
 from dbt.tests.adapter.basic.test_empty import BaseEmpty
 from dbt.tests.adapter.basic.test_ephemeral import BaseEphemeral
-from dbt.tests.adapter.basic.test_incremental import BaseIncremental, BaseIncrementalNotSchemaChange
+from dbt.tests.adapter.basic.test_incremental import (
+    BaseIncremental,
+    BaseIncrementalNotSchemaChange,
+)
 from dbt.tests.adapter.basic.test_generic_tests import BaseGenericTests
 from dbt.tests.adapter.basic.test_snapshot_check_cols import BaseSnapshotCheckCols
 from dbt.tests.adapter.basic.test_snapshot_timestamp import BaseSnapshotTimestamp
 from dbt.tests.adapter.basic.test_adapter_methods import BaseAdapterMethod
-from dbt.tests.adapter.basic.test_docs_generate import BaseDocsGenerate, BaseDocsGenReferences
+from dbt.tests.adapter.basic.test_docs_generate import (
+    BaseDocsGenerate,
+    BaseDocsGenReferences,
+)
 
 
 class TestSimpleMaterializationsDatabricks(BaseSimpleMaterializations):

--- a/tests/functional/adapter/test_changing_relation_type.py
+++ b/tests/functional/adapter/test_changing_relation_type.py
@@ -1,6 +1,8 @@
 import pytest
 
-from dbt.tests.adapter.relations.test_changing_relation_type import BaseChangeRelationTypeValidator
+from dbt.tests.adapter.relations.test_changing_relation_type import (
+    BaseChangeRelationTypeValidator,
+)
 
 
 class TestChangeRelationTypesDatabricks(BaseChangeRelationTypeValidator):

--- a/tests/functional/adapter/test_concurrency.py
+++ b/tests/functional/adapter/test_concurrency.py
@@ -6,7 +6,10 @@ from dbt.tests.util import (
     run_dbt_and_capture,
     write_file,
 )
-from dbt.tests.adapter.concurrency.test_concurrency import BaseConcurrency, seeds__update_csv
+from dbt.tests.adapter.concurrency.test_concurrency import (
+    BaseConcurrency,
+    seeds__update_csv,
+)
 
 
 class TestConncurenncyDatabricks(BaseConcurrency):

--- a/tests/functional/adapter/test_constraints.py
+++ b/tests/functional/adapter/test_constraints.py
@@ -180,7 +180,9 @@ class BaseSparkConstraintsRollbackSetup:
 
 
 @pytest.mark.skip_profile("databricks_sql_endpoint", "databricks_cluster")
-class TestSparkTableConstraintsRollback(BaseSparkConstraintsRollbackSetup, BaseConstraintsRollback):
+class TestSparkTableConstraintsRollback(
+    BaseSparkConstraintsRollbackSetup, BaseConstraintsRollback
+):
     @pytest.fixture(scope="class")
     def models(self):
         return {

--- a/tests/functional/adapter/test_grants.py
+++ b/tests/functional/adapter/test_grants.py
@@ -6,7 +6,9 @@ from dbt.tests.adapter.grants.test_seed_grants import BaseSeedGrants
 from dbt.tests.adapter.grants.test_snapshot_grants import BaseSnapshotGrants
 
 
-@pytest.mark.skip(reason="DECO team must provide DBT_TEST_USER_1/2/3 before we re-enable")
+@pytest.mark.skip(
+    reason="DECO team must provide DBT_TEST_USER_1/2/3 before we re-enable"
+)
 # @pytest.mark.skip_profile("databricks_cluster", "databricks_sql_endpoint")
 class TestModelGrantsDatabricks(BaseModelGrants):
     def privilege_grantee_name_overrides(self):
@@ -19,13 +21,17 @@ class TestModelGrantsDatabricks(BaseModelGrants):
         }
 
 
-@pytest.mark.skip(reason="DECO team must provide DBT_TEST_USER_1/2/3 before we re-enable")
+@pytest.mark.skip(
+    reason="DECO team must provide DBT_TEST_USER_1/2/3 before we re-enable"
+)
 # @pytest.mark.skip_profile("databricks_cluster", "databricks_sql_endpoint")
 class TestIncrementalGrantsDatabricks(BaseIncrementalGrants):
     pass
 
 
-@pytest.mark.skip(reason="DECO team must provide DBT_TEST_USER_1/2/3 before we re-enable")
+@pytest.mark.skip(
+    reason="DECO team must provide DBT_TEST_USER_1/2/3 before we re-enable"
+)
 # @pytest.mark.skip_profile("databricks_cluster", "databricks_sql_endpoint")
 class TestSeedGrantsDatabricks(BaseSeedGrants):
     # seeds in dbt-spark are currently "full refreshed," in such a way that
@@ -35,13 +41,17 @@ class TestSeedGrantsDatabricks(BaseSeedGrants):
         return False
 
 
-@pytest.mark.skip(reason="DECO team must provide DBT_TEST_USER_1/2/3 before we re-enable")
+@pytest.mark.skip(
+    reason="DECO team must provide DBT_TEST_USER_1/2/3 before we re-enable"
+)
 # @pytest.mark.skip_profile("databricks_cluster", "databricks_sql_endpoint")
 class TestSnapshotGrantsDatabricks(BaseSnapshotGrants):
     pass
 
 
-@pytest.mark.skip(reason="DECO team must provide DBT_TEST_USER_1/2/3 before we re-enable")
+@pytest.mark.skip(
+    reason="DECO team must provide DBT_TEST_USER_1/2/3 before we re-enable"
+)
 # @pytest.mark.skip_profile("databricks_cluster", "databricks_sql_endpoint")
 class TestInvalidGrantsDatabricks(BaseInvalidGrants):
     def grantee_does_not_exist_error(self):

--- a/tests/functional/adapter/test_incremental_predicates.py
+++ b/tests/functional/adapter/test_incremental_predicates.py
@@ -1,5 +1,7 @@
 import pytest
-from dbt.tests.adapter.incremental.test_incremental_predicates import BaseIncrementalPredicates
+from dbt.tests.adapter.incremental.test_incremental_predicates import (
+    BaseIncrementalPredicates,
+)
 
 
 models__databricks_incremental_predicates_sql = """

--- a/tests/functional/adapter/test_incremental_unique_id.py
+++ b/tests/functional/adapter/test_incremental_unique_id.py
@@ -1,4 +1,6 @@
-from dbt.tests.adapter.incremental.test_incremental_unique_id import BaseIncrementalUniqueKey
+from dbt.tests.adapter.incremental.test_incremental_unique_id import (
+    BaseIncrementalUniqueKey,
+)
 
 
 class TestUniqueKeyDatabricks(BaseIncrementalUniqueKey):

--- a/tests/functional/adapter/utils/test_utils.py
+++ b/tests/functional/adapter/utils/test_utils.py
@@ -11,7 +11,9 @@ from dbt.tests.adapter.utils.test_current_timestamp import BaseCurrentTimestampA
 from dbt.tests.adapter.utils.test_dateadd import BaseDateAdd
 from dbt.tests.adapter.utils.test_datediff import BaseDateDiff
 from dbt.tests.adapter.utils.test_date_trunc import BaseDateTrunc
-from dbt.tests.adapter.utils.test_escape_single_quotes import BaseEscapeSingleQuotesBackslash
+from dbt.tests.adapter.utils.test_escape_single_quotes import (
+    BaseEscapeSingleQuotesBackslash,
+)
 from dbt.tests.adapter.utils.test_except import BaseExcept
 from dbt.tests.adapter.utils.test_hash import BaseHash
 from dbt.tests.adapter.utils.test_intersect import BaseIntersect
@@ -32,7 +34,9 @@ from tests.functional.adapter.utils.fixture_dateadd import (
     models__test_dateadd_sql,
     seeds__data_dateadd_csv,
 )
-from tests.functional.adapter.utils.fixture_listagg import models__test_listagg_no_order_by_sql
+from tests.functional.adapter.utils.fixture_listagg import (
+    models__test_listagg_no_order_by_sql,
+)
 
 
 class TestAnyValue(BaseAnyValue):

--- a/tests/integration/base.py
+++ b/tests/integration/base.py
@@ -153,7 +153,8 @@ class DBTIntegrationTest(unittest.TestCase):
             _randint = random.randint(0, 9999)
             _runtime_timedelta = datetime.utcnow() - datetime(1970, 1, 1, 0, 0, 0)
             _runtime = (
-                int(_runtime_timedelta.total_seconds() * 1e6) + _runtime_timedelta.microseconds
+                int(_runtime_timedelta.total_seconds() * 1e6)
+                + _runtime_timedelta.microseconds
             )
 
             self._prefix = f"test{_runtime}{_randint:04}"
@@ -362,7 +363,9 @@ class DBTIntegrationTest(unittest.TestCase):
             shutil.rmtree(self.test_root_dir)
         except EnvironmentError:
             logger.exception(
-                "Could not clean up after test - {} not removable".format(self.test_root_dir)
+                "Could not clean up after test - {} not removable".format(
+                    self.test_root_dir
+                )
             )
 
     def _get_schema_fqn(self, database, schema):
@@ -463,7 +466,9 @@ class DBTIntegrationTest(unittest.TestCase):
         }
         if kwargs is None:
             kwargs = {}
-        base_kwargs.update({key: value for key, value in kwargs.items() if value is not None})
+        base_kwargs.update(
+            {key: value for key, value in kwargs.items() if value is not None}
+        )
         if "database_schema" not in base_kwargs:
             if base_kwargs["database"] is not None:
                 base_kwargs[
@@ -554,7 +559,9 @@ class DBTIntegrationTest(unittest.TestCase):
         with self.get_connection():
             columns = self.adapter.get_columns_in_relation(relation)
 
-        return sorted(((c.name, c.dtype, c.char_size) for c in columns), key=lambda x: x[0])
+        return sorted(
+            ((c.name, c.dtype, c.char_size) for c in columns), key=lambda x: x[0]
+        )
 
     def get_table_columns(self, table, schema=None, database=None):
         schema = self.unique_schema() if schema is None else schema
@@ -670,7 +677,9 @@ class DBTIntegrationTest(unittest.TestCase):
 
         return column_specs
 
-    def assertManyRelationsEqual(self, relations, default_schema=None, default_database=None):
+    def assertManyRelationsEqual(
+        self, relations, default_schema=None, default_database=None
+    ):
         if default_schema is None:
             default_schema = self.unique_schema()
         if default_database is None:
@@ -686,9 +695,13 @@ class DBTIntegrationTest(unittest.TestCase):
             if len(relation) == 3:
                 relation = self._make_relation(*relation)
             elif len(relation) == 2:
-                relation = self._make_relation(relation[0], relation[1], default_database)
+                relation = self._make_relation(
+                    relation[0], relation[1], default_database
+                )
             elif len(relation) == 1:
-                relation = self._make_relation(relation[0], default_schema, default_database)
+                relation = self._make_relation(
+                    relation[0], default_schema, default_database
+                )
             else:
                 raise ValueError("relation must be a sequence of 1, 2, or 3 values")
 
@@ -720,7 +733,9 @@ class DBTIntegrationTest(unittest.TestCase):
             if first_relation is None:
                 first_relation = relation
             else:
-                sql = self._assertTablesEqualSql(first_relation, relation, columns=first_columns)
+                sql = self._assertTablesEqualSql(
+                    first_relation, relation, columns=first_columns
+                )
                 result = self.run_sql(sql, fetch="one")
 
                 self.assertEqual(result[0], 0, "row_count_difference nonzero: " + sql)
@@ -807,7 +822,9 @@ class DBTIntegrationTest(unittest.TestCase):
             self.assertEqual(
                 a_name,
                 b_name,
-                '{} vs {}: column "{}" != "{}"'.format(relation_a, relation_b, a_name, b_name),
+                '{} vs {}: column "{}" != "{}"'.format(
+                    relation_a, relation_b, a_name, b_name
+                ),
             )
 
             self.assertEqual(

--- a/tests/integration/copy_into/test_copy_into.py
+++ b/tests/integration/copy_into/test_copy_into.py
@@ -35,7 +35,9 @@ class TestCopyInto(DBTIntegrationTest):
     def prepare(self):
         self.run_dbt(["run"])
         # Get the location of the source table.
-        rows = self.run_sql("describe table extended {database_schema}.source", fetch="all")
+        rows = self.run_sql(
+            "describe table extended {database_schema}.source", fetch="all"
+        )
         path = None
         for row in rows:
             if row.col_name == "Location":

--- a/tests/integration/incremental_on_schema_change/test_incremental_on_schema_change.py
+++ b/tests/integration/incremental_on_schema_change/test_incremental_on_schema_change.py
@@ -42,14 +42,20 @@ class TestIncrementalOnSchemaChange(DBTIntegrationTest):
 
     def run_incremental_fail_on_schema_change(self):
         select = "model_a incremental_fail"
-        results_one = self.run_dbt(["run", "--models", select, "--full-refresh"])  # noqa: F841
+        results_one = self.run_dbt(
+            ["run", "--models", select, "--full-refresh"]
+        )  # noqa: F841
         results_two = self.run_dbt(["run", "--models", select], expect_pass=False)
         self.assertIn("Compilation Error", results_two[1].message)
 
     def run_incremental_sync_all_columns(self):
         # this doesn't work on Delta today
-        select = "model_a incremental_sync_all_columns incremental_sync_all_columns_target"
-        results_one = self.run_dbt(["run", "--models", select, "--full-refresh"])  # noqa: F841
+        select = (
+            "model_a incremental_sync_all_columns incremental_sync_all_columns_target"
+        )
+        results_one = self.run_dbt(
+            ["run", "--models", select, "--full-refresh"]
+        )  # noqa: F841
         results_two = self.run_dbt(["run", "--models", select], expect_pass=False)
         self.assertIn("Compilation Error", results_two[1].message)
 

--- a/tests/integration/model_contract/test_model_contract.py
+++ b/tests/integration/model_contract/test_model_contract.py
@@ -26,7 +26,9 @@ class TestModelContract(DBTIntegrationTest):
             kwargs=dict(model_name=model_name),
         )
         constraints = {
-            row.key: row.value for row in rows if row.key.startswith("delta.constraints")
+            row.key: row.value
+            for row in rows
+            if row.key.startswith("delta.constraints")
         }
         assert len(constraints) == len(expected)
         self.assertDictEqual(constraints, expected)
@@ -39,7 +41,9 @@ class TestModelContract(DBTIntegrationTest):
         assert res.message and err_msg in res.message
 
     def check_staging_table_cleaned(self):
-        tmp_tables = self.run_sql("SHOW TABLES IN {database_schema} LIKE '*__dbt_tmp'", fetch="all")
+        tmp_tables = self.run_sql(
+            "SHOW TABLES IN {database_schema} LIKE '*__dbt_tmp'", fetch="all"
+        )
         assert len(tmp_tables) == 0
 
 
@@ -54,7 +58,9 @@ class TestModelContractConstraints(TestModelContract):
         self.run_dbt(["run", "--select", expected_model_name])
         self.assertTablesEqual(model_name, expected_model_name)
 
-        self.check_constraints(model_name, {"delta.constraints.id_greater_than_zero": "id > 0"})
+        self.check_constraints(
+            model_name, {"delta.constraints.id_greater_than_zero": "id > 0"}
+        )
 
         # Insert a row into the seed model that violates the NOT NULL constraint on name.
         self.run_sql_file("insert_invalid_name.sql")
@@ -89,7 +95,9 @@ class TestIncrementalModelContractConstraints(TestModelContract):
         self.run_dbt(["seed"])
         model_name = "incremental_model"
         self.run_dbt(["run", "--select", model_name, "--full-refresh"])
-        self.check_constraints(model_name, {"delta.constraints.id_greater_than_zero": "id > 0"})
+        self.check_constraints(
+            model_name, {"delta.constraints.id_greater_than_zero": "id > 0"}
+        )
 
         # Insert a row into the seed model with an invalid id.
         self.run_sql_file("insert_invalid_id.sql")
@@ -109,7 +117,9 @@ class TestIncrementalModelContractConstraints(TestModelContract):
         self.run_sql("delete from {database_schema}.seed where id = 3")
 
         # Insert a valid row into the seed model.
-        self.run_sql("insert into {database_schema}.seed values (3, 'Cathy', '2022-03-01')")
+        self.run_sql(
+            "insert into {database_schema}.seed values (3, 'Cathy', '2022-03-01')"
+        )
         self.run_dbt(["run", "--select", model_name])
         expected_model_name = "expected_incremental_model"
         self.run_dbt(["run", "--select", expected_model_name])
@@ -219,7 +229,9 @@ class TestTableWithModelContractConstraintsDisabled(TestModelContract):
         self.check_constraints(model_name, {})
 
         # Insert a row into the seed model with the name being null.
-        self.run_sql("insert into {database_schema}.seed values (3, null, '2022-03-01')")
+        self.run_sql(
+            "insert into {database_schema}.seed values (3, null, '2022-03-01')"
+        )
 
         # Check the table can be created without failure.
         self.run_dbt(["run", "--select", model_name])

--- a/tests/integration/multi_catalog/test_multi_catalog.py
+++ b/tests/integration/multi_catalog/test_multi_catalog.py
@@ -36,8 +36,16 @@ class TestMultiCatalog(DBTIntegrationTest):
         self.assertManyRelationsEqual(
             [
                 ("seed", self.unique_schema(), seed_catalog),
-                ("alternative_catalog", self.unique_schema(), self.alternative_database),
-                ("refer_alternative_catalog", self.unique_schema(), self.default_database),
+                (
+                    "alternative_catalog",
+                    self.unique_schema(),
+                    self.alternative_database,
+                ),
+                (
+                    "refer_alternative_catalog",
+                    self.unique_schema(),
+                    self.default_database,
+                ),
                 ("cross_catalog", self.unique_schema(), self.default_database),
             ]
         )

--- a/tests/integration/persist_constraints/test_persist_constraints.py
+++ b/tests/integration/persist_constraints/test_persist_constraints.py
@@ -27,7 +27,9 @@ class TestConstraints(DBTIntegrationTest):
             kwargs=dict(model_name=model_name),
         )
         constraints = {
-            row.key: row.value for row in rows if row.key.startswith("delta.constraints")
+            row.key: row.value
+            for row in rows
+            if row.key.startswith("delta.constraints")
         }
         assert len(constraints) == len(expected)
         self.assertDictEqual(constraints, expected)
@@ -40,7 +42,9 @@ class TestConstraints(DBTIntegrationTest):
         assert res.message and err_msg in res.message
 
     def check_staging_table_cleaned(self):
-        tmp_tables = self.run_sql("SHOW TABLES IN {database_schema} LIKE '*__dbt_tmp'", fetch="all")
+        tmp_tables = self.run_sql(
+            "SHOW TABLES IN {database_schema} LIKE '*__dbt_tmp'", fetch="all"
+        )
         assert len(tmp_tables) == 0
 
 
@@ -54,7 +58,9 @@ class TestTableConstraints(TestConstraints):
         self.run_dbt(["run", "--select", expected_model_name])
         self.assertTablesEqual(model_name, expected_model_name)
 
-        self.check_constraints(model_name, {"delta.constraints.id_greater_than_zero": "id > 0"})
+        self.check_constraints(
+            model_name, {"delta.constraints.id_greater_than_zero": "id > 0"}
+        )
 
         # Insert a row into the seed model that violates the NOT NULL constraint on name.
         self.run_sql_file("insert_invalid_name.sql")
@@ -89,7 +95,9 @@ class TestIncrementalConstraints(TestConstraints):
         self.run_dbt(["seed"])
         model_name = "incremental_model"
         self.run_dbt(["run", "--select", model_name, "--full-refresh"])
-        self.check_constraints(model_name, {"delta.constraints.id_greater_than_zero": "id > 0"})
+        self.check_constraints(
+            model_name, {"delta.constraints.id_greater_than_zero": "id > 0"}
+        )
 
         # Insert a row into the seed model with an invalid id.
         self.run_sql_file("insert_invalid_id.sql")
@@ -109,7 +117,9 @@ class TestIncrementalConstraints(TestConstraints):
         self.run_sql("delete from {database_schema}.seed where id = 3")
 
         # Insert a valid row into the seed model.
-        self.run_sql("insert into {database_schema}.seed values (3, 'Cathy', '2022-03-01')")
+        self.run_sql(
+            "insert into {database_schema}.seed values (3, 'Cathy', '2022-03-01')"
+        )
         self.run_dbt(["run", "--select", model_name])
         expected_model_name = "expected_incremental_model"
         self.run_dbt(["run", "--select", expected_model_name])
@@ -134,7 +144,9 @@ class TestIncrementalConstraints(TestConstraints):
 
 class TestSnapshotConstraints(TestConstraints):
     def check_snapshot_results(self, num_rows: int):
-        results = self.run_sql("select * from {database_schema}.my_snapshot", fetch="all")
+        results = self.run_sql(
+            "select * from {database_schema}.my_snapshot", fetch="all"
+        )
         self.assertEqual(len(results), num_rows)
 
     def test_snapshot(self):
@@ -145,7 +157,10 @@ class TestSnapshotConstraints(TestConstraints):
 
         self.run_sql_file("insert_invalid_name.sql")
         results = self.run_dbt(["snapshot"], expect_pass=False)
-        assert "NOT NULL constraint violated for column: name" in results.results[0].message
+        assert (
+            "NOT NULL constraint violated for column: name"
+            in results.results[0].message
+        )
         self.check_staging_table_cleaned()
 
         self.run_dbt(["seed"])
@@ -178,7 +193,9 @@ class TestInvalidCheckConstraints(TestConstraints):
     def test_invalid_check_constraints(self):
         model_name = "invalid_check_constraint"
         self.run_dbt(["seed"])
-        self.run_and_check_failure(model_name, err_msg="Invalid check constraint condition")
+        self.run_and_check_failure(
+            model_name, err_msg="Invalid check constraint condition"
+        )
 
     @use_profile("databricks_cluster")
     def test_databricks_cluster(self):
@@ -237,7 +254,9 @@ class TestTableWithConstraintsDisabled(TestConstraints):
         self.check_constraints(model_name, {})
 
         # Insert a row into the seed model with the name being null.
-        self.run_sql("insert into {database_schema}.seed values (3, null, '2022-03-01')")
+        self.run_sql(
+            "insert into {database_schema}.seed values (3, null, '2022-03-01')"
+        )
 
         # Check the table can be created without failure.
         self.run_dbt(["run", "--select", model_name])

--- a/tests/integration/set_tblproperties/test_set_tblproperties.py
+++ b/tests/integration/set_tblproperties/test_set_tblproperties.py
@@ -24,7 +24,9 @@ class TestSetTblproperties(DBTIntegrationTest):
             assert prop in tblproperties
 
     def check_snapshot_results(self, num_rows: int):
-        results = self.run_sql("select * from {database_schema}.my_snapshot", fetch="all")
+        results = self.run_sql(
+            "select * from {database_schema}.my_snapshot", fetch="all"
+        )
         self.assertEqual(len(results), num_rows)
 
     def test_set_tblproperties(self):

--- a/tests/profiles.py
+++ b/tests/profiles.py
@@ -67,7 +67,8 @@ def databricks_uc_cluster_target():
 def databricks_uc_sql_endpoint_target():
     return _build_databricks_cluster_target(
         http_path=os.getenv(
-            "DBT_DATABRICKS_UC_ENDPOINT_HTTP_PATH", os.getenv("DBT_DATABRICKS_HTTP_PATH")
+            "DBT_DATABRICKS_UC_ENDPOINT_HTTP_PATH",
+            os.getenv("DBT_DATABRICKS_HTTP_PATH"),
         ),
         catalog=os.getenv("DBT_DATABRICKS_UC_INITIAL_CATALOG", "main"),
     )

--- a/tests/unit/test_adapter.py
+++ b/tests/unit/test_adapter.py
@@ -190,7 +190,9 @@ class TestDatabricksAdapter(unittest.TestCase):
                             "host": "yourorg.databricks.com",
                             "http_path": "sql/protocolv1/o/1234567890123456/1234-567890-test123",
                             "token": "dapiXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
-                            "connection_parameters": {"server_hostname": "theirorg.databricks.com"},
+                            "connection_parameters": {
+                                "server_hostname": "theirorg.databricks.com"
+                            },
                         }
                     },
                     "target": "test",
@@ -203,7 +205,9 @@ class TestDatabricksAdapter(unittest.TestCase):
                 dbt.exceptions.DbtProfileError,
                 "The connection parameter `http_headers` should be dict of strings.",
             ):
-                self._get_target_databricks_sql_connector_http_header(self.project_cfg, http_header)
+                self._get_target_databricks_sql_connector_http_header(
+                    self.project_cfg, http_header
+                )
 
         test_http_headers("a")
         test_http_headers(["a", "b"])
@@ -216,7 +220,9 @@ class TestDatabricksAdapter(unittest.TestCase):
         ):
             config = self._get_target_databricks_sql_connector(self.project_cfg)
             adapter = DatabricksAdapter(config)
-            with mock.patch.dict("os.environ", **{DBT_DATABRICKS_INVOCATION_ENV: "(Some-thing)"}):
+            with mock.patch.dict(
+                "os.environ", **{DBT_DATABRICKS_INVOCATION_ENV: "(Some-thing)"}
+            ):
                 connection = adapter.acquire_connection("dummy")
                 connection.handle  # trigger lazy-load
 
@@ -315,7 +321,9 @@ class TestDatabricksAdapter(unittest.TestCase):
 
     @unittest.skip("not ready")
     def test_client_creds_settings(self):
-        config = self._get_target_databricks_sql_connector_client_creds(self.project_cfg)
+        config = self._get_target_databricks_sql_connector_client_creds(
+            self.project_cfg
+        )
 
         adapter = DatabricksAdapter(config)
 
@@ -346,7 +354,9 @@ class TestDatabricksAdapter(unittest.TestCase):
             **kwargs,
         ):
             self.assertEqual(server_hostname, "yourorg.databricks.com")
-            self.assertEqual(http_path, "sql/protocolv1/o/1234567890123456/1234-567890-test123")
+            self.assertEqual(
+                http_path, "sql/protocolv1/o/1234567890123456/1234-567890-test123"
+            )
             if not (expected_no_token or expected_client_creds):
                 self.assertEqual(
                     credentials_provider._token, "dapiXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
@@ -365,7 +375,9 @@ class TestDatabricksAdapter(unittest.TestCase):
                     f"dbt-databricks/{__version__.version}; {expected_invocation_env}",
                 )
             else:
-                self.assertEqual(_user_agent_entry, f"dbt-databricks/{__version__.version}")
+                self.assertEqual(
+                    _user_agent_entry, f"dbt-databricks/{__version__.version}"
+                )
             if expected_http_headers is None:
                 self.assertIsNone(http_headers)
             else:
@@ -380,7 +392,9 @@ class TestDatabricksAdapter(unittest.TestCase):
         config = self._get_target_databricks_sql_connector(self.project_cfg)
         adapter = DatabricksAdapter(config)
 
-        with mock.patch("dbt.adapters.databricks.connections.dbsql.connect", new=connect):
+        with mock.patch(
+            "dbt.adapters.databricks.connections.dbsql.connect", new=connect
+        ):
             connection = adapter.acquire_connection("dummy")
             connection.handle  # trigger lazy-load
 
@@ -390,11 +404,14 @@ class TestDatabricksAdapter(unittest.TestCase):
                 connection.credentials.http_path,
                 "sql/protocolv1/o/1234567890123456/1234-567890-test123",
             )
-            self.assertEqual(connection.credentials.token, "dapiXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX")
+            self.assertEqual(
+                connection.credentials.token, "dapiXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+            )
             self.assertEqual(connection.credentials.schema, "analytics")
             self.assertEqual(len(connection.credentials.session_properties), 1)
             self.assertEqual(
-                connection.credentials.session_properties["spark.sql.ansi.enabled"], "true"
+                connection.credentials.session_properties["spark.sql.ansi.enabled"],
+                "true",
             )
             self.assertIsNone(connection.credentials.database)
 
@@ -407,7 +424,9 @@ class TestDatabricksAdapter(unittest.TestCase):
         config = self._get_target_databricks_sql_connector_catalog(self.project_cfg)
         adapter = DatabricksAdapter(config)
 
-        with mock.patch("dbt.adapters.databricks.connections.dbsql.connect", new=connect):
+        with mock.patch(
+            "dbt.adapters.databricks.connections.dbsql.connect", new=connect
+        ):
             connection = adapter.acquire_connection("dummy")
             connection.handle  # trigger lazy-load
 
@@ -417,7 +436,9 @@ class TestDatabricksAdapter(unittest.TestCase):
                 connection.credentials.http_path,
                 "sql/protocolv1/o/1234567890123456/1234-567890-test123",
             )
-            self.assertEqual(connection.credentials.token, "dapiXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX")
+            self.assertEqual(
+                connection.credentials.token, "dapiXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+            )
             self.assertEqual(connection.credentials.schema, "analytics")
             self.assertEqual(connection.credentials.database, "main")
 
@@ -430,13 +451,17 @@ class TestDatabricksAdapter(unittest.TestCase):
             self._connect_func(expected_http_headers=[("aaa", "xxx"), ("bbb", "yyy")]),
         )
 
-    def _test_databricks_sql_connector_http_header_connection(self, http_headers, connect):
+    def _test_databricks_sql_connector_http_header_connection(
+        self, http_headers, connect
+    ):
         config = self._get_target_databricks_sql_connector_http_header(
             self.project_cfg, http_headers
         )
         adapter = DatabricksAdapter(config)
 
-        with mock.patch("dbt.adapters.databricks.connections.dbsql.connect", new=connect):
+        with mock.patch(
+            "dbt.adapters.databricks.connections.dbsql.connect", new=connect
+        ):
             connection = adapter.acquire_connection("dummy")
             connection.handle  # trigger lazy-load
 
@@ -446,7 +471,9 @@ class TestDatabricksAdapter(unittest.TestCase):
                 connection.credentials.http_path,
                 "sql/protocolv1/o/1234567890123456/1234-567890-test123",
             )
-            self.assertEqual(connection.credentials.token, "dapiXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX")
+            self.assertEqual(
+                connection.credentials.token, "dapiXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+            )
             self.assertEqual(connection.credentials.schema, "analytics")
             self.assertIsNone(connection.credentials.database)
 
@@ -455,7 +482,10 @@ class TestDatabricksAdapter(unittest.TestCase):
         rel_type = DatabricksRelation.get_relation_type.Table
 
         relation = DatabricksRelation.create(
-            database="test_catalog", schema="default_schema", identifier="mytable", type=rel_type
+            database="test_catalog",
+            schema="default_schema",
+            identifier="mytable",
+            type=rel_type,
         )
         assert relation.database == "test_catalog"
 
@@ -491,14 +521,19 @@ class TestDatabricksAdapter(unittest.TestCase):
             ("Location", "/mnt/vo"),
             ("Serde Library", "org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe"),
             ("InputFormat", "org.apache.hadoop.mapred.SequenceFileInputFormat"),
-            ("OutputFormat", "org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat"),
+            (
+                "OutputFormat",
+                "org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat",
+            ),
             ("Partition Provider", "Catalog"),
         ]
 
         input_cols = [Row(keys=["col_name", "data_type"], values=r) for r in plain_rows]
 
         config = self._get_target_databricks_sql_connector(self.project_cfg)
-        metadata, rows = DatabricksAdapter(config).parse_describe_extended(relation, input_cols)
+        metadata, rows = DatabricksAdapter(config).parse_describe_extended(
+            relation, input_cols
+        )
 
         self.assertDictEqual(
             metadata,
@@ -609,7 +644,9 @@ class TestDatabricksAdapter(unittest.TestCase):
         input_cols = [Row(keys=["col_name", "data_type"], values=r) for r in plain_rows]
 
         config = self._get_target_databricks_sql_connector(self.project_cfg)
-        _, rows = DatabricksAdapter(config).parse_describe_extended(relation, input_cols)
+        _, rows = DatabricksAdapter(config).parse_describe_extended(
+            relation, input_cols
+        )
 
         self.assertEqual(rows[0].to_column_dict().get("table_owner"), "1234")
 
@@ -638,14 +675,19 @@ class TestDatabricksAdapter(unittest.TestCase):
             ("Location", "/mnt/vo"),
             ("Serde Library", "org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe"),
             ("InputFormat", "org.apache.hadoop.mapred.SequenceFileInputFormat"),
-            ("OutputFormat", "org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat"),
+            (
+                "OutputFormat",
+                "org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat",
+            ),
             ("Partition Provider", "Catalog"),
         ]
 
         input_cols = [Row(keys=["col_name", "data_type"], values=r) for r in plain_rows]
 
         config = self._get_target_databricks_sql_connector(self.project_cfg)
-        metadata, rows = DatabricksAdapter(config).parse_describe_extended(relation, input_cols)
+        metadata, rows = DatabricksAdapter(config).parse_describe_extended(
+            relation, input_cols
+        )
 
         self.assertEqual(
             metadata,
@@ -698,7 +740,9 @@ class TestDatabricksAdapter(unittest.TestCase):
         adapter = DatabricksAdapter(config)
         r1 = adapter.Relation.create(schema="different", identifier="table")
         assert r1.database is None
-        r2 = adapter.Relation.create(database="something", schema="different", identifier="table")
+        r2 = adapter.Relation.create(
+            database="something", schema="different", identifier="table"
+        )
         assert r2.database == "something"
 
     def test_parse_columns_from_information_with_table_type_and_delta_provider(self):
@@ -734,7 +778,9 @@ class TestDatabricksAdapter(unittest.TestCase):
         )
 
         config = self._get_target_databricks_sql_connector(self.project_cfg)
-        columns = DatabricksAdapter(config).parse_columns_from_information(relation, information)
+        columns = DatabricksAdapter(config).parse_columns_from_information(
+            relation, information
+        )
         self.assertEqual(len(columns), 4)
         self.assertEqual(
             columns[0].to_column_dict(omit_none=False),
@@ -819,7 +865,9 @@ class TestDatabricksAdapter(unittest.TestCase):
         )
 
         config = self._get_target_databricks_sql_connector(self.project_cfg)
-        columns = DatabricksAdapter(config).parse_columns_from_information(relation, information)
+        columns = DatabricksAdapter(config).parse_columns_from_information(
+            relation, information
+        )
         self.assertEqual(len(columns), 4)
         self.assertEqual(
             columns[1].to_column_dict(omit_none=False),
@@ -885,7 +933,9 @@ class TestDatabricksAdapter(unittest.TestCase):
         )
 
         config = self._get_target_databricks_sql_connector(self.project_cfg)
-        columns = DatabricksAdapter(config).parse_columns_from_information(relation, information)
+        columns = DatabricksAdapter(config).parse_columns_from_information(
+            relation, information
+        )
         self.assertEqual(len(columns), 4)
         self.assertEqual(
             columns[2].to_column_dict(omit_none=False),
@@ -940,7 +990,9 @@ class TestDatabricksAdapter(unittest.TestCase):
 
 class TestCheckNotFound(unittest.TestCase):
     def test_prefix(self):
-        self.assertTrue(check_not_found_error("Runtime error \n Database 'dbt' not found"))
+        self.assertTrue(
+            check_not_found_error("Runtime error \n Database 'dbt' not found")
+        )
 
     def test_no_prefix_or_suffix(self):
         self.assertTrue(check_not_found_error("Database not found"))

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -56,7 +56,11 @@ class TestTokenAuth(unittest.TestCase):
     def test_token(self):
         host = "my.cloud.databricks.com"
         creds = DatabricksCredentials(
-            host=host, token="foo", database="andre", http_path="http://foo", schema="dbt"
+            host=host,
+            token="foo",
+            database="andre",
+            http_path="http://foo",
+            schema="dbt",
         )
         provider = creds.authenticate(None)
         self.assertIsNotNone(provider)

--- a/tests/unit/test_macros.py
+++ b/tests/unit/test_macros.py
@@ -27,16 +27,22 @@ class TestSparkMacros(unittest.TestCase):
             "var": mock.Mock(),
             "return": lambda r: r,
         }
-        self.default_context["config"].get = lambda key, default=None, **kwargs: self.config.get(
+        self.default_context[
+            "config"
+        ].get = lambda key, default=None, **kwargs: self.config.get(key, default)
+
+        self.default_context["var"] = lambda key, default=None, **kwargs: self.var.get(
             key, default
         )
 
-        self.default_context["var"] = lambda key, default=None, **kwargs: self.var.get(key, default)
-
     def __get_template(self, template_filename):
-        parent = self.parent_jinja_env.get_template(template_filename, globals=self.default_context)
+        parent = self.parent_jinja_env.get_template(
+            template_filename, globals=self.default_context
+        )
         self.default_context.update(parent.module.__dict__)
-        return self.jinja_env.get_template(template_filename, globals=self.default_context)
+        return self.jinja_env.get_template(
+            template_filename, globals=self.default_context
+        )
 
     def __run_macro(self, template, name, temporary, relation, sql):
         self.default_context["model"].alias = relation
@@ -64,7 +70,9 @@ class TestSparkMacros(unittest.TestCase):
             template, "databricks__create_table_as", False, "my_table", "select 1"
         ).strip()
 
-        self.assertEqual(sql, "create or replace table my_table using delta as select 1")
+        self.assertEqual(
+            sql, "create or replace table my_table using delta as select 1"
+        )
 
     def test_macros_create_table_as_file_format(self):
         template = self.__get_template("adapters.sql")
@@ -308,15 +316,21 @@ class TestDatabricksMacros(unittest.TestCase):
             "adapter": mock.Mock(),
             "return": lambda r: r,
         }
-        self.default_context["config"].get = lambda key, default=None, **kwargs: self.config.get(
+        self.default_context[
+            "config"
+        ].get = lambda key, default=None, **kwargs: self.config.get(key, default)
+        self.default_context["var"] = lambda key, default=None, **kwargs: self.var.get(
             key, default
         )
-        self.default_context["var"] = lambda key, default=None, **kwargs: self.var.get(key, default)
 
     def __get_template(self, template_filename):
-        parent = self.parent_jinja_env.get_template(template_filename, globals=self.default_context)
+        parent = self.parent_jinja_env.get_template(
+            template_filename, globals=self.default_context
+        )
         self.default_context.update(parent.module.__dict__)
-        return self.jinja_env.get_template(template_filename, globals=self.default_context)
+        return self.jinja_env.get_template(
+            template_filename, globals=self.default_context
+        )
 
     def __run_macro(self, template, name, temporary, relation, sql):
         self.default_context["model"].alias = relation
@@ -393,18 +407,30 @@ class TestDatabricksMacros(unittest.TestCase):
         relation = DatabricksRelation.from_dict(data)
 
         self.config["zorder"] = "foo"
-        sql = self.__run_macro(template, "get_optimize_sql", None, relation, None).strip()
+        sql = self.__run_macro(
+            template, "get_optimize_sql", None, relation, None
+        ).strip()
 
         self.assertEqual(
             sql,
-            ("optimize " "`some_database`.`some_schema`.`some_table` " "zorder by (foo)"),
+            (
+                "optimize "
+                "`some_database`.`some_schema`.`some_table` "
+                "zorder by (foo)"
+            ),
         )
         self.config["zorder"] = ["foo", "bar"]
-        sql2 = self.__run_macro(template, "get_optimize_sql", None, relation, None).strip()
+        sql2 = self.__run_macro(
+            template, "get_optimize_sql", None, relation, None
+        ).strip()
 
         self.assertEqual(
             sql2,
-            ("optimize " "`some_database`.`some_schema`.`some_table` " "zorder by (foo, bar)"),
+            (
+                "optimize "
+                "`some_database`.`some_schema`.`some_table` "
+                "zorder by (foo, bar)"
+            ),
         )
 
     def test_macros_optimize(self):
@@ -472,7 +498,9 @@ class TestDatabricksMacros(unittest.TestCase):
         r = self.__run_macro2(
             template, "databricks_constraints_to_dbt", relation, [constraint]
         ).strip()
-        self.assertEquals(r, "[{'name': 'name', 'type': 'check', 'expression': 'id > 0'}]")
+        self.assertEquals(
+            r, "[{'name': 'name', 'type': 'check', 'expression': 'id > 0'}]"
+        )
 
         constraint = {"condition": "id > 0"}
         r = self.__run_macro2(
@@ -490,7 +518,9 @@ class TestDatabricksMacros(unittest.TestCase):
         r = self.__run_macro2(
             template, "databricks_constraints_to_dbt", relation, [constraint]
         ).strip()
-        self.assertEquals(r, "[{'type': 'check', 'name': 'name', 'expression': 'id > 0'}]")
+        self.assertEquals(
+            r, "[{'type': 'check', 'name': 'name', 'expression': 'id > 0'}]"
+        )
 
         column = {"name": "col"}
         constraint = {"name": "name", "condition": "id > 0"}
@@ -503,7 +533,9 @@ class TestDatabricksMacros(unittest.TestCase):
         r = self.__run_macro2(
             template, "databricks_constraints_to_dbt", relation, [constraint], column
         ).strip()
-        self.assertEquals(r, "[{'type': 'check', 'name': 'name', 'expression': 'id > 0'}]")
+        self.assertEquals(
+            r, "[{'type': 'check', 'name': 'name', 'expression': 'id > 0'}]"
+        )
 
         constraint = "not_null"
         r = self.__run_macro2(
@@ -524,22 +556,30 @@ class TestDatabricksMacros(unittest.TestCase):
             "constraints": [{"type": "not_null", "columns": ["id", "name"]}],
         }
 
-        r = self.__run_macro2(template, "get_model_constraints", relation, model).strip()
+        r = self.__run_macro2(
+            template, "get_model_constraints", relation, model
+        ).strip()
         expected = "[{'type': 'not_null', 'columns': ['id', 'name']}]"
         assert expected in r
 
         self.config["persist_constraints"] = True
-        r = self.__run_macro2(template, "get_model_constraints", relation, model).strip()
+        r = self.__run_macro2(
+            template, "get_model_constraints", relation, model
+        ).strip()
         expected = "[{'type': 'not_null', 'columns': ['id', 'name']}]"
         assert expected in r
 
         model["meta"] = {"constraints": [{"type": "foo"}]}
-        r = self.__run_macro2(template, "get_model_constraints", relation, model).strip()
+        r = self.__run_macro2(
+            template, "get_model_constraints", relation, model
+        ).strip()
         expected = "[{'type': 'foo'}]"
         assert expected in r
 
         self.config["persist_constraints"] = False
-        r = self.__run_macro2(template, "get_model_constraints", relation, model).strip()
+        r = self.__run_macro2(
+            template, "get_model_constraints", relation, model
+        ).strip()
         expected = "[{'type': 'not_null', 'columns': ['id', 'name']}]"
         assert expected in r
 
@@ -548,34 +588,48 @@ class TestDatabricksMacros(unittest.TestCase):
         relation = self.get_test_relation()
         column = {"name": "id"}
 
-        r = self.__run_macro2(template, "get_column_constraints", relation, column).strip()
+        r = self.__run_macro2(
+            template, "get_column_constraints", relation, column
+        ).strip()
         self.assertEqual(r, "[]")
 
         column["constraints"] = []
         self.config["persist_constraints"] = True
-        r = self.__run_macro2(template, "get_column_constraints", relation, column).strip()
+        r = self.__run_macro2(
+            template, "get_column_constraints", relation, column
+        ).strip()
         self.assertEqual(r, "[]")
 
         column["constraints"] = [{"type": "non_null"}]
         self.config["persist_constraints"] = True
-        r = self.__run_macro2(template, "get_column_constraints", relation, column).strip()
+        r = self.__run_macro2(
+            template, "get_column_constraints", relation, column
+        ).strip()
         self.assertEqual(r, "[{'type': 'non_null'}]")
 
         self.config["persist_constraints"] = True
         column["meta"] = {"constraint": "foo"}
-        r = self.__run_macro2(template, "get_column_constraints", relation, column).strip()
+        r = self.__run_macro2(
+            template, "get_column_constraints", relation, column
+        ).strip()
         assert "raise_compiler_error" in r
 
         column["meta"] = {"constraint": {"condition": "foo", "name": "name"}}
-        r = self.__run_macro2(template, "get_column_constraints", relation, column).strip()
+        r = self.__run_macro2(
+            template, "get_column_constraints", relation, column
+        ).strip()
         assert "raise_compiler_error" in r
 
         column["meta"] = {"constraint": "not_null"}
-        r = self.__run_macro2(template, "get_column_constraints", relation, column).strip()
+        r = self.__run_macro2(
+            template, "get_column_constraints", relation, column
+        ).strip()
         self.assertEqual(r, "[{'type': 'not_null', 'columns': ['id']}]")
 
         self.config["persist_constraints"] = False
-        r = self.__run_macro2(template, "get_column_constraints", relation, column).strip()
+        r = self.__run_macro2(
+            template, "get_column_constraints", relation, column
+        ).strip()
         self.assertEqual(r, "[{'type': 'non_null'}]")
 
     def test_macros_get_constraint_sql_not_null(self):

--- a/tests/unit/test_relation.py
+++ b/tests/unit/test_relation.py
@@ -80,7 +80,9 @@ class TestDatabricksRelation(unittest.TestCase):
         self.assertEqual(
             relation.get_default_quote_policy(), DatabricksQuotePolicy(True, True, True)
         )
-        self.assertEqual(relation.render(), "`some_database`.`some_schema`.`some_table`")
+        self.assertEqual(
+            relation.render(), "`some_database`.`some_schema`.`some_table`"
+        )
 
         data = {
             "path": {

--- a/tests/unit/utils.py
+++ b/tests/unit/utils.py
@@ -80,7 +80,9 @@ def project_from_dict(project, profile, packages=None, selectors=None, cli_vars=
     return partial.render(renderer)
 
 
-def config_from_parts_or_dicts(project, profile, packages=None, selectors=None, cli_vars="{}"):
+def config_from_parts_or_dicts(
+    project, profile, packages=None, selectors=None, cli_vars="{}"
+):
     from dbt.config import Project, Profile, RuntimeConfig
     from dbt.config.utils import parse_cli_vars
     from copy import deepcopy
@@ -181,8 +183,12 @@ class ContractTestCase(TestCase):
 def compare_dicts(dict1, dict2):
     first_set = set(dict1.keys())
     second_set = set(dict2.keys())
-    print(f"--- Difference between first and second keys: {first_set.difference(second_set)}")
-    print(f"--- Difference between second and first keys: {second_set.difference(first_set)}")
+    print(
+        f"--- Difference between first and second keys: {first_set.difference(second_set)}"
+    )
+    print(
+        f"--- Difference between second and first keys: {second_set.difference(first_set)}"
+    )
     common_keys = set(first_set).intersection(set(second_set))
     found_differences = False
     for key in common_keys:


### PR DESCRIPTION
Resolves #362 

### Description

Added the option to provide a custom index_url from which to install Python libraries on the Databricks cluster. This enables developers at enterprise organizations that are required to install libraries from their own index to provide this URL. Also, it's must easier to implement shared logic over different Python models when the need arises (if SQL really is no option).

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
