### PR TITLE
Revert python library install behavior if index_url not specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,11 @@
 ### Fixes
 
 - Optimize now runs after creating / updating liquid clustering tables ([463](https://github.com/databricks/dbt-databricks/pull/463))
-- fix Pylance import errors ([471](https://github.com/databricks/dbt-databricks/pull/471))
+- Fixing an issue where the new python library install from index behavior breaks users who were already customizing their installs ([472](https://github.com/databricks/dbt-databricks/pull/472))
+
+### Under the Hood
+
+- fix Pylance import errors (thanks @dataders) ([471](https://github.com/databricks/dbt-databricks/pull/471))
 
 ## dbt-databricks 1.6.5 (September 26, 2023)
 

--- a/dbt/adapters/databricks/python_submissions.py
+++ b/dbt/adapters/databricks/python_submissions.py
@@ -96,14 +96,17 @@ class BaseDatabricksHelper(PythonJobHelper):
         packages = self.parsed_model["config"].get("packages", [])
 
         # custom index URL or default
-        index_url = self.parsed_model["config"].get("index_url", "https://pypi.org/simple")
+        index_url = self.parsed_model["config"].get("index_url", None)
 
         # additional format of packages
         additional_libs = self.parsed_model["config"].get("additional_libs", [])
         libraries = []
 
         for package in packages:
-            libraries.append({"pypi": {"package": package, "repo": index_url}})
+            if index_url:
+                libraries.append({"pypi": {"package": package, "repo": index_url}})
+            else:
+                libraries.append({"pypi": {"package": package}})
 
         for lib in additional_libs:
             libraries.append(lib)


### PR DESCRIPTION
<!-- Please review our pull request review process in CONTRIBUTING.md before your proceed. -->

Resolves #466 

<!---
  Include the number of the issue addressed by this PR above if applicable.
  
  Example:
    resolves #1234

  Please review our pull request review process in CONTRIBUTING.md before your proceed.
-->

### Description

I was unaware that users were doing some sophisticated things to do custom library installs from private locations.  This PR makes it so that we only explicitly specify the url if index_url is specified; this should allow defaulting to however pip is configured for the cluster.

### Checklist

- [ ] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
