### PR TITLE
Allow more arguments to be added on streaming table create + refresh

### DIFF
--- a/dbt/include/databricks/macros/materializations/streaming_table/create_or_refresh_streaming_table_as.sql
+++ b/dbt/include/databricks/macros/materializations/streaming_table/create_or_refresh_streaming_table_as.sql
@@ -4,6 +4,11 @@
 
 {% macro databricks__get_create_streaming_table_as_sql(relation, sql) -%}
   create streaming table {{ relation }}
+  {{ file_format_clause() }}
+  {{ partition_cols(label="partitioned by") }}
+  {{ location_clause() }}
+  {{ comment_clause() }}
+  {{ tblproperties_clause() }}
   as
     {{ sql }}
 {% endmacro %}
@@ -14,6 +19,8 @@
 
 {% macro databricks__get_refresh_streaming_table_as_sql(relation, sql) -%}
   create or refresh streaming table {{ relation }}
+  {{ comment_clause() }}
+  {{ tblproperties_clause() }}
   as
     {{ sql }}
 {% endmacro %}


### PR DESCRIPTION
<!-- Please review our pull request review process in CONTRIBUTING.md before your proceed. -->

Resolves #

<!---
  Include the number of the issue addressed by this PR above if applicable.
  
  Example:
    resolves #1234

  Please review our pull request review process in CONTRIBUTING.md before your proceed.
-->

### Description

Allow Streaming Tables to be created and refreshed with Options, Tblproperties, etc.

I'm sure this isn't a complete MR, but it would be great to see this brought into the fold, as the streaming table functionality is incomplete without it.

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
