### PR TITLE
Implementing metadata freshness checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## dbt-databricks 1.7.x (TBD)
 
+### Features
+
+- Added support for getting freshness from metadata ([481](https://github.com/databricks/dbt-databricks/pull/481))
+
 ## dbt-databricks 1.7.0rc1 (October 13, 2023)
 
 ### Fixes

--- a/dbt/adapters/databricks/impl.py
+++ b/dbt/adapters/databricks/impl.py
@@ -20,7 +20,7 @@ from typing import (
 from agate import Row, Table, Text
 
 from dbt.adapters.base import AdapterConfig, PythonJobHelper
-from dbt.adapters.base.impl import catch_as_completed, FreshnessResponse
+from dbt.adapters.base.impl import catch_as_completed
 from dbt.adapters.base.meta import available
 from dbt.adapters.base.relation import BaseRelation, InformationSchema
 from dbt.adapters.capability import CapabilityDict, CapabilitySupport, Support, Capability

--- a/dbt/adapters/databricks/impl.py
+++ b/dbt/adapters/databricks/impl.py
@@ -20,9 +20,10 @@ from typing import (
 from agate import Row, Table, Text
 
 from dbt.adapters.base import AdapterConfig, PythonJobHelper
-from dbt.adapters.base.impl import catch_as_completed
+from dbt.adapters.base.impl import catch_as_completed, FreshnessResponse
 from dbt.adapters.base.meta import available
 from dbt.adapters.base.relation import BaseRelation, InformationSchema
+from dbt.adapters.capability import CapabilityDict, CapabilitySupport, Support, Capability
 from dbt.adapters.spark.impl import (
     SparkAdapter,
     GET_COLUMNS_IN_RELATION_RAW_MACRO_NAME,
@@ -106,6 +107,10 @@ class DatabricksAdapter(SparkAdapter):
     connections: DatabricksConnectionManager
 
     AdapterSpecificConfigs = DatabricksConfig
+
+    _capabilities = CapabilityDict(
+        {Capability.TableLastModifiedMetadata: CapabilitySupport(support=Support.Full)}
+    )
 
     @available.parse(lambda *a, **k: 0)
     def compare_dbr_version(self, major: int, minor: int) -> int:

--- a/dbt/adapters/databricks/relation.py
+++ b/dbt/adapters/databricks/relation.py
@@ -43,7 +43,7 @@ class DatabricksInformationSchema(InformationSchema):
     include_policy: Policy = field(default_factory=lambda: DatabricksIncludePolicy())
     quote_character: str = "`"
 
-    def is_hive_metastore(self):
+    def is_hive_metastore(self) -> bool:
         return self.database is None or self.database == "hive_metastore"
 
 
@@ -126,7 +126,7 @@ class DatabricksRelation(BaseRelation):
     def get_relation_type(cls) -> Type[DatabricksRelationType]:
         return DatabricksRelationType
 
-    def information_schema(self, view_name=None) -> InformationSchema:
+    def information_schema(self, view_name: Optional[str] = None) -> InformationSchema:
         # some of our data comes from jinja, where things can be `Undefined`.
         if not isinstance(view_name, str):
             view_name = None

--- a/dbt/include/databricks/macros/metadata.sql
+++ b/dbt/include/databricks/macros/metadata.sql
@@ -20,8 +20,8 @@
         from {{ information_schema }}.tables
         where (
           {%- for relation in relations -%}
-            (upper(table_schema) = upper('{{ relation.schema }}') and
-             upper(table_name) = upper('{{ relation.identifier }}')){%- if not loop.last %} or {% endif -%}
+            (table_schema = '{{ relation.schema }}' and
+             table_name = '{{ relation.identifier }}'){%- if not loop.last %} or {% endif -%}
           {%- endfor -%}
         )
     {% endif %}

--- a/dbt/include/databricks/macros/metadata.sql
+++ b/dbt/include/databricks/macros/metadata.sql
@@ -1,0 +1,32 @@
+{% macro databricks__get_relation_last_modified(information_schema, relations) -%}
+
+  {%- call statement('last_modified', fetch_result=True) -%}
+    {% if information_schema.is_hive_metastore %}
+        {%- for relation in relations -%}
+            select '{{ relation.schema }}' as schema,
+                    '{{ relation.identifier }}' as identifier,
+                    max(timestamp) as last_modified,
+                    {{ current_timestamp() }} as snapshotted_at
+            from (describe history {{ relation.schema }}.{{ relation.identifier }})
+            {% if not loop.last %}
+            union all
+            {% endif %}
+        {%- endfor -%}
+    {% else %}
+        select table_schema as schema,
+               table_name as identifier,
+               last_altered as last_modified,
+               {{ current_timestamp() }} as snapshotted_at
+        from {{ information_schema }}.tables
+        where (
+          {%- for relation in relations -%}
+            (upper(table_schema) = upper('{{ relation.schema }}') and
+             upper(table_name) = upper('{{ relation.identifier }}')){%- if not loop.last %} or {% endif -%}
+          {%- endfor -%}
+        )
+    {% endif %}
+  {%- endcall -%}
+
+  {{ return(load_result('last_modified')) }}
+
+{% endmacro %}

--- a/tests/functional/adapter/test_source_freshness.py
+++ b/tests/functional/adapter/test_source_freshness.py
@@ -1,0 +1,59 @@
+import os
+import pytest
+
+from dbt.cli.main import dbtRunner
+
+freshness_via_metadata_schema_yml = """version: 2
+sources:
+  - name: test_source
+    freshness:
+      warn_after: {count: 10, period: hour}
+      error_after: {count: 1, period: day}
+    schema: "{{ env_var('DBT_GET_RELATION_TEST_SCHEMA') }}"
+    tables:
+      - name: test_table
+"""
+
+
+class TestGetRelationLastModified:
+    @pytest.fixture(scope="class", autouse=True)
+    def set_env_vars(self, project):
+        os.environ["DBT_GET_RELATION_TEST_SCHEMA"] = project.test_schema
+        yield
+        del os.environ["DBT_GET_RELATION_TEST_SCHEMA"]
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"schema.yml": freshness_via_metadata_schema_yml}
+
+    @pytest.fixture(scope="class")
+    def custom_schema(self, project, set_env_vars):
+        with project.adapter.connection_named("__test"):
+            relation = project.adapter.Relation.create(
+                database=project.database, schema=os.environ["DBT_GET_RELATION_TEST_SCHEMA"]
+            )
+            project.adapter.drop_schema(relation)
+            project.adapter.create_schema(relation)
+
+        yield relation.schema
+
+        with project.adapter.connection_named("__test"):
+            project.adapter.drop_schema(relation)
+
+    def test_get_relation_last_modified(self, project, set_env_vars, custom_schema):
+        project.run_sql(
+            f"create table {custom_schema}.test_table (id integer, name varchar(100) not null);"
+        )
+
+        warning_or_error = False
+
+        def probe(e):
+            nonlocal warning_or_error
+            if e.info.level in ["warning", "error"]:
+                warning_or_error = True
+
+        runner = dbtRunner(callbacks=[probe])
+        runner.invoke(["source", "freshness"])
+
+        # The 'source freshness' command should succeed without warnings or errors.
+        assert not warning_or_error

--- a/tests/functional/adapter/test_source_freshness.py
+++ b/tests/functional/adapter/test_source_freshness.py
@@ -3,7 +3,8 @@ import pytest
 
 from dbt.tests.util import get_artifact, run_dbt
 
-freshness_via_metadata_schema_yml = """version: 2
+freshness_via_metadata_schema_yml = """
+version: 2
 sources:
   - name: test_source
     freshness:

--- a/tests/functional/adapter/test_source_freshness.py
+++ b/tests/functional/adapter/test_source_freshness.py
@@ -1,7 +1,7 @@
 import os
 import pytest
 
-from dbt.cli.main import dbtRunner
+from dbt.tests.util import get_artifact, run_dbt
 
 freshness_via_metadata_schema_yml = """version: 2
 sources:
@@ -45,15 +45,8 @@ class TestGetRelationLastModified:
             f"create table {custom_schema}.test_table (id integer, name varchar(100) not null);"
         )
 
-        warning_or_error = False
+        run_dbt(["source", "freshness"])
 
-        def probe(e):
-            nonlocal warning_or_error
-            if e.info.level in ["warning", "error"]:
-                warning_or_error = True
+        sources = get_artifact("target/sources.json")
 
-        runner = dbtRunner(callbacks=[probe])
-        runner.invoke(["source", "freshness"])
-
-        # The 'source freshness' command should succeed without warnings or errors.
-        assert not warning_or_error
+        assert sources["results"][0]["status"] == "pass"

--- a/tests/functional/adapter/test_source_freshness.py
+++ b/tests/functional/adapter/test_source_freshness.py
@@ -40,7 +40,7 @@ class TestGetRelationLastModified:
         with project.adapter.connection_named("__test"):
             project.adapter.drop_schema(relation)
 
-    def test_get_relation_last_modified(self, project, set_env_vars, custom_schema):
+    def test_get_relation_last_modified(self, project, custom_schema):
         project.run_sql(
             f"create table {custom_schema}.test_table (id integer, name varchar(100) not null);"
         )


### PR DESCRIPTION
<!---
  Include the number of the issue addressed by this PR above if applicable.
  
  Example:
    resolves #1234

  Please review our pull request review process in CONTRIBUTING.md before your proceed.
-->

### Description

Addresses the 'metadata freshness changes' part of https://github.com/dbt-labs/dbt-core/discussions/8307
Doing this in a way that can work for hive and unity was interesting.  I'm a little concerned about the accuracy/perf around the hive implementation, but its the best I can do, and I don't have a great way to insert a check for hive metastore earlier in the call chain.  

@dataders any concern that if someone has a view as a source (as is the case in my bigger transform jobs), then this mechanism doesn't work?  I didn't see if there was any logic that only called down to this path if the relation is a table.  Both using information schema in this way and describe history are table-only features.  I mean we could look at information_schema.views, but last altered doesn't give the same sort of information for views as it does for tables.

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
