### PR TITLE
Avoid describe extended on hive_metastore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Fixes
 
 - Fixed an issue with AWS OAuth M2M flow ([#445](https://github.com/databricks/dbt-databricks/pull/445))
+- Fixed an issue where every table in hive_metastore would get described ([#446](https://github.com/databricks/dbt-databricks/pull/446))
 
 ## dbt-databricks 1.6.3 (September 8, 2023)
 

--- a/dbt/adapters/databricks/impl.py
+++ b/dbt/adapters/databricks/impl.py
@@ -264,6 +264,8 @@ class DatabricksAdapter(SparkAdapter):
                         if view_names[name]
                         else DatabricksRelationType.View
                     )
+                elif database is None or database == "hive_metastore":
+                    return DatabricksRelationType.Table
                 else:
                     # not a view so it might be a streaming table
                     # get extended information to determine

--- a/tests/integration/avoid_describe_extended/models/new_model.sql
+++ b/tests/integration/avoid_describe_extended/models/new_model.sql
@@ -1,0 +1,7 @@
+{{ config(
+    materialized = 'table'
+) }}
+
+select cast(1 as bigint) as id, 'hello' as msg
+union all
+select cast(2 as bigint) as id, 'goodbye' as msg

--- a/tests/integration/avoid_describe_extended/seeds/preexisting_data.csv
+++ b/tests/integration/avoid_describe_extended/seeds/preexisting_data.csv
@@ -1,0 +1,5 @@
+id,msg
+1,hello
+2,goodbye
+2,yo
+3,anyway

--- a/tests/integration/avoid_describe_extended/test_avoid_describe_extended.py
+++ b/tests/integration/avoid_describe_extended/test_avoid_describe_extended.py
@@ -1,0 +1,35 @@
+import os
+import pytest
+from tests.integration.base import DBTIntegrationTest, use_profile
+
+
+class TestAvoidDescribeExtended(DBTIntegrationTest):
+    """Tests in this class exist to ensure we don't call describe extended unnecessarily.
+    This became a problem due to needing to discern tables from streaming tables, which is not
+    relevant on hive, but users on hive were having all of their tables describe extended-ed.
+    We only need to call describe extended if we are using a UC catalog and we can't determine the
+    type of the materialization."""
+
+    @property
+    def schema(self):
+        return "schema"
+
+    @property
+    def models(self):
+        return "models"
+
+    def _test_avoid_describe_extended(self):
+        # Add some existing data to ensure we don't try to 'describe extended' it.
+        self.run_dbt(["seed"])
+        _, log_output = self.run_dbt_and_capture(["run"])
+        self.assertNotIn("describe extended", log_output)
+
+    @use_profile("databricks_cluster")
+    def test_avoid_describe_extended_databricks_cluster(self):
+        """When UC is not enabled, we can assumed that all tables are regular tables"""
+        self._test_avoid_describe_extended()
+
+    @use_profile("databricks_uc_sql_endpoint")
+    def test_avoid_describe_extended_databricks_uc_sql_endpoint(self):
+        """When UC is enabled, regular tables are marked as such"""
+        self._test_avoid_describe_extended()

--- a/tests/integration/avoid_describe_extended/test_avoid_describe_extended.py
+++ b/tests/integration/avoid_describe_extended/test_avoid_describe_extended.py
@@ -1,5 +1,3 @@
-import os
-import pytest
 from tests.integration.base import DBTIntegrationTest, use_profile
 
 


### PR DESCRIPTION
<!-- Please review our pull request review process in CONTRIBUTING.md before your proceed. -->

Resolves #442 

<!---
  Include the number of the issue addressed by this PR above if applicable.
  
  Example:
    resolves #1234

  Please review our pull request review process in CONTRIBUTING.md before your proceed.
-->

### Description

As of 1.6.0, we added logic to determine Streaming Tables from normal Tables using describe extended if the type isn't returned.  There's no reason to do this on hive, which also unfortunately does not return the type when you ask it to show tables.  This PR says that if an object was returned by show tables, and the database (catalog) is none or hive_metastore, return the type table without calling describe extended.

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
