### PR TITLE
Patching external location support in python models

### DIFF
--- a/dbt/adapters/databricks/impl.py
+++ b/dbt/adapters/databricks/impl.py
@@ -145,7 +145,7 @@ class DatabricksAdapter(SparkAdapter):
                 identifier=name,
                 type=self.Relation.get_relation_type(kind),
             )
-            for database, schema, name, kind in results.select(
+            for database, schema, name, kind in results.select(  # type: ignore[attr-defined]
                 ["database_name", "schema_name", "name", "kind"]
             )
         ]
@@ -154,10 +154,11 @@ class DatabricksAdapter(SparkAdapter):
         self, schema_relation: DatabricksRelation
     ) -> List[Tuple[DatabricksRelation, str]]:
         kwargs = {"schema_relation": schema_relation}
+        results: List[Row]
         try:
             # The catalog for `show table extended` needs to match the current catalog.
             with self._catalog(schema_relation.database):
-                results = self.execute_macro(SHOW_TABLE_EXTENDED_MACRO_NAME, kwargs=kwargs)
+                results = list(self.execute_macro(SHOW_TABLE_EXTENDED_MACRO_NAME, kwargs=kwargs))
         except dbt.exceptions.DbtRuntimeError as e:
             errmsg = getattr(e, "msg", "")
             if check_not_found_error(errmsg):
@@ -212,7 +213,7 @@ class DatabricksAdapter(SparkAdapter):
             with self._catalog(relation.database):
                 views = self.execute_macro(SHOW_VIEWS_MACRO_NAME, kwargs=kwargs)
 
-            view_names = set(views.columns["viewName"].values())
+            view_names = set(views.columns["viewName"].values())  # type: ignore[attr-defined]
             new_rows = [
                 (
                     row[0],
@@ -285,8 +286,10 @@ class DatabricksAdapter(SparkAdapter):
         self, relation: DatabricksRelation
     ) -> Tuple[DatabricksRelation, List[DatabricksColumn]]:
         try:
-            rows = self.execute_macro(
-                GET_COLUMNS_IN_RELATION_RAW_MACRO_NAME, kwargs={"relation": relation}
+            rows: List[Row] = list(
+                self.execute_macro(
+                    GET_COLUMNS_IN_RELATION_RAW_MACRO_NAME, kwargs={"relation": relation}
+                )
             )
             metadata, columns = self.parse_describe_extended(relation, rows)
         except dbt.exceptions.DbtRuntimeError as e:

--- a/dbt/include/databricks/macros/python.sql
+++ b/dbt/include/databricks/macros/python.sql
@@ -52,6 +52,9 @@ writer.saveAsTable("{{ target_relation }}")
 .format("{{ file_format }}")
 {%- if location_root is not none %}
 {%- set identifier = model['alias'] %}
+{%- if is_incremental() %}
+{%- set identifier = identifier + '_incremental' %}
+{%- endif %}
 .option("path", "{{ location_root }}/{{ identifier }}")
 {%- endif -%}
 {%- if partition_by is not none -%}

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
         "databricks-sql-connector~=2.7.0",
         "databricks-sdk==0.1.7",
         "keyring>=23.13.0",
-        "protobuf>=4.21.0" # workaround for dbt-core issue
+        "protobuf>=4.21.0",  # workaround for dbt-core issue
     ],
     zip_safe=False,
     classifiers=[

--- a/tests/unit/macros/test_python_macros.py
+++ b/tests/unit/macros/test_python_macros.py
@@ -26,9 +26,7 @@ class TestPythonMacros(TestMacros):
         self.default_context["is_incremental"] = MagicMock(return_value=True)
         result = self._run_macro_raw("py_get_writer_options")
 
-        expected = (
-            '.format("delta")\n.option("path", "s3://fake_location/schema_incremental")'
-        )
+        expected = '.format("delta")\n.option("path", "s3://fake_location/schema_incremental")'
         self.assertEqual(result, expected)
 
     def test_py_get_writer__partition_by_single_column(self):

--- a/tests/unit/macros/test_python_macros.py
+++ b/tests/unit/macros/test_python_macros.py
@@ -23,9 +23,12 @@ class TestPythonMacros(TestMacros):
         self.config["location_root"] = "s3://fake_location"
         d = {"alias": "schema"}
         self.default_context["model"].__getitem__.side_effect = d.__getitem__
+        self.default_context["is_incremental"] = MagicMock(return_value=True)
         result = self._run_macro_raw("py_get_writer_options")
 
-        expected = '.format("delta")\n.option("path", "s3://fake_location/schema")'
+        expected = (
+            '.format("delta")\n.option("path", "s3://fake_location/schema_incremental")'
+        )
         self.assertEqual(result, expected)
 
     def test_py_get_writer__partition_by_single_column(self):


### PR DESCRIPTION
<!-- Please review our pull request review process in CONTRIBUTING.md before your proceed. -->
<!---
  Include the number of the issue addressed by this PR above if applicable.
  
  Example:
    resolves #1234

  Please review our pull request review process in CONTRIBUTING.md before your proceed.
-->

### Description

<!--- Describe the Pull Request here -->
Fixes issues where incremental + external_location would complain about location overlap on incremental runs.  It does this by writing the temp tables to their own folder.  Note: since Databricks does not delete files in external locations when relations are dropped, owners will need to manage these folders themselves.

This support is experimental.

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.

I have tested manually since we are still working on test infrastructure to run integration tests against external locations in github.  My manual tests involved two types of tests:
1.) verify that we can run the same dbt command 3 times.  Why 3?  To make sure that we can create the incremental staging tables repeatedly without complaint about overlapping location.
2.) verify that when using python models, incremental, and external locations, we merge successive runs as expected.

I have not included the tests here as they are both hacky and incompatible with our current test environment, but have committed them locally for inclusion when our test environment is ready for external location testing.