### PR TITLE
Python: if the cluster is already starting up, just wait for it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,14 @@
 ### Features
 
 - When installing python libraries onto clusters, you can now specify an index_url (Thanks @casperdamen123) ([367](https://github.com/databricks/dbt-databricks/pull/367))
-- Log job run information such as run_id when submitting jobs to databricks (Thanks @jeffrey-harrison) ([#454](https://github.com/databricks/dbt-databricks/pull/454))
+- Log job run information such as run_id when submitting Python jobs to databricks (Thanks @jeffrey-harrison) ([#454](https://github.com/databricks/dbt-databricks/pull/454))
 
 ### Fixes
 
 - Node info now gets added to SQLQueryStatus (Thanks @colin-rogers-dbt) ([453](https://github.com/databricks/dbt-databricks/pull/453))
 - Fixing python model compatibility with newer DBRs ([459](https://github.com/databricks/dbt-databricks/pull/459))
 - Updated the Databricks SDK dependency so as to prevent reliance on an insecure version of requests ([460](https://github.com/databricks/dbt-databricks/pull/460))
+- Update logic around submitting python jobs so that if the cluster is already starting, just wait for it to start rather than failing ([461](https://github.com/databricks/dbt-databricks/pull/461))
 
 ## dbt-databricks 1.6.4 (September 14, 2023)
 

--- a/dbt/adapters/databricks/python_submissions.py
+++ b/dbt/adapters/databricks/python_submissions.py
@@ -223,6 +223,9 @@ class DBContext:
             self.start_cluster()
             logger.debug(f"Cluster {self.cluster_id} is now running.")
 
+        if current_status != "RUNNING":
+            self._wait_for_cluster_to_start()
+
         response = requests.post(
             f"https://{self.host}/api/1.2/contexts/create",
             headers=self.auth_header,
@@ -289,7 +292,12 @@ class DBContext:
                 f"Error starting terminated cluster.\n {response.content!r}"
             )
 
+        self._wait_for_cluster_to_start()
+
+    def _wait_for_cluster_to_start(self) -> None:
         # seconds
+        logger.info("Waiting for cluster to be ready")
+
         MAX_CLUSTER_START_TIME = 900
         start_time = time.time()
 


### PR DESCRIPTION
<!---
  Include the number of the issue addressed by this PR above if applicable.
  
  Example:
    resolves #1234

  Please review our pull request review process in CONTRIBUTING.md before your proceed.
-->

### Description

This should fix the issue where multiple threads try to start the same cluster, and we get an exception saying the cluster is Pending.

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
