### PR TITLE
Improve dbt seed times by removing type lookup and casting during INSERT

### DIFF
--- a/dbt/include/databricks/macros/materializations/seeds/helpers.sql
+++ b/dbt/include/databricks/macros/materializations/seeds/helpers.sql
@@ -20,9 +20,7 @@
           insert {% if loop.index0 == 0 -%} overwrite {% else -%} into {% endif -%} {{ this.render() }} values
           {% for row in chunk -%}
               ({%- for col_name in agate_table.column_names -%}
-                  {%- set inferred_type = adapter.convert_type(agate_table, loop.index0) -%}
-                  {%- set type = column_override.get(col_name, inferred_type) -%}
-                    cast({{ get_binding_char() }} as {{type}})
+                  {{ get_binding_char() }}
                   {%- if not loop.last%},{%- endif %}
               {%- endfor -%})
               {%- if not loop.last%},{%- endif %}


### PR DESCRIPTION
<!-- Please review our pull request review process in CONTRIBUTING.md before your proceed. -->

Resolves #476 

<!---
  Include the number of the issue addressed by this PR above if applicable.
  
  Example:
    resolves #1234

  Please review our pull request review process in CONTRIBUTING.md before your proceed.
-->

### Description

<!--- Describe the Pull Request here -->

Several users have noticed slow run times for loading dbt seeds with >1k records when using the `dbt-databricks` adapter, with run times becoming prohibitively slow for seeds with >10k records.  This PR speeds up that run time substantially by removing unnecessary type lookup and casting during the `INSERT` statement.

DBT seeds essentially are built in two steps:
1. The table is created with the appropriate column types (explicit or inferred) with `CREATE TABLE AS ...`
2. The values are loaded into that table with `INSERT OVERWRITE INTO table.schema VALUES ...`

For some reason in the second step, there is both a type lookup and subsequent `CAST(x) AS type` for **every single value (rows x columns)** in the seed.  This is effectively redundant and unnecessary, since the type information was already used when defining the column types during table creation.

Removing these steps significantly speeds up the seed run times.  For example, I was able to load a seed with 47k records and 9 columns in about 1 minute with this change, whereas previously the seed hadn't even finished after 10+ minutes of loading.


### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
