### PR TITLE
Improve python stacktrace rendering in dbt.log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## dbt-databricks 1.6.x (Release TBD)
 
+### Fixes
+
+- Improved legibility of python stack traces ([#434](https://github.com/databricks/dbt-databricks/pull/434)).
+
 ## dbt-databricks 1.6.2 (August 29, 2023)
 
 ### Features

--- a/dbt/adapters/databricks/python_submissions.py
+++ b/dbt/adapters/databricks/python_submissions.py
@@ -39,9 +39,7 @@ class BaseDatabricksHelper(PythonJobHelper):
 
     @property
     def cluster_id(self) -> str:
-        return self.parsed_model["config"].get(
-            "cluster_id", self.credentials.cluster_id
-        )
+        return self.parsed_model["config"].get("cluster_id", self.credentials.cluster_id)
 
     def get_timeout(self) -> int:
         timeout = self.parsed_model["config"].get("timeout", DEFAULT_TIMEOUT)
@@ -131,20 +129,15 @@ class BaseDatabricksHelper(PythonJobHelper):
                 "url": f"https://{self.credentials.host}/api/2.1/jobs/runs/get?run_id={run_id}",
                 "headers": self.auth_header,
             },
-            get_state_func=lambda response: response.json()["state"][
-                "life_cycle_state"
-            ],
+            get_state_func=lambda response: response.json()["state"]["life_cycle_state"],
             terminal_states=("TERMINATED", "SKIPPED", "INTERNAL_ERROR"),
             expected_end_state="TERMINATED",
-            get_state_msg_func=lambda response: response.json()["state"][
-                "state_message"
-            ],
+            get_state_msg_func=lambda response: response.json()["state"]["state_message"],
         )
 
         # get end state to return to user
         run_output = requests.get(
-            f"https://{self.credentials.host}"
-            f"/api/2.1/jobs/runs/get-output?run_id={run_id}",
+            f"https://{self.credentials.host}" f"/api/2.1/jobs/runs/get-output?run_id={run_id}",
             headers=self.auth_header,
         )
         json_run_output = run_output.json()
@@ -196,14 +189,10 @@ class BaseDatabricksHelper(PythonJobHelper):
 class JobClusterPythonJobHelper(BaseDatabricksHelper):
     def check_credentials(self) -> None:
         if not self.parsed_model["config"].get("job_cluster_config", None):
-            raise ValueError(
-                "job_cluster_config is required for commands submission method."
-            )
+            raise ValueError("job_cluster_config is required for commands submission method.")
 
     def submit(self, compiled_code: str) -> None:
-        cluster_spec = {
-            "new_cluster": self.parsed_model["config"]["job_cluster_config"]
-        }
+        cluster_spec = {"new_cluster": self.parsed_model["config"]["job_cluster_config"]}
         self._submit_through_notebook(compiled_code, cluster_spec)
 
 
@@ -220,9 +209,7 @@ class DBContext:
 
         current_status = self.get_cluster_status().get("state", "").upper()
         if current_status in ["TERMINATED", "TERMINATING"]:
-            logger.debug(
-                f"Cluster {self.cluster_id} is not running. Attempting to restart."
-            )
+            logger.debug(f"Cluster {self.cluster_id} is not running. Attempting to restart.")
             self.start_cluster()
             logger.debug(f"Cluster {self.cluster_id} is now running.")
 
@@ -365,9 +352,7 @@ class AllPurposeClusterPythonJobHelper(BaseDatabricksHelper):
 
     def submit(self, compiled_code: str) -> None:
         if self.parsed_model["config"].get("create_notebook", False):
-            self._submit_through_notebook(
-                compiled_code, {"existing_cluster_id": self.cluster_id}
-            )
+            self._submit_through_notebook(compiled_code, {"existing_cluster_id": self.cluster_id})
         else:
             context = DBContext(self.credentials, self.cluster_id, self.auth_header)
             command = DBCommand(self.credentials, self.cluster_id, self.auth_header)
@@ -384,9 +369,7 @@ class AllPurposeClusterPythonJobHelper(BaseDatabricksHelper):
                     get_state_func=lambda response: response["status"],
                     terminal_states=("Cancelled", "Error", "Finished"),
                     expected_end_state="Finished",
-                    get_state_msg_func=lambda response: response.json()["results"][
-                        "data"
-                    ],
+                    get_state_msg_func=lambda response: response.json()["results"]["data"],
                 )
                 if response["results"]["resultType"] == "error":
                     raise dbt.exceptions.DbtRuntimeError(
@@ -419,9 +402,7 @@ class DbtDatabricksBasePythonJobHelper(BaseDatabricksHelper):
         http_headers: Dict[str, str] = credentials.get_all_http_headers(
             connection_parameters.pop("http_headers", {})
         )
-        self._credentials_provider = credentials.authenticate(
-            self._credentials_provider
-        )
+        self._credentials_provider = credentials.authenticate(self._credentials_provider)
         header_factory = self._credentials_provider()
         headers = header_factory()
 

--- a/dbt/adapters/databricks/utils.py
+++ b/dbt/adapters/databricks/utils.py
@@ -72,3 +72,8 @@ def _wrap_function(func: Callable) -> Callable:
         return func(*new_args, **new_kwargs)
 
     return wrapper
+
+
+def remove_ansi(line):
+    ansi_escape = re.compile(r"(?:\x1B[@-_]|[\x80-\x9F])[0-?]*[ -/]*[@-~]")
+    return ansi_escape.sub("", line)

--- a/dbt/adapters/databricks/utils.py
+++ b/dbt/adapters/databricks/utils.py
@@ -74,6 +74,6 @@ def _wrap_function(func: Callable) -> Callable:
     return wrapper
 
 
-def remove_ansi(line):
+def remove_ansi(line: str) -> str:
     ansi_escape = re.compile(r"(?:\x1B[@-_]|[\x80-\x9F])[0-?]*[ -/]*[@-~]")
     return ansi_escape.sub("", line)

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,6 +1,6 @@
 import unittest
 
-from dbt.adapters.databricks.utils import redact_credentials
+from dbt.adapters.databricks.utils import redact_credentials, remove_ansi
 
 
 class TestDatabricksUtils(unittest.TestCase):
@@ -68,3 +68,22 @@ class TestDatabricksUtils(unittest.TestCase):
             "copy_options ('mergeSchema' = 'True')"
         )
         self.assertEqual(redact_credentials(sql), expected)
+
+    def test_remove_ansi(self):
+        test_string = """Python model failed with traceback as:
+  [0;31m---------------------------------------------------------------------------[0m
+  [0;31mException[0m                                 Traceback (most recent call last)
+  File [0;32m~/.ipykernel/1292/command--1-4090367456:79[0m
+  [1;32m     70[0m [38;5;66;03m# COMMAND ----------[39;00m
+  [1;32m     71[0m 
+  [1;32m     72[0m [38;5;66;03m# how to execute python model in notebook[39;00m
+"""
+        expected_string = """Python model failed with traceback as:
+  ---------------------------------------------------------------------------
+  Exception                                 Traceback (most recent call last)
+  File ~/.ipykernel/1292/command--1-4090367456:79
+       70 # COMMAND ----------
+       71 
+       72 # how to execute python model in notebook
+"""
+        self.assertEqual(remove_ansi(test_string), expected_string)

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -75,7 +75,7 @@ class TestDatabricksUtils(unittest.TestCase):
   [0;31mException[0m                                 Traceback (most recent call last)
   File [0;32m~/.ipykernel/1292/command--1-4090367456:79[0m
   [1;32m     70[0m [38;5;66;03m# COMMAND ----------[39;00m
-  [1;32m     71[0m 
+  [1;32m     71[0m
   [1;32m     72[0m [38;5;66;03m# how to execute python model in notebook[39;00m
 """
         expected_string = """Python model failed with traceback as:
@@ -83,7 +83,7 @@ class TestDatabricksUtils(unittest.TestCase):
   Exception                                 Traceback (most recent call last)
   File ~/.ipykernel/1292/command--1-4090367456:79
        70 # COMMAND ----------
-       71 
+       71
        72 # how to execute python model in notebook
 """
         self.assertEqual(remove_ansi(test_string), expected_string)


### PR DESCRIPTION
<!-- Please review our pull request review process in CONTRIBUTING.md before your proceed. -->

Resolves #355 

<!---
  Include the number of the issue addressed by this PR above if applicable.
  
  Example:
    resolves #1234

  Please review our pull request review process in CONTRIBUTING.md before your proceed.
-->

### Description

<!--- Describe the Pull Request here -->

Removes ANSI color tags from strings in exceptions.  While these tags look great when you're monitoring a terminal, they are nearly incomprehensible when looking at the dbt.log.  As dbt-databricks does not control the code that emits to logs vs terminal, this change ensures that the python stack traces are always legible at the expense of not being as colorful as they would otherwise be.

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
