### PR TITLE
Allow models to execute on different warehouses

### DIFF
--- a/dbt/adapters/databricks/connections.py
+++ b/dbt/adapters/databricks/connections.py
@@ -1123,8 +1123,16 @@ def get_http_path(node: Optional[ResultNode], creds: DatabricksCredentials) -> O
     # Get the http path of the compute resource specified in the node's config.
     # If none is specified return the default path from creds.
     compute_name = get_compute_name(node)
-    http_path = creds.http_path
-    if compute_name and creds.compute:
-        http_path = creds.compute.get(compute_name, {}).get("http_path", creds.http_path)
+    if not node or not compute_name:
+        return creds.http_path
+
+    http_path = None
+    if creds.compute:
+        http_path = creds.compute.get(compute_name, {}).get("http_path", None)
+
+    if not http_path:
+        raise dbt.exceptions.DbtRuntimeError(
+            f"Compute resource {compute_name} does not exist, relation: {node.relation_name}"
+        )
 
     return http_path

--- a/tests/functional/adapter/warehouse_per_model/fixtures.py
+++ b/tests/functional/adapter/warehouse_per_model/fixtures.py
@@ -1,0 +1,50 @@
+source = """id,name,date
+1,Alice,2022-01-01
+2,Bob,2022-01-02
+"""
+
+target = """
+{{config(materialized='table', databricks_compute='alternate_warehouse')}}
+
+select * from {{ ref('source') }}
+"""
+
+target2 = """
+{{config(materialized='table')}}
+
+select * from {{ ref('source') }}
+"""
+
+target3 = """
+{{config(materialized='table')}}
+
+select * from {{ ref('source') }}
+"""
+
+model_schema = """
+version: 2
+
+models:
+  - name: target
+    columns:
+      - name: id
+      - name: name
+      - name: date
+  - name: target2
+    config:
+      databricks_compute: alternate_warehouse
+    columns:
+      - name: id
+      - name: name
+      - name: date
+  - name: target3
+    columns:
+      - name: id
+      - name: name
+      - name: date
+"""
+
+expected_target = """id,name,date
+1,Alice,2022-01-01
+2,Bob,2022-01-02
+"""

--- a/tests/functional/adapter/warehouse_per_model/test_warehouse_per_model.py
+++ b/tests/functional/adapter/warehouse_per_model/test_warehouse_per_model.py
@@ -1,0 +1,100 @@
+import pytest
+from dbt.tests import util
+from tests.functional.adapter.warehouse_per_model import fixtures
+
+
+class BaseWarehousePerModel:
+    args_formatter = ""
+
+    @pytest.fixture(scope="class")
+    def seeds(self):
+        return {
+            "source.csv": fixtures.source,
+        }
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        d = dict()
+        d["target4.sql"] = fixtures.target3
+        return {
+            "target.sql": fixtures.target,
+            "target2.sql": fixtures.target2,
+            "target3.sql": fixtures.target3,
+            "schema.yml": fixtures.model_schema,
+            "special": d,
+        }
+
+
+class BaseSpecifyingCompute(BaseWarehousePerModel):
+    """Base class for testing various ways to specify a warehouse."""
+
+    def test_wpm(self, project):
+        util.run_dbt(["seed"])
+        models = project.test_config.get("model_names")
+        for model_name in models:
+            # Since the profile doesn't define a compute resource named 'alternate_warehouse'
+            # we should fail with an error if the warehouse specified for the model is
+            # correctly handled.
+            res = util.run_dbt(["run", "--select", model_name], expect_pass=False)
+            msg = res.results[0].message
+            assert "Compute resource alternate_warehouse does not exist" in msg
+            assert model_name in msg
+
+
+class TestSpecifyingInConfigBlock(BaseSpecifyingCompute):
+    @pytest.fixture(scope="class")
+    def test_config(self):
+        return {"model_names": ["target"]}
+
+
+class TestSpecifyingInSchemaYml(BaseSpecifyingCompute):
+    @pytest.fixture(scope="class")
+    def test_config(self):
+        return {"model_names": ["target2"]}
+
+
+class TestSpecifyingForProjectModels(BaseSpecifyingCompute):
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {
+            "models": {
+                "+databricks_compute": "alternate_warehouse",
+            }
+        }
+
+    @pytest.fixture(scope="class")
+    def test_config(self):
+        return {"model_names": ["target3"]}
+
+
+class TestSpecifyingForProjectModelsInFolder(BaseSpecifyingCompute):
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {
+            "models": {
+                "test": {
+                    "special": {
+                        "+databricks_compute": "alternate_warehouse",
+                    },
+                },
+            }
+        }
+
+    @pytest.fixture(scope="class")
+    def test_config(self):
+        return {"model_names": ["target4"]}
+
+
+class TestWarehousePerModel(BaseWarehousePerModel):
+    @pytest.fixture(scope="class")
+    def profiles_config_update(self, dbt_profile_target):
+        outputs = {"default": dbt_profile_target}
+        outputs["default"]["compute"] = {
+            "alternate_warehouse": {"http_path": dbt_profile_target["http_path"]}
+        }
+        return {"test": {"outputs": outputs, "target": "default"}}
+
+    def test_wpm(self, project):
+        util.run_dbt(["seed"])
+        util.run_dbt(["run", "--select", "target"])
+        util.check_relations_equal(project.adapter, ["target", "source"])

--- a/tests/unit/test_compute_config.py
+++ b/tests/unit/test_compute_config.py
@@ -1,0 +1,178 @@
+import unittest
+import dbt.exceptions
+from dbt.contracts.graph import nodes, model_config
+from dbt.adapters.databricks import connections
+
+
+class TestDatabricksConnectionHTTPPath(unittest.TestCase):
+    """Test the various cases for determining a specified warehouse."""
+
+    def test_get_http_path_model(self):
+        default_path = "my_http_path"
+        creds = connections.DatabricksCredentials(http_path=default_path)
+
+        path = connections._get_http_path(None, creds)
+        self.assertEqual(default_path, path)
+
+        node = nodes.ModelNode(
+            relation_name="a_relation",
+            database="database",
+            schema="schema",
+            name="node_name",
+            resource_type="model",
+            package_name="package",
+            path="path",
+            original_file_path="orig_path",
+            unique_id="uniqueID",
+            fqn=[],
+            alias="alias",
+            checksum=None,
+        )
+        path = connections._get_http_path(node, creds)
+        self.assertEqual(default_path, path)
+
+        node.config = model_config.ModelConfig()
+        path = connections._get_http_path(node, creds)
+        self.assertEqual(default_path, path)
+
+        node.config._extra = {}
+        path = connections._get_http_path(node, creds)
+        self.assertEqual(default_path, path)
+
+        node.config._extra["databricks_compute"] = "foo"
+        with self.assertRaisesRegex(
+            dbt.exceptions.DbtRuntimeError,
+            "Compute resource foo does not exist, relation: a_relation",
+        ):
+            connections._get_http_path(node, creds)
+
+        creds.compute = {}
+        with self.assertRaisesRegex(
+            dbt.exceptions.DbtRuntimeError,
+            "Compute resource foo does not exist, relation: a_relation",
+        ):
+            connections._get_http_path(node, creds)
+
+        creds.compute = {"foo": {}}
+        with self.assertRaisesRegex(
+            dbt.exceptions.DbtRuntimeError,
+            "Compute resource foo does not exist, relation: a_relation",
+        ):
+            connections._get_http_path(node, creds)
+
+        creds.compute = {"foo": {"http_path": "alternate_path"}}
+        path = connections._get_http_path(node, creds)
+        self.assertEqual("alternate_path", path)
+
+    def test_get_http_path_seed(self):
+        default_path = "my_http_path"
+        creds = connections.DatabricksCredentials(http_path=default_path)
+
+        path = connections._get_http_path(None, creds)
+        self.assertEqual(default_path, path)
+
+        node = nodes.SeedNode(
+            relation_name="a_relation",
+            database="database",
+            schema="schema",
+            name="node_name",
+            resource_type="model",
+            package_name="package",
+            path="path",
+            original_file_path="orig_path",
+            unique_id="uniqueID",
+            fqn=[],
+            alias="alias",
+            checksum=None,
+        )
+        path = connections._get_http_path(node, creds)
+        self.assertEqual(default_path, path)
+
+        node.config = model_config.SeedConfig()
+        path = connections._get_http_path(node, creds)
+        self.assertEqual(default_path, path)
+
+        node.config._extra = {}
+        path = connections._get_http_path(node, creds)
+        self.assertEqual(default_path, path)
+
+        node.config._extra["databricks_compute"] = "foo"
+        with self.assertRaisesRegex(
+            dbt.exceptions.DbtRuntimeError,
+            "Compute resource foo does not exist, relation: a_relation",
+        ):
+            connections._get_http_path(node, creds)
+
+        creds.compute = {}
+        with self.assertRaisesRegex(
+            dbt.exceptions.DbtRuntimeError,
+            "Compute resource foo does not exist, relation: a_relation",
+        ):
+            connections._get_http_path(node, creds)
+
+        creds.compute = {"foo": {}}
+        with self.assertRaisesRegex(
+            dbt.exceptions.DbtRuntimeError,
+            "Compute resource foo does not exist, relation: a_relation",
+        ):
+            connections._get_http_path(node, creds)
+
+        creds.compute = {"foo": {"http_path": "alternate_path"}}
+        path = connections._get_http_path(node, creds)
+        self.assertEqual("alternate_path", path)
+
+    def test_get_http_path_snapshot(self):
+        default_path = "my_http_path"
+        creds = connections.DatabricksCredentials(http_path=default_path)
+
+        path = connections._get_http_path(None, creds)
+        self.assertEqual(default_path, path)
+
+        node = nodes.SnapshotNode(
+            config=None,
+            relation_name="a_relation",
+            database="database",
+            schema="schema",
+            name="node_name",
+            resource_type="model",
+            package_name="package",
+            path="path",
+            original_file_path="orig_path",
+            unique_id="uniqueID",
+            fqn=[],
+            alias="alias",
+            checksum=None,
+        )
+
+        node.config = model_config.SnapshotConfig()
+        path = connections._get_http_path(node, creds)
+        self.assertEqual(default_path, path)
+
+        node.config._extra = {}
+        path = connections._get_http_path(node, creds)
+        self.assertEqual(default_path, path)
+
+        node.config._extra["databricks_compute"] = "foo"
+        with self.assertRaisesRegex(
+            dbt.exceptions.DbtRuntimeError,
+            "Compute resource foo does not exist, relation: a_relation",
+        ):
+            connections._get_http_path(node, creds)
+
+        creds.compute = {}
+        with self.assertRaisesRegex(
+            dbt.exceptions.DbtRuntimeError,
+            "Compute resource foo does not exist, relation: a_relation",
+        ):
+            connections._get_http_path(node, creds)
+
+        creds.compute = {"foo": {}}
+        with self.assertRaisesRegex(
+            dbt.exceptions.DbtRuntimeError,
+            "Compute resource foo does not exist, relation: a_relation",
+        ):
+            connections._get_http_path(node, creds)
+
+        creds.compute = {"foo": {"http_path": "alternate_path"}}
+        path = connections._get_http_path(node, creds)
+        self.assertEqual("alternate_path", path)


### PR DESCRIPTION

Resolves PECO-1182

### Description

Allows models in a dbt project to run on different SQL warehouses.
The available warehouses are specified as named values in the dbt profile.
The configuration for a model can specify by name which warehouse it should run on.

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
