### PR TITLE
Another usage of limit param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Features
 - Added support for materialized_view and streaming_table materializations
+- Support new dbt `limit` command-line flag
 
 ## dbt-databricks 1.5.5 (July 7, 2023)
 

--- a/dbt/adapters/databricks/impl.py
+++ b/dbt/adapters/databricks/impl.py
@@ -124,11 +124,12 @@ class DatabricksAdapter(SparkAdapter):
         sql: str,
         auto_begin: bool = False,
         fetch: bool = False,
+        limit: Optional[int] = None,
         *,
         staging_table: Optional[BaseRelation] = None,
     ) -> Tuple[AdapterResponse, Table]:
         try:
-            return super().execute(sql=sql, auto_begin=auto_begin, fetch=fetch)
+            return super().execute(sql=sql, auto_begin=auto_begin, fetch=fetch, limit=limit)
         finally:
             if staging_table is not None:
                 self.drop_relation(staging_table)


### PR DESCRIPTION
### Description

This is a follow-on to #392 to completely implement the changes needed as a result of https://github.com/dbt-labs/dbt-core/pull/7545

Previously, I had only given guidance that `DatabricksConnectionManager.execute()` was the only place where limit should be added. 

However, TIL that dbt-databricks overrides dbt-core's [`BaseAdapter.execute()`](https://github.com/dbt-labs/dbt-core/blob/main/core/dbt/adapters/base/impl.py#L275-L290), therefore that function signature must also be updated. This was a miss on my part, because AFAIK, dbt-databricks is the only adapter doing this. I updated https://github.com/dbt-labs/dbt-core/discussions/7958 to reflect this information.


Perhaps there's a follow-up item where can revisit the use case of overriding that method and if there's an alternative way to handle `__tmp` tables.

### Checklist

- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
