### PR TITLE
Add node_info to SQLQuery events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 - Added support for getting info only on specified relations to improve performance of gathering metadata ([486](https://github.com/databricks/dbt-databricks/pull/486))
 - Added support for getting freshness from metadata ([481](https://github.com/databricks/dbt-databricks/pull/481))
 
+### Fixes
+
+- Node info now gets added to SQLQuery event ([494](https://github.com/databricks/dbt-databricks/pull/494))
+
 ### Under the Hood
 
 - Added required adapter tests to ensure compatibility with 1.7.0 ([487](https://github.com/databricks/dbt-databricks/pull/487))

--- a/dbt/adapters/databricks/connections.py
+++ b/dbt/adapters/databricks/connections.py
@@ -762,7 +762,13 @@ class DatabricksConnectionManager(SparkConnectionManager):
                 if abridge_sql_log:
                     log_sql = "{}...".format(log_sql[:512])
 
-                fire_event(SQLQuery(conn_name=cast_to_str(connection.name), sql=log_sql))
+                fire_event(
+                    SQLQuery(
+                        conn_name=cast_to_str(connection.name),
+                        sql=log_sql,
+                        node_info=get_node_info(),
+                    )
+                )
                 pre = time.time()
 
                 cursor = cast(DatabricksSQLConnectionWrapper, connection.handle).cursor()
@@ -815,7 +821,13 @@ class DatabricksConnectionManager(SparkConnectionManager):
         with self.exception_handler(log_sql):
             cursor: Optional[DatabricksSQLCursorWrapper] = None
             try:
-                fire_event(SQLQuery(conn_name=cast_to_str(connection.name), sql=log_sql))
+                fire_event(
+                    SQLQuery(
+                        conn_name=cast_to_str(connection.name),
+                        sql=log_sql,
+                        node_info=get_node_info(),
+                    )
+                )
                 pre = time.time()
 
                 handle: DatabricksSQLConnectionWrapper = connection.handle


### PR DESCRIPTION
<!-- Please review our pull request review process in CONTRIBUTING.md before your proceed. -->


### Description

This is a follow-up to https://github.com/databricks/dbt-databricks/pull/453, which added `node_info` to the `SQLQueryStatus` event. This PR adds `node_info` to the `SQLQuery` event.

I did not open a separate issue for this as it feels very related to https://github.com/databricks/dbt-databricks/issues/452, but happy to log a new issue if desired!


### Checklist

- [ ] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.


### PR Status

Keeping this as draft for the moment while I get set up to run the linter and add a changelog entry. 
