### PR TITLE
Liquid Clustering config for table materialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 - Fix issue where the show tables extended command is limited to 2048 characters. ([#326](https://github.com/databricks/dbt-databricks/pull/326))
 - Extend python model support to cover the same config options as SQL ([#379](https://github.com/databricks/dbt-databricks/pull/379))
 
+### Features
+
+- Add `liquid_clustered_by` config to enable Liquid Clustering for Delta-based dbt models.
+
 ## dbt-databricks 1.5.5 (July 7, 2023)
 
 ### Fixes

--- a/dbt/adapters/databricks/impl.py
+++ b/dbt/adapters/databricks/impl.py
@@ -66,6 +66,7 @@ class DatabricksConfig(AdapterConfig):
     location_root: Optional[str] = None
     partition_by: Optional[Union[List[str], str]] = None
     clustered_by: Optional[Union[List[str], str]] = None
+    liquid_clustered_by: Optional[Union[List[str], str]] = None
     buckets: Optional[int] = None
     options: Optional[Dict[str, str]] = None
     merge_update_columns: Optional[str] = None

--- a/dbt/include/databricks/macros/adapters.sql
+++ b/dbt/include/databricks/macros/adapters.sql
@@ -43,6 +43,25 @@
   {%- endif %}
 {%- endmacro -%}
 
+{% macro liquid_clustered_cols(label, required=false) -%}
+  {{ return(adapter.dispatch('liquid_clustered_cols', 'dbt')(label, required)) }}
+{%- endmacro -%}
+
+{% macro databricks__liquid_clustered_cols(label, required=false) -%}
+  {%- set cols = config.get('liquid_clustered_by', validator=validation.any[list, basestring]) -%}
+  {%- if cols is not none %}
+    {%- if cols is string -%}
+      {%- set cols = [cols] -%}
+    {%- endif -%}
+    {{ label }} (
+    {%- for item in cols -%}
+      {{ item }}
+      {%- if not loop.last -%},{%- endif -%}
+    {%- endfor -%}
+    )
+  {%- endif %}
+{%- endmacro -%}
+
 
 {% macro databricks__create_table_as(temporary, relation, compiled_code, language='sql') -%}
   {%- if language == 'sql' -%}
@@ -62,6 +81,7 @@
       {{ file_format_clause() }}
       {{ options_clause() }}
       {{ partition_cols(label="partitioned by") }}
+      {{ liquid_clustered_cols(label="cluster by") }}
       {{ clustered_cols(label="clustered by") }}
       {{ location_clause() }}
       {{ comment_clause() }}

--- a/dbt/include/databricks/macros/python.sql
+++ b/dbt/include/databricks/macros/python.sql
@@ -47,6 +47,7 @@ writer.saveAsTable("{{ target_relation }}")
 {%- set location_root = config.get('location_root', validator=validation.any[basestring]) -%}
 {%- set file_format = config.get('file_format', validator=validation.any[basestring])|default('delta', true) -%}
 {%- set partition_by = config.get('partition_by', validator=validation.any[list, basestring]) -%}
+{%- set liquid_clustered_by = config.get('liquid_clustered_by', validator=validation.any[list, basestring]) -%}
 {%- set clustered_by = config.get('clustered_by', validator=validation.any[list, basestring]) -%}
 {%- set buckets = config.get('buckets', validator=validation.any[int]) -%}
 .format("{{ file_format }}")
@@ -59,6 +60,9 @@ writer.saveAsTable("{{ target_relation }}")
         {%- set partition_by = [partition_by] -%}
     {%- endif %}
 .partitionBy({{ partition_by }})
+{%- endif -%}
+{%- if liquid_clustered_by is not none -%}
+    {% log("`liquid_clustered_by` is only supported in `sql` language. Ignoring liquid clustering...", True) %}
 {%- endif -%}
 {%- if (clustered_by is not none) and (buckets is not none) -%}
     {%- if clustered_by is string -%}

--- a/dbt/include/databricks/macros/python.sql
+++ b/dbt/include/databricks/macros/python.sql
@@ -47,7 +47,6 @@ writer.saveAsTable("{{ target_relation }}")
 {%- set location_root = config.get('location_root', validator=validation.any[basestring]) -%}
 {%- set file_format = config.get('file_format', validator=validation.any[basestring])|default('delta', true) -%}
 {%- set partition_by = config.get('partition_by', validator=validation.any[list, basestring]) -%}
-{%- set liquid_clustered_by = config.get('liquid_clustered_by', validator=validation.any[list, basestring]) -%}
 {%- set clustered_by = config.get('clustered_by', validator=validation.any[list, basestring]) -%}
 {%- set buckets = config.get('buckets', validator=validation.any[int]) -%}
 .format("{{ file_format }}")
@@ -60,9 +59,6 @@ writer.saveAsTable("{{ target_relation }}")
         {%- set partition_by = [partition_by] -%}
     {%- endif %}
 .partitionBy({{ partition_by }})
-{%- endif -%}
-{%- if liquid_clustered_by is not none -%}
-    {% log("`liquid_clustered_by` is only supported in `sql` language. Ignoring liquid clustering...", True) %}
 {%- endif -%}
 {%- if (clustered_by is not none) and (buckets is not none) -%}
     {%- if clustered_by is string -%}

--- a/tests/unit/macros/test_adapters_macros.py
+++ b/tests/unit/macros/test_adapters_macros.py
@@ -8,9 +8,7 @@ class TestAdaptersMacros(TestMacros):
         super().setUp()
         self.template = self._get_template("adapters.sql")
 
-    def _render_create_table_as(
-        self, relation="my_table", temporary=False, sql="select 1"
-    ):
+    def _render_create_table_as(self, relation="my_table", temporary=False, sql="select 1"):
         self.default_context["model"].alias = relation
 
         return self._run_macro("databricks__create_table_as", temporary, relation, sql)
@@ -20,9 +18,7 @@ class TestSparkMacros(TestAdaptersMacros):
     def test_macros_create_table_as(self):
         sql = self._render_create_table_as()
 
-        self.assertEqual(
-            sql, "create or replace table my_table using delta as select 1"
-        )
+        self.assertEqual(sql, "create or replace table my_table using delta as select 1")
 
     def test_macros_create_table_as_file_format(self):
         for format in ["parquet", "hudi"]:
@@ -115,8 +111,7 @@ class TestSparkMacros(TestAdaptersMacros):
 
         self.assertEqual(
             sql,
-            "create or replace table my_table "
-            "using delta cluster by (cluster_1) as select 1",
+            "create or replace table my_table " "using delta cluster by (cluster_1) as select 1",
         )
 
     def test_macros_create_table_as_liquid_clusters(self):
@@ -262,11 +257,7 @@ class TestDatabricksMacros(TestAdaptersMacros):
 
         self.assertEqual(
             sql,
-            (
-                "optimize "
-                "`some_database`.`some_schema`.`some_table` "
-                "zorder by (foo)"
-            ),
+            ("optimize " "`some_database`.`some_schema`.`some_table` " "zorder by (foo)"),
         )
 
     def test_macro_get_optimize_sql_multiple_args(self):
@@ -275,11 +266,7 @@ class TestDatabricksMacros(TestAdaptersMacros):
 
         self.assertEqual(
             sql,
-            (
-                "optimize "
-                "`some_database`.`some_schema`.`some_table` "
-                "zorder by (foo, bar)"
-            ),
+            ("optimize " "`some_database`.`some_schema`.`some_table` " "zorder by (foo, bar)"),
         )
 
     def test_macros_optimize_with_extraneous_info(self):
@@ -313,9 +300,7 @@ class TestDatabricksMacros(TestAdaptersMacros):
         constraint = {"name": "name", "condition": "id > 0"}
         r = self.__render_constraints([constraint])
 
-        self.assertEquals(
-            r, "[{'name': 'name', 'type': 'check', 'expression': 'id > 0'}]"
-        )
+        self.assertEquals(r, "[{'name': 'name', 'type': 'check', 'expression': 'id > 0'}]")
 
     def test_macros_databricks_constraints_missing_name(self):
         constraint = {"condition": "id > 0"}
@@ -333,9 +318,7 @@ class TestDatabricksMacros(TestAdaptersMacros):
         constraint = {"type": "check", "name": "name", "expression": "id > 0"}
         r = self.__render_constraints([constraint])
 
-        self.assertEquals(
-            r, "[{'type': 'check', 'name': 'name', 'expression': 'id > 0'}]"
-        )
+        self.assertEquals(r, "[{'type': 'check', 'name': 'name', 'expression': 'id > 0'}]")
 
     def test_macros_databricks_constraints_with_column_missing_expression(self):
         column = {"name": "col"}
@@ -348,9 +331,7 @@ class TestDatabricksMacros(TestAdaptersMacros):
         constraint = {"type": "check", "name": "name", "expression": "id > 0"}
         r = self.__render_constraints([constraint], column)
 
-        self.assertEquals(
-            r, "[{'type': 'check', 'name': 'name', 'expression': 'id > 0'}]"
-        )
+        self.assertEquals(r, "[{'type': 'check', 'name': 'name', 'expression': 'id > 0'}]")
 
     def test_macros_databricks_constraints_with_column_not_null(self):
         column = {"name": "col"}
@@ -474,23 +455,23 @@ class TestDatabricksMacros(TestAdaptersMacros):
 
     def test_macros_get_constraint_sql_not_null_with_columns(self):
         model = self.__model()
-        r = self.__render_constraint_sql(
-            {"type": "not_null", "columns": ["id", "name"]}, model
-        )
-        expected = "['alter table `some_database`.`some_schema`.`some_table` change column id " \
-                   "set not null ;', 'alter table `some_database`.`some_schema`.`some_table` " \
-                   "change column name set not null ;']"  # noqa: E501
+        r = self.__render_constraint_sql({"type": "not_null", "columns": ["id", "name"]}, model)
+        expected = (
+            "['alter table `some_database`.`some_schema`.`some_table` change column id "
+            "set not null ;', 'alter table `some_database`.`some_schema`.`some_table` "
+            "change column name set not null ;']"
+        )  # noqa: E501
 
         assert expected in r
 
     def test_macros_get_constraint_sql_not_null_with_column(self):
         model = self.__model()
-        r = self.__render_constraint_sql(
-            {"type": "not_null"}, model, model["columns"]["id"]
-        )
+        r = self.__render_constraint_sql({"type": "not_null"}, model, model["columns"]["id"])
 
-        expected = "['alter table `some_database`.`some_schema`.`some_table` change column id " \
-                   "set not null ;']"  # noqa: E501
+        expected = (
+            "['alter table `some_database`.`some_schema`.`some_table` change column id "
+            "set not null ;']"
+        )  # noqa: E501
         assert expected in r
 
     def test_macros_get_constraint_sql_not_null_mismatched_columns(self):
@@ -499,8 +480,10 @@ class TestDatabricksMacros(TestAdaptersMacros):
             {"type": "not_null", "columns": ["name"]}, model, model["columns"]["id"]
         )
 
-        expected = "['alter table `some_database`.`some_schema`.`some_table` change column name " \
-                   "set not null ;']"  # noqa: E501
+        expected = (
+            "['alter table `some_database`.`some_schema`.`some_table` change column name "
+            "set not null ;']"
+        )  # noqa: E501
         assert expected in r
 
     def test_macros_get_constraint_sql_check(self):
@@ -513,8 +496,10 @@ class TestDatabricksMacros(TestAdaptersMacros):
         }
         r = self.__render_constraint_sql(constraint, model)
 
-        expected = "['alter table `some_database`.`some_schema`.`some_table` add constraint " \
-                   "myconstraint check (id != name);']"  # noqa: E501
+        expected = (
+            "['alter table `some_database`.`some_schema`.`some_table` add constraint "
+            "myconstraint check (id != name);']"
+        )  # noqa: E501
         assert expected in r
 
     def test_macros_get_constraint_sql_check_named_constraint(self):
@@ -526,8 +511,10 @@ class TestDatabricksMacros(TestAdaptersMacros):
         }
         r = self.__render_constraint_sql(constraint, model)
 
-        expected = "['alter table `some_database`.`some_schema`.`some_table` add constraint " \
-                   "myconstraint check (id != name);']"  # noqa: E501
+        expected = (
+            "['alter table `some_database`.`some_schema`.`some_table` add constraint "
+            "myconstraint check (id != name);']"
+        )  # noqa: E501
         assert expected in r
 
     def test_macros_get_constraint_sql_check_none_constraint(self):
@@ -538,8 +525,10 @@ class TestDatabricksMacros(TestAdaptersMacros):
         }
         r = self.__render_constraint_sql(constraint, model)
 
-        expected = "['alter table `some_database`.`some_schema`.`some_table` add constraint None " \
-                   "check (id != name);']"  # noqa: E501
+        expected = (
+            "['alter table `some_database`.`some_schema`.`some_table` add constraint None "
+            "check (id != name);']"
+        )  # noqa: E501
         assert expected in r
 
     def test_macros_get_constraint_sql_check_missing_expression(self):
@@ -561,8 +550,10 @@ class TestDatabricksMacros(TestAdaptersMacros):
         }
         r = self.__render_constraint_sql(constraint, model)
 
-        expected = "['alter table `some_database`.`some_schema`.`some_table` add constraint " \
-                   "myconstraint primary key(name);']"  # noqa: E501
+        expected = (
+            "['alter table `some_database`.`some_schema`.`some_table` add constraint "
+            "myconstraint primary key(name);']"
+        )  # noqa: E501
         assert expected in r
 
     def test_macros_get_constraint_sql_primary_key_with_specified_column(self):
@@ -575,8 +566,10 @@ class TestDatabricksMacros(TestAdaptersMacros):
         column = {"name": "id"}
         r = self.__render_constraint_sql(constraint, model, column)
 
-        expected = "['alter table `some_database`.`some_schema`.`some_table` add constraint " \
-                   "myconstraint primary key(name);']"  # noqa: E501
+        expected = (
+            "['alter table `some_database`.`some_schema`.`some_table` add constraint "
+            "myconstraint primary key(name);']"
+        )  # noqa: E501
         assert expected in r
 
     def test_macros_get_constraint_sql_primary_key_with_name(self):
@@ -588,8 +581,10 @@ class TestDatabricksMacros(TestAdaptersMacros):
         column = {"name": "id"}
         r = self.__render_constraint_sql(constraint, model, column)
 
-        expected = "['alter table `some_database`.`some_schema`.`some_table` add constraint " \
-                   "myconstraint primary key(id);']"  # noqa: E501
+        expected = (
+            "['alter table `some_database`.`some_schema`.`some_table` add constraint "
+            "myconstraint primary key(id);']"
+        )  # noqa: E501
         assert expected in r
 
     def test_macros_get_constraint_sql_foreign_key(self):
@@ -602,9 +597,11 @@ class TestDatabricksMacros(TestAdaptersMacros):
         }
         r = self.__render_constraint_sql(constraint, model)
 
-        expected = "['alter table `some_database`.`some_schema`.`some_table` add " \
-                   "constraint myconstraint foreign key(name) references " \
-                   "some_schema.parent_table;']"  # noqa: E501
+        expected = (
+            "['alter table `some_database`.`some_schema`.`some_table` add "
+            "constraint myconstraint foreign key(name) references "
+            "some_schema.parent_table;']"
+        )  # noqa: E501
         assert expected in r
 
     def test_macros_get_constraint_sql_foreign_key_parent_column(self):
@@ -618,9 +615,11 @@ class TestDatabricksMacros(TestAdaptersMacros):
         }
         r = self.__render_constraint_sql(constraint, model)
 
-        expected = "['alter table `some_database`.`some_schema`.`some_table` add " \
-                   "constraint myconstraint foreign key(name) references " \
-                   "some_schema.parent_table(parent_name);']"  # noqa: E501
+        expected = (
+            "['alter table `some_database`.`some_schema`.`some_table` add "
+            "constraint myconstraint foreign key(name) references "
+            "some_schema.parent_table(parent_name);']"
+        )  # noqa: E501
         assert expected in r
 
     def test_macros_get_constraint_sql_foreign_key_multiple_columns(self):
@@ -634,9 +633,11 @@ class TestDatabricksMacros(TestAdaptersMacros):
         }
         r = self.__render_constraint_sql(constraint, model)
 
-        expected = "['alter table `some_database`.`some_schema`.`some_table` add constraint " \
-                   "myconstraint foreign key(name, id) " \
-                   "references some_schema.parent_table(parent_name, parent_id);']"  # noqa: E501
+        expected = (
+            "['alter table `some_database`.`some_schema`.`some_table` add constraint "
+            "myconstraint foreign key(name, id) "
+            "references some_schema.parent_table(parent_name, parent_id);']"
+        )  # noqa: E501
         assert expected in r
 
     def test_macros_get_constraint_sql_foreign_key_columns_supplied_separately(self):
@@ -650,7 +651,9 @@ class TestDatabricksMacros(TestAdaptersMacros):
         column = {"name": "id"}
         r = self.__render_constraint_sql(constraint, model, column)
 
-        expected = "['alter table `some_database`.`some_schema`.`some_table` add constraint " \
-                   "myconstraint foreign key(id) references " \
-                   "some_schema.parent_table(parent_name);']"  # noqa: E501
+        expected = (
+            "['alter table `some_database`.`some_schema`.`some_table` add constraint "
+            "myconstraint foreign key(id) references "
+            "some_schema.parent_table(parent_name);']"
+        )  # noqa: E501
         assert expected in r

--- a/tests/unit/macros/test_adapters_macros.py
+++ b/tests/unit/macros/test_adapters_macros.py
@@ -8,7 +8,9 @@ class TestAdaptersMacros(TestMacros):
         super().setUp()
         self.template = self._get_template("adapters.sql")
 
-    def _render_create_table_as(self, relation="my_table", temporary=False, sql="select 1"):
+    def _render_create_table_as(
+        self, relation="my_table", temporary=False, sql="select 1"
+    ):
         self.default_context["model"].alias = relation
 
         return self._run_macro("databricks__create_table_as", temporary, relation, sql)
@@ -18,7 +20,9 @@ class TestSparkMacros(TestAdaptersMacros):
     def test_macros_create_table_as(self):
         sql = self._render_create_table_as()
 
-        self.assertEqual(sql, "create or replace table my_table using delta as select 1")
+        self.assertEqual(
+            sql, "create or replace table my_table using delta as select 1"
+        )
 
     def test_macros_create_table_as_file_format(self):
         for format in ["parquet", "hudi"]:
@@ -176,7 +180,7 @@ class TestSparkMacros(TestAdaptersMacros):
             "create or replace table my_table "
             "using delta "
             "partitioned by (partition_1,partition_2) "
-            "cluster by (cluster_1,cluster_2)"
+            "cluster by (cluster_1,cluster_2) "
             "clustered by (cluster_1,cluster_2) into 1 buckets "
             "location '/mnt/root/my_table' "
             "comment 'Description Test' "
@@ -258,7 +262,11 @@ class TestDatabricksMacros(TestAdaptersMacros):
 
         self.assertEqual(
             sql,
-            ("optimize " "`some_database`.`some_schema`.`some_table` " "zorder by (foo)"),
+            (
+                "optimize "
+                "`some_database`.`some_schema`.`some_table` "
+                "zorder by (foo)"
+            ),
         )
 
     def test_macro_get_optimize_sql_multiple_args(self):
@@ -267,7 +275,11 @@ class TestDatabricksMacros(TestAdaptersMacros):
 
         self.assertEqual(
             sql,
-            ("optimize " "`some_database`.`some_schema`.`some_table` " "zorder by (foo, bar)"),
+            (
+                "optimize "
+                "`some_database`.`some_schema`.`some_table` "
+                "zorder by (foo, bar)"
+            ),
         )
 
     def test_macros_optimize_with_extraneous_info(self):
@@ -301,7 +313,9 @@ class TestDatabricksMacros(TestAdaptersMacros):
         constraint = {"name": "name", "condition": "id > 0"}
         r = self.__render_constraints([constraint])
 
-        self.assertEquals(r, "[{'name': 'name', 'type': 'check', 'expression': 'id > 0'}]")
+        self.assertEquals(
+            r, "[{'name': 'name', 'type': 'check', 'expression': 'id > 0'}]"
+        )
 
     def test_macros_databricks_constraints_missing_name(self):
         constraint = {"condition": "id > 0"}
@@ -319,7 +333,9 @@ class TestDatabricksMacros(TestAdaptersMacros):
         constraint = {"type": "check", "name": "name", "expression": "id > 0"}
         r = self.__render_constraints([constraint])
 
-        self.assertEquals(r, "[{'type': 'check', 'name': 'name', 'expression': 'id > 0'}]")
+        self.assertEquals(
+            r, "[{'type': 'check', 'name': 'name', 'expression': 'id > 0'}]"
+        )
 
     def test_macros_databricks_constraints_with_column_missing_expression(self):
         column = {"name": "col"}
@@ -332,7 +348,9 @@ class TestDatabricksMacros(TestAdaptersMacros):
         constraint = {"type": "check", "name": "name", "expression": "id > 0"}
         r = self.__render_constraints([constraint], column)
 
-        self.assertEquals(r, "[{'type': 'check', 'name': 'name', 'expression': 'id > 0'}]")
+        self.assertEquals(
+            r, "[{'type': 'check', 'name': 'name', 'expression': 'id > 0'}]"
+        )
 
     def test_macros_databricks_constraints_with_column_not_null(self):
         column = {"name": "col"}
@@ -456,14 +474,18 @@ class TestDatabricksMacros(TestAdaptersMacros):
 
     def test_macros_get_constraint_sql_not_null_with_columns(self):
         model = self.__model()
-        r = self.__render_constraint_sql({"type": "not_null", "columns": ["id", "name"]}, model)
+        r = self.__render_constraint_sql(
+            {"type": "not_null", "columns": ["id", "name"]}, model
+        )
         expected = "['alter table `some_database`.`some_schema`.`some_table` change column id set not null ;', 'alter table `some_database`.`some_schema`.`some_table` change column name set not null ;']"  # noqa: E501
 
         assert expected in r
 
     def test_macros_get_constraint_sql_not_null_with_column(self):
         model = self.__model()
-        r = self.__render_constraint_sql({"type": "not_null"}, model, model["columns"]["id"])
+        r = self.__render_constraint_sql(
+            {"type": "not_null"}, model, model["columns"]["id"]
+        )
 
         expected = "['alter table `some_database`.`some_schema`.`some_table` change column id set not null ;']"  # noqa: E501
         assert expected in r

--- a/tests/unit/macros/test_adapters_macros.py
+++ b/tests/unit/macros/test_adapters_macros.py
@@ -477,7 +477,9 @@ class TestDatabricksMacros(TestAdaptersMacros):
         r = self.__render_constraint_sql(
             {"type": "not_null", "columns": ["id", "name"]}, model
         )
-        expected = "['alter table `some_database`.`some_schema`.`some_table` change column id set not null ;', 'alter table `some_database`.`some_schema`.`some_table` change column name set not null ;']"  # noqa: E501
+        expected = "['alter table `some_database`.`some_schema`.`some_table` change column id " \
+                   "set not null ;', 'alter table `some_database`.`some_schema`.`some_table` " \
+                   "change column name set not null ;']"  # noqa: E501
 
         assert expected in r
 
@@ -487,7 +489,8 @@ class TestDatabricksMacros(TestAdaptersMacros):
             {"type": "not_null"}, model, model["columns"]["id"]
         )
 
-        expected = "['alter table `some_database`.`some_schema`.`some_table` change column id set not null ;']"  # noqa: E501
+        expected = "['alter table `some_database`.`some_schema`.`some_table` change column id " \
+                   "set not null ;']"  # noqa: E501
         assert expected in r
 
     def test_macros_get_constraint_sql_not_null_mismatched_columns(self):
@@ -496,7 +499,8 @@ class TestDatabricksMacros(TestAdaptersMacros):
             {"type": "not_null", "columns": ["name"]}, model, model["columns"]["id"]
         )
 
-        expected = "['alter table `some_database`.`some_schema`.`some_table` change column name set not null ;']"  # noqa: E501
+        expected = "['alter table `some_database`.`some_schema`.`some_table` change column name " \
+                   "set not null ;']"  # noqa: E501
         assert expected in r
 
     def test_macros_get_constraint_sql_check(self):
@@ -509,7 +513,8 @@ class TestDatabricksMacros(TestAdaptersMacros):
         }
         r = self.__render_constraint_sql(constraint, model)
 
-        expected = "['alter table `some_database`.`some_schema`.`some_table` add constraint myconstraint check (id != name);']"  # noqa: E501
+        expected = "['alter table `some_database`.`some_schema`.`some_table` add constraint " \
+                   "myconstraint check (id != name);']"  # noqa: E501
         assert expected in r
 
     def test_macros_get_constraint_sql_check_named_constraint(self):
@@ -521,7 +526,8 @@ class TestDatabricksMacros(TestAdaptersMacros):
         }
         r = self.__render_constraint_sql(constraint, model)
 
-        expected = "['alter table `some_database`.`some_schema`.`some_table` add constraint myconstraint check (id != name);']"  # noqa: E501
+        expected = "['alter table `some_database`.`some_schema`.`some_table` add constraint " \
+                   "myconstraint check (id != name);']"  # noqa: E501
         assert expected in r
 
     def test_macros_get_constraint_sql_check_none_constraint(self):
@@ -532,7 +538,8 @@ class TestDatabricksMacros(TestAdaptersMacros):
         }
         r = self.__render_constraint_sql(constraint, model)
 
-        expected = "['alter table `some_database`.`some_schema`.`some_table` add constraint None check (id != name);']"  # noqa: E501
+        expected = "['alter table `some_database`.`some_schema`.`some_table` add constraint None " \
+                   "check (id != name);']"  # noqa: E501
         assert expected in r
 
     def test_macros_get_constraint_sql_check_missing_expression(self):
@@ -554,7 +561,8 @@ class TestDatabricksMacros(TestAdaptersMacros):
         }
         r = self.__render_constraint_sql(constraint, model)
 
-        expected = "['alter table `some_database`.`some_schema`.`some_table` add constraint myconstraint primary key(name);']"  # noqa: E501
+        expected = "['alter table `some_database`.`some_schema`.`some_table` add constraint " \
+                   "myconstraint primary key(name);']"  # noqa: E501
         assert expected in r
 
     def test_macros_get_constraint_sql_primary_key_with_specified_column(self):
@@ -567,7 +575,8 @@ class TestDatabricksMacros(TestAdaptersMacros):
         column = {"name": "id"}
         r = self.__render_constraint_sql(constraint, model, column)
 
-        expected = "['alter table `some_database`.`some_schema`.`some_table` add constraint myconstraint primary key(name);']"  # noqa: E501
+        expected = "['alter table `some_database`.`some_schema`.`some_table` add constraint " \
+                   "myconstraint primary key(name);']"  # noqa: E501
         assert expected in r
 
     def test_macros_get_constraint_sql_primary_key_with_name(self):
@@ -579,7 +588,8 @@ class TestDatabricksMacros(TestAdaptersMacros):
         column = {"name": "id"}
         r = self.__render_constraint_sql(constraint, model, column)
 
-        expected = "['alter table `some_database`.`some_schema`.`some_table` add constraint myconstraint primary key(id);']"  # noqa: E501
+        expected = "['alter table `some_database`.`some_schema`.`some_table` add constraint " \
+                   "myconstraint primary key(id);']"  # noqa: E501
         assert expected in r
 
     def test_macros_get_constraint_sql_foreign_key(self):
@@ -592,7 +602,9 @@ class TestDatabricksMacros(TestAdaptersMacros):
         }
         r = self.__render_constraint_sql(constraint, model)
 
-        expected = "['alter table `some_database`.`some_schema`.`some_table` add constraint myconstraint foreign key(name) references some_schema.parent_table;']"  # noqa: E501
+        expected = "['alter table `some_database`.`some_schema`.`some_table` add " \
+                   "constraint myconstraint foreign key(name) references " \
+                   "some_schema.parent_table;']"  # noqa: E501
         assert expected in r
 
     def test_macros_get_constraint_sql_foreign_key_parent_column(self):
@@ -606,7 +618,9 @@ class TestDatabricksMacros(TestAdaptersMacros):
         }
         r = self.__render_constraint_sql(constraint, model)
 
-        expected = "['alter table `some_database`.`some_schema`.`some_table` add constraint myconstraint foreign key(name) references some_schema.parent_table(parent_name);']"  # noqa: E501
+        expected = "['alter table `some_database`.`some_schema`.`some_table` add " \
+                   "constraint myconstraint foreign key(name) references " \
+                   "some_schema.parent_table(parent_name);']"  # noqa: E501
         assert expected in r
 
     def test_macros_get_constraint_sql_foreign_key_multiple_columns(self):
@@ -620,7 +634,9 @@ class TestDatabricksMacros(TestAdaptersMacros):
         }
         r = self.__render_constraint_sql(constraint, model)
 
-        expected = "['alter table `some_database`.`some_schema`.`some_table` add constraint myconstraint foreign key(name, id) references some_schema.parent_table(parent_name, parent_id);']"  # noqa: E501
+        expected = "['alter table `some_database`.`some_schema`.`some_table` add constraint " \
+                   "myconstraint foreign key(name, id) " \
+                   "references some_schema.parent_table(parent_name, parent_id);']"  # noqa: E501
         assert expected in r
 
     def test_macros_get_constraint_sql_foreign_key_columns_supplied_separately(self):
@@ -634,5 +650,7 @@ class TestDatabricksMacros(TestAdaptersMacros):
         column = {"name": "id"}
         r = self.__render_constraint_sql(constraint, model, column)
 
-        expected = "['alter table `some_database`.`some_schema`.`some_table` add constraint myconstraint foreign key(id) references some_schema.parent_table(parent_name);']"  # noqa: E501
+        expected = "['alter table `some_database`.`some_schema`.`some_table` add constraint " \
+                   "myconstraint foreign key(id) references " \
+                   "some_schema.parent_table(parent_name);']"  # noqa: E501
         assert expected in r

--- a/tests/unit/macros/test_adapters_macros.py
+++ b/tests/unit/macros/test_adapters_macros.py
@@ -105,6 +105,27 @@ class TestSparkMacros(TestAdaptersMacros):
             "using delta clustered by (cluster_1,cluster_2) into 1 buckets as select 1",
         )
 
+    def test_macros_create_table_as_liquid_cluster(self):
+        self.config["liquid_clustered_by"] = "cluster_1"
+        sql = self._render_create_table_as()
+
+        self.assertEqual(
+            sql,
+            "create or replace table my_table "
+            "using delta cluster by (cluster_1) as select 1",
+        )
+
+    def test_macros_create_table_as_liquid_clusters(self):
+        self.config["liquid_clustered_by"] = ["cluster_1", "cluster_2"]
+        self.config["buckets"] = "1"
+        sql = self._render_create_table_as()
+
+        self.assertEqual(
+            sql,
+            "create or replace table my_table "
+            "using delta cluster by (cluster_1,cluster_2) as select 1",
+        )
+
     def test_macros_create_table_as_location(self):
         self.config["location_root"] = "/mnt/root"
         sql = self._render_create_table_as()
@@ -140,6 +161,7 @@ class TestSparkMacros(TestAdaptersMacros):
     def test_macros_create_table_as_all_delta(self):
         self.config["location_root"] = "/mnt/root"
         self.config["partition_by"] = ["partition_1", "partition_2"]
+        self.config["liquid_clustered_by"] = ["cluster_1", "cluster_2"]
         self.config["clustered_by"] = ["cluster_1", "cluster_2"]
         self.config["buckets"] = "1"
         self.config["persist_docs"] = {"relation": True}
@@ -154,6 +176,7 @@ class TestSparkMacros(TestAdaptersMacros):
             "create or replace table my_table "
             "using delta "
             "partitioned by (partition_1,partition_2) "
+            "cluster by (cluster_1,cluster_2)"
             "clustered by (cluster_1,cluster_2) into 1 buckets "
             "location '/mnt/root/my_table' "
             "comment 'Description Test' "


### PR DESCRIPTION
<!-- Please review our pull request review process in CONTRIBUTING.md before your proceed. -->
<!---
  Include the number of the issue addressed by this PR above if applicable.
  
  Example:
    resolves #1234

  Please review our pull request review process in CONTRIBUTING.md before your proceed.
-->

Resolves https://github.com/databricks/dbt-databricks/issues/399

### Description

With this change, dbt user could supply `liquid_clustered_by` model config with column (or list of columns) to be used as clustering keys using **Liquid Clustering** feature of Delta. The change introduces a small change in DDL query, while it does nothing for `python`-based models (as I couldn't find the python API for **Liquid Clustering**).

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
