### PR TITLE
Add Node Info to SQLQueryStatus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - When installing python libraries onto clusters, you can now specify an index_url (Thanks @casperdamen123) ([367](https://github.com/databricks/dbt-databricks/pull/367))
 
+### Fixes
+
+- Node info now gets added to SQLQueryStatus (Thanks @colin-rogers-dbt) ([453](https://github.com/databricks/dbt-databricks/pull/453))
+
 ## dbt-databricks 1.6.4 (September 14, 2023)
 
 ### Fixes

--- a/dbt/adapters/databricks/connections.py
+++ b/dbt/adapters/databricks/connections.py
@@ -40,6 +40,7 @@ from dbt.contracts.connection import (
 )
 from dbt.contracts.graph.manifest import Manifest
 from dbt.events import AdapterLogger
+from dbt.events.contextvars import get_node_info
 from dbt.events.functions import fire_event
 from dbt.events.types import ConnectionUsed, SQLQuery, SQLQueryStatus
 from dbt.utils import DECIMALS, cast_to_str
@@ -768,6 +769,7 @@ class DatabricksConnectionManager(SparkConnectionManager):
                     SQLQueryStatus(
                         status=str(self.get_response(cursor)),
                         elapsed=round((time.time() - pre), 2),
+                        node_info=get_node_info(),
                     )
                 )
 
@@ -821,6 +823,7 @@ class DatabricksConnectionManager(SparkConnectionManager):
                     SQLQueryStatus(
                         status=str(self.get_response(cursor)),
                         elapsed=round((time.time() - pre), 2),
+                        node_info=get_node_info(),
                     )
                 )
 


### PR DESCRIPTION
<!-- Please review our pull request review process in CONTRIBUTING.md before your proceed. -->

Resolves #452 

<!---
  Include the number of the issue addressed by this PR above if applicable.
  
  Example:
    resolves #1234

  Please review our pull request review process in CONTRIBUTING.md before your proceed.
-->

### Description

Use the get_node_info method to populate node info into SQLQueryStatus. Tested locally and validated node_info is correctly populated in logs. 

### Checklist

- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
