### PR TITLE
Fix: revert #326 which breaks DESCRIBE table for some non Glue Catalog users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## dbt-databricks 1.6.x (Release TBD)
 
+## dbt-databricks 1.6.1 (August 2, 2023)
+
+### Fixes
+
+- Revert change from #326 as it breaks DESCRIBE table in cases where the dbt API key does not have access to all tables in the schema
+
 ## dbt-databricks 1.6.0 (August 2, 2023)
 
 ### Features

--- a/dbt/adapters/databricks/__version__.py
+++ b/dbt/adapters/databricks/__version__.py
@@ -1,1 +1,1 @@
-version: str = "1.6.0"
+version: str = "1.6.1"

--- a/dbt/adapters/databricks/impl.py
+++ b/dbt/adapters/databricks/impl.py
@@ -452,7 +452,7 @@ class DatabricksAdapter(SparkAdapter):
             schema_relation = self.Relation.create(
                 database=database,
                 schema=schema,
-                identifier=("|".join(table_names) if len("|".join(table_names)) < 2048 else "*"),
+                identifier="|".join(table_names),
                 quote_policy=self.config.quoting,
             )
             for relation, information in self._list_relations_with_information(schema_relation):


### PR DESCRIPTION
<!-- Please review our pull request review process in CONTRIBUTING.md before your proceed. -->

Resolves #403

<!---
  Include the number of the issue addressed by this PR above if applicable.
  
  Example:
    resolves #1234

  Please review our pull request review process in CONTRIBUTING.md before your proceed.
-->

### Description

The change from #326 targets AWS Glue Catalog users but is enabled by default for all users. We need to reimplement that fix behind an environment variable so that admins can enable that behaviour only in the cases where they know they need it and can take responsibility for table access permissions.

<!--- Describe the Pull Request here -->
Resolves 

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
