### PR TITLE
Fix failing model contract integration test

### DIFF
--- a/tests/integration/model_contract/test_model_contract.py
+++ b/tests/integration/model_contract/test_model_contract.py
@@ -161,7 +161,7 @@ class TestInvalidModelContractCheckConstraints(TestModelContract):
         res = self.run_dbt(["run", "--select", model_name])
         self.assertFalse(res.success, "dbt exit state did not match expected")
 
-        # dbt 1.5.2 changed the error message returned when an invalid constraint is 
+        # dbt 1.5.2 changed the error message returned when an invalid constraint is
         # encountered. Check for either to maintain compatability with all 1.5.x versions.
         expectedErrors = ["Constraint validation failed", "Contract enforcement failed"]
         assert res.exception and [m for m in expectedErrors if m in res.exception.msg]

--- a/tests/integration/model_contract/test_model_contract.py
+++ b/tests/integration/model_contract/test_model_contract.py
@@ -160,7 +160,11 @@ class TestInvalidModelContractCheckConstraints(TestModelContract):
         model_name = "invalid_check_constraint"
         res = self.run_dbt(["run", "--select", model_name])
         self.assertFalse(res.success, "dbt exit state did not match expected")
-        assert res.exception and "Constraint validation failed" in res.exception.msg
+
+        # dbt 1.5.2 changed the error message returned when an invalid constraint is 
+        # encountered. Check for either to maintain compatability with all 1.5.x versions.
+        expectedErrors = ["Constraint validation failed", "Contract enforcement failed"]
+        assert res.exception and [m for m in expectedErrors if m in res.exception.msg]
 
     @use_profile("databricks_cluster")
     def test_databricks_cluster(self):


### PR DESCRIPTION

### Description

TestInvalidModelContractCheckConstraints tests that an invalid constraint causes a failure.  The test checked that the error message contained 'Constraint validation failed'. dbt 1.5.2 changed the error message to 'Contract enforcement failed'. Updated the test to check for either the original or updated message.

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
