### PR TITLE
Ensure optimize is run with liquid_clustered_by

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## dbt-databricks 1.6.x (Release TBD)
 
+### Fixes
+
+- Optimize now runs after creating / updating liquid clustering tables ([463](https://github.com/databricks/dbt-databricks/pull/463))
+
 ## dbt-databricks 1.6.5 (September 26, 2023)
 
 ### Features

--- a/dbt/include/databricks/macros/adapters.sql
+++ b/dbt/include/databricks/macros/adapters.sql
@@ -380,25 +380,25 @@
   {%- endif -%}
 {%- endmacro -%}
 
-{%- macro get_optimize_sql(relation) -%}
+{%- macro get_optimize_sql(relation) %}
   optimize {{ relation }}
-  {%- if config.get('zorder', False) and config.get('file_format', 'delta') == 'delta' -%}
-    {%- if config.get('liquid_clustered_by', False) -%}
+  {%- if config.get('zorder', False) and config.get('file_format', 'delta') == 'delta' %}
+    {%- if config.get('liquid_clustered_by', False) %}
       {{ exceptions.warn("Both zorder and liquid_clustered_by are set but they are incompatible. zorder will be ignored.") }}
-    {%- else -%}
-      {%- set zorder = config.get('zorder', none) -%}
+    {%- else %}
+      {%- set zorder = config.get('zorder', none) %}
       {# TODO: predicates here? WHERE ...  #}
-      {%- if zorder is sequence and zorder is not string -%}
+      {%- if zorder is sequence and zorder is not string %}
         zorder by (
-        {%- for col in zorder -%}
+        {%- for col in zorder %}
         {{ col }}{% if not loop.last %}, {% endif %}
-        {%- endfor -%}
+        {%- endfor %}
         )
-      {%- else -%}
+      {%- else %}
         zorder by ({{zorder}})
-      {%- endif -%}
-    {%- endif -%}
-  {%- endif -%}
+      {%- endif %}
+    {%- endif %}
+  {%- endif %}
 {%- endmacro -%}
 
 {% macro databricks__list_relations_without_caching(schema_relation) %}

--- a/dbt/include/databricks/macros/adapters.sql
+++ b/dbt/include/databricks/macros/adapters.sql
@@ -368,32 +368,38 @@
   {{ return(adapter.dispatch('optimize', 'dbt')(relation)) }}
 {% endmacro %}
 
-{% macro databricks__optimize(relation) %}
-  {% if config.get('zorder', False) and config.get('file_format', 'delta') == 'delta' %}
-    {% if var('DATABRICKS_SKIP_OPTIMIZE', 'false')|lower != 'true' and var('databricks_skip_optimize', 'false')|lower != 'true' %}
-      {% call statement('run_optimize_stmt') %}
+{%- macro databricks__optimize(relation) -%}
+  {%- if var('DATABRICKS_SKIP_OPTIMIZE', 'false')|lower != 'true' and 
+        var('databricks_skip_optimize', 'false')|lower != 'true' and 
+        config.get('file_format', 'delta') == 'delta' -%}
+    {%- if (config.get('zorder', False) or config.get('liquid_clustered_by', False)) -%}
+      {%- call statement('run_optimize_stmt') -%}
         {{ get_optimize_sql(relation) }}
-      {% endcall %}
-    {% endif %}
-  {% endif %}
-{% endmacro %}
+      {%- endcall -%}
+    {%- endif -%}
+  {%- endif -%}
+{%- endmacro -%}
 
-{% macro get_optimize_sql(relation) %}
-  {% if config.get('zorder', False) and config.get('file_format', 'delta') == 'delta' %}
-     {%- set zorder = config.get('zorder', none) -%}
-    optimize {{ relation }}
-    {# TODO: predicates here? WHERE ...  #}
-    {% if zorder is sequence and zorder is not string %}
-      zorder by (
+{%- macro get_optimize_sql(relation) -%}
+  optimize {{ relation }}
+  {%- if config.get('zorder', False) and config.get('file_format', 'delta') == 'delta' -%}
+    {%- if config.get('liquid_clustered_by', False) -%}
+      {{ exceptions.warn("Both zorder and liquid_clustered_by are set but they are incompatible. zorder will be ignored.") }}
+    {%- else -%}
+      {%- set zorder = config.get('zorder', none) -%}
+      {# TODO: predicates here? WHERE ...  #}
+      {%- if zorder is sequence and zorder is not string -%}
+        zorder by (
         {%- for col in zorder -%}
         {{ col }}{% if not loop.last %}, {% endif %}
         {%- endfor -%}
-      )
-    {% else %}
-      zorder by ({{zorder}})
-    {% endif %}
-  {% endif %}
-{% endmacro %}
+        )
+      {%- else -%}
+        zorder by ({{zorder}})
+      {%- endif -%}
+    {%- endif -%}
+  {%- endif -%}
+{%- endmacro -%}
 
 {% macro databricks__list_relations_without_caching(schema_relation) %}
   {{ return(adapter.get_relations_without_caching(schema_relation)) }}

--- a/tests/integration/base.py
+++ b/tests/integration/base.py
@@ -605,6 +605,12 @@ class DBTIntegrationTest(unittest.TestCase):
 
         return sql
 
+    def assert_in_log(self, message) -> None:
+        log_file = os.path.join(self._logs_dir, "dbt.log")
+        with open(log_file, "r") as f:
+            log = f.read()
+            assert message in log
+
     def assertTablesEqual(
         self,
         table_a,

--- a/tests/integration/base.py
+++ b/tests/integration/base.py
@@ -605,11 +605,11 @@ class DBTIntegrationTest(unittest.TestCase):
 
         return sql
 
-    def assert_in_log(self, message) -> None:
+    def assert_in_log(self, message: str) -> None:
         log_file = os.path.join(self._logs_dir, "dbt.log")
         with open(log_file, "r") as f:
             log = f.read()
-            assert message in log
+            assert message.lower() in log.lower()
 
     def assertTablesEqual(
         self,

--- a/tests/integration/liquid_clustering/models/liquid_clustered.sql
+++ b/tests/integration/liquid_clustering/models/liquid_clustered.sql
@@ -1,0 +1,2 @@
+{{ config(materialized='incremental', liquid_clustered_by='id') }}
+select 1 as id, 'Joe' as name

--- a/tests/integration/liquid_clustering/test_liquid_clustering.py
+++ b/tests/integration/liquid_clustering/test_liquid_clustering.py
@@ -1,4 +1,3 @@
-import os
 from tests.integration.base import DBTIntegrationTest, use_profile
 
 

--- a/tests/integration/liquid_clustering/test_liquid_clustering.py
+++ b/tests/integration/liquid_clustering/test_liquid_clustering.py
@@ -1,0 +1,17 @@
+import os
+from tests.integration.base import DBTIntegrationTest, use_profile
+
+
+class TestLiquidClustering(DBTIntegrationTest):
+    @property
+    def schema(self):
+        return "liquid"
+
+    @property
+    def models(self):
+        return "models"
+
+    @use_profile("databricks_uc_sql_endpoint")
+    def test_liquid_clustering_databricks_uc_sql_endpoint(self):
+        self.run_dbt()
+        self.assert_in_log("optimize")

--- a/tests/integration/zorder/test_zorder.py
+++ b/tests/integration/zorder/test_zorder.py
@@ -16,7 +16,8 @@ class TestZOrder(DBTIntegrationTest):
 
     def _test_zorder(self):
         self.run_dbt(["run"])
-        self.run_dbt(["run"])  # make sure it also run in incremental
+        self.run_dbt(["run"])
+        self.assert_in_log("zorder")  # make sure it also run in incremental
 
     @use_profile("databricks_cluster")
     def test_zorder_databricks_cluster(self):

--- a/tests/integration/zorder/test_zorder.py
+++ b/tests/integration/zorder/test_zorder.py
@@ -17,7 +17,7 @@ class TestZOrder(DBTIntegrationTest):
     def _test_zorder(self):
         self.run_dbt(["run"])
         self.run_dbt(["run"])
-        self.assert_in_log("zorder")  # make sure it also run in incremental
+        self.assert_in_log("zorder by")  # make sure it also run in incremental
 
     @use_profile("databricks_cluster")
     def test_zorder_databricks_cluster(self):

--- a/tests/unit/macros/test_adapters_macros.py
+++ b/tests/unit/macros/test_adapters_macros.py
@@ -266,7 +266,7 @@ class TestDatabricksMacros(TestAdaptersMacros):
 
         self.assertEqual(
             sql,
-            ("optimize " "`some_database`.`some_schema`.`some_table` " "zorder by (foo, bar)"),
+            ("optimize " "`some_database`.`some_schema`.`some_table` " "zorder by ( foo, bar )"),
         )
 
     def test_macros_optimize_with_extraneous_info(self):


### PR DESCRIPTION
<!-- Please review our pull request review process in CONTRIBUTING.md before your proceed. -->

Resolves #448 

<!---
  Include the number of the issue addressed by this PR above if applicable.
  
  Example:
    resolves #1234

  Please review our pull request review process in CONTRIBUTING.md before your proceed.
-->

### Description

Discovered that we weren't running optimize with liquid_cluster_by because the optimize clause was only set up to respect z-ordering.

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
