### PR TITLE
Update m2m OAuth scopes to not include offline_access.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## dbt-databricks 1.6.x (Release TBD)
 
+### Fixes
+
+- Fixed an issue with AWS OAuth M2M flow ([#445](https://github.com/databricks/dbt-databricks/pull/445))
+
 ## dbt-databricks 1.6.3 (September 8, 2023)
 
 ### Fixes

--- a/dbt/adapters/databricks/auth.py
+++ b/dbt/adapters/databricks/auth.py
@@ -40,12 +40,12 @@ class m2m_auth(CredentialsProvider):
 
         config = Config(host=host, credentials_provider=noop_credentials)
         oidc = config.oidc_endpoints
-        scopes = ["offline_access", "all-apis"]
+        scopes = ["all-apis"]
         if not oidc:
             raise ValueError(f"{host} does not support OAuth")
         if config.is_azure:
             # Azure AD only supports full access to Azure Databricks.
-            scopes = [f"{config.effective_azure_login_app_id}/.default", "offline_access"]
+            scopes = [f"{config.effective_azure_login_app_id}/.default"]
         self._token_source = ClientCredentials(
             client_id=client_id,
             client_secret=client_secret,


### PR DESCRIPTION
<!---
  Include the number of the issue addressed by this PR above if applicable.
  
  Example:
    resolves #1234

  Please review our pull request review process in CONTRIBUTING.md before your proceed.
-->

### Description

Including 'offline_access' as a scope in the m2m flow was breaking AWS OAuth.  After consulting with Jacky, it seems safe to remove for m2m flow, as it should only be needed for u2m flow.

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
