### PR TITLE
1.7.0 Compat

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -13,7 +13,7 @@ jobs:
       DBT_DATABRICKS_CLIENT_ID: ${{ secrets.TEST_PECO_SP_ID }}
       DBT_DATABRICKS_CLIENT_SECRET: ${{ secrets.TEST_PECO_SP_SECRET }}
       DBT_DATABRICKS_UC_INITIAL_CATALOG: peco
-      DBT_DATABRICKS_LOCATION_ROOT: ${{ secrets.TEST_PECO_EXTERNAL_LOCATION }}
+      DBT_DATABRICKS_LOCATION_ROOT: ${{ secrets.TEST_PECO_EXTERNAL_LOCATION }}test
       TEST_PECO_UC_CLUSTER_ID: ${{ secrets.TEST_PECO_UC_CLUSTER_ID }}
     steps:
       - name: Check out repository
@@ -41,7 +41,7 @@ jobs:
       DBT_DATABRICKS_CLIENT_SECRET: ${{ secrets.TEST_PECO_SP_SECRET }}
       DBT_DATABRICKS_HTTP_PATH: ${{ secrets.TEST_PECO_WAREHOUSE_HTTP_PATH }}
       DBT_DATABRICKS_UC_INITIAL_CATALOG: peco
-      DBT_DATABRICKS_LOCATION_ROOT: ${{ secrets.TEST_PECO_EXTERNAL_LOCATION }}
+      DBT_DATABRICKS_LOCATION_ROOT: ${{ secrets.TEST_PECO_EXTERNAL_LOCATION }}test
       TEST_PECO_UC_CLUSTER_ID: ${{ secrets.TEST_PECO_UC_CLUSTER_ID }}
     steps:
       - name: Check out repository
@@ -67,7 +67,7 @@ jobs:
       DBT_DATABRICKS_HOST_NAME: ${{ secrets.DATABRICKS_HOST }}
       DBT_DATABRICKS_TOKEN: ${{ secrets.DATABRICKS_TOKEN }}
       TEST_PECO_CLUSTER_ID: ${{ secrets.TEST_PECO_CLUSTER_ID }}
-      DBT_DATABRICKS_LOCATION_ROOT: ${{ secrets.TEST_PECO_EXTERNAL_LOCATION }}
+      DBT_DATABRICKS_LOCATION_ROOT: ${{ secrets.TEST_PECO_EXTERNAL_LOCATION }}test
     steps:
       - name: Check out repository
         uses: actions/checkout@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Features
 
-- Added support for getting info only on specified relations to improve performance of gathering metadata ([486](https://github.com/databricks/dbt-databricks/pull/486))
+- Added support for getting info only on specified relations to improve performance of gathering metadata ([486](https://github.com/databricks/dbt-databricks/pull/486)), also (with generous help from from @mikealfare) ([499](https://github.com/databricks/dbt-databricks/pull/499))
 - Added support for getting freshness from metadata ([481](https://github.com/databricks/dbt-databricks/pull/481))
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## dbt-databricks 1.7.0 (TBD)
+## dbt-databricks 1.7.0 (November 9, 2023)
 
 ### Features
 
@@ -7,12 +7,13 @@
 
 ### Fixes
 
-- Node info now gets added to SQLQuery event ([494](https://github.com/databricks/dbt-databricks/pull/494))
+- Node info now gets added to SQLQuery event (thanks @davidharting!) ([494](https://github.com/databricks/dbt-databricks/pull/494))
+- Compatibility with dbt-spark and dbt-core 1.7.1 ([499](https://github.com/databricks/dbt-databricks/pull/499))
 
 ### Under the Hood
 
 - Added required adapter tests to ensure compatibility with 1.7.0 ([487](https://github.com/databricks/dbt-databricks/pull/487))
-- Improved large seed performance by not casting every value (thanks @nrichards17!) ([493](https://github.com/databricks/dbt-databricks/pull/493))
+- Improved large seed performance by not casting every value (thanks @nrichards17!) ([493](https://github.com/databricks/dbt-databricks/pull/493)). Note: for `file_format="parquet"` we still need to cast.
 
 ## dbt-databricks 1.7.0rc1 (October 13, 2023)
 

--- a/dbt/adapters/databricks/__version__.py
+++ b/dbt/adapters/databricks/__version__.py
@@ -1,1 +1,1 @@
-version: str = "1.7.0rc1"
+version: str = "1.7.0"

--- a/dbt/adapters/databricks/impl.py
+++ b/dbt/adapters/databricks/impl.py
@@ -428,12 +428,15 @@ class DatabricksAdapter(SparkAdapter):
             columns.append(column)
         return columns
 
-    def get_catalog(
-        self, manifest: Manifest, selected_nodes: Optional[Set] = None
+    def get_catalog(self, manifest: Manifest) -> Tuple[Table, List[Exception]]:
+        catalog_relations = self._get_catalog_relations(manifest)
+        return self.get_catalog_by_relations(manifest, catalog_relations)
+
+    def get_catalog_by_relations(
+        self, manifest: Manifest, relations: Set[BaseRelation] = None
     ) -> Tuple[Table, List[Exception]]:
         with executor(self.config) as tpe:
-            catalog_relations = self._get_catalog_relations(manifest, selected_nodes)
-            relations_by_catalog = self._get_catalog_relations_by_info_schema(catalog_relations)
+            relations_by_catalog = self._get_catalog_relations_by_info_schema(relations)
 
             futures: List[Future[Table]] = []
 

--- a/dbt/adapters/databricks/impl.py
+++ b/dbt/adapters/databricks/impl.py
@@ -256,10 +256,14 @@ class DatabricksAdapter(SparkAdapter):
         # if there are any table types to be resolved
         if any(not row[3] for row in new_rows):
             # Get view names and create a dictionary of view name to materialization
+            relation_all_tables = self.Relation.create(
+                database=relation.database, schema=relation.schema, identifier="*"
+            )
+
             with self._catalog(relation.database):
                 views = self.execute_macro(SHOW_VIEWS_MACRO_NAME, kwargs=kwargs)
                 tables = self.execute_macro(
-                    SHOW_TABLE_EXTENDED_MACRO_NAME, kwargs={"schema_relation": relation}
+                    SHOW_TABLE_EXTENDED_MACRO_NAME, kwargs={"schema_relation": relation_all_tables}
                 )
             view_names: Dict[str, bool] = {
                 view["viewName"]: view.get("isMaterialized", False) for view in views

--- a/dbt/adapters/databricks/impl.py
+++ b/dbt/adapters/databricks/impl.py
@@ -236,7 +236,7 @@ class DatabricksAdapter(SparkAdapter):
         new_rows: List[Tuple[Optional[str], str, str, str]]
         if all([relation.database, relation.schema]):
             tables = self.connections.list_tables(
-                database=relation.database, schema=relation.schema
+                database=relation.database, schema=relation.schema  # type: ignore[arg-type]
             )
 
             new_rows = []
@@ -457,17 +457,17 @@ class DatabricksAdapter(SparkAdapter):
         return self.get_catalog_by_relations(manifest, relations)
 
     def get_catalog_by_relations(
-        self, manifest: Manifest, catalog_relations: Set[BaseRelation]
+        self, manifest: Manifest, relations: Set[BaseRelation]
     ) -> Tuple[Table, List[Exception]]:
         with executor(self.config) as tpe:
-            relations_by_catalog = self._get_catalog_relations_by_info_schema(catalog_relations)
+            relations_by_catalog = self._get_catalog_relations_by_info_schema(relations)
 
             futures: List[Future[Table]] = []
 
-            for info_schema, relations in relations_by_catalog.items():
+            for info_schema, catalog_relations in relations_by_catalog.items():
                 if is_hive_metastore(info_schema.database):
                     schema_map = defaultdict(list)
-                    for relation in relations:
+                    for relation in catalog_relations:
                         schema_map[relation.schema].append(relation)
 
                     for schema, schema_relations in schema_map.items():
@@ -487,7 +487,7 @@ class DatabricksAdapter(SparkAdapter):
                         name,
                         self._get_one_catalog_by_relations,
                         info_schema,
-                        relations,
+                        catalog_relations,
                         manifest,
                     )
                     futures.append(fut)

--- a/dbt/adapters/databricks/relation.py
+++ b/dbt/adapters/databricks/relation.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional, Set, Type
+from typing import Any, Dict, Optional, Set, Type
 from dbt.contracts.relation import (
     ComponentName,
 )
@@ -141,5 +141,5 @@ def is_hive_metastore(database: Optional[str]) -> bool:
     return database is None or database.lower() == "hive_metastore"
 
 
-def extract_identifiers(relations: List[BaseRelation]) -> Set[str]:
+def extract_identifiers(relations: Set[BaseRelation]) -> Set[str]:
     return {r.identifier for r in relations if r.identifier is not None}

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -23,8 +23,8 @@ tox>=3.2.0
 types-requests
 types-mock
 
-dbt-core==1.7.0rc1
-dbt-tests-adapter==1.7.0rc1
+dbt-core==1.7.1
+dbt-tests-adapter==1.7.1
 # git+https://github.com/dbt-labs/dbt-spark.git@1.5.latest#egg=dbt-spark
 # git+https://github.com/dbt-labs/dbt-core.git@1.5.latest#egg=dbt-core&subdirectory=core
 # git+https://github.com/dbt-labs/dbt-core.git@1.5.latest#egg=dbt-tests-adapter&subdirectory=tests/adapter

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 databricks-sql-connector>=2.9.3, <3.0.0
 dbt-spark==1.7.1
-databricks-sdk==0.9.0
+databricks-sdk>=0.9.0
 keyring>=23.13.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 databricks-sql-connector>=2.9.3, <3.0.0
-dbt-spark==1.7.0rc1
+dbt-spark==1.7.0
 databricks-sdk==0.9.0
 keyring>=23.13.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 databricks-sql-connector>=2.9.3, <3.0.0
-dbt-spark==1.7.0
+dbt-spark==1.7.1
 databricks-sdk==0.9.0
 keyring>=23.13.0

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
     packages=find_namespace_packages(include=["dbt", "dbt.*"]),
     include_package_data=True,
     install_requires=[
-        "dbt-spark==1.7.0",
+        "dbt-spark==1.7.1",
         "databricks-sql-connector>=2.9.3, <3.0.0",
         "databricks-sdk>=0.9.0",
         "keyring>=23.13.0",

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
     packages=find_namespace_packages(include=["dbt", "dbt.*"]),
     include_package_data=True,
     install_requires=[
-        "dbt-spark==1.7.0rc1",
+        "dbt-spark==1.7.0",
         "databricks-sql-connector>=2.9.3, <3.0.0",
         "databricks-sdk>=0.9.0",
         "keyring>=23.13.0",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ pytest_plugins = ["dbt.tests.fixtures.project"]
 
 
 def pytest_addoption(parser):
-    parser.addoption("--profile", action="store", default="databricks_cluster", type=str)
+    parser.addoption("--profile", action="store", default="databricks_uc_sql_endpoint", type=str)
 
 
 # Using @pytest.mark.skip_profile('databricks_cluster') uses the 'skip_by_adapter_type'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ pytest_plugins = ["dbt.tests.fixtures.project"]
 
 
 def pytest_addoption(parser):
-    parser.addoption("--profile", action="store", default="databricks_uc_sql_endpoint", type=str)
+    parser.addoption("--profile", action="store", default="databricks_cluster", type=str)
 
 
 # Using @pytest.mark.skip_profile('databricks_cluster') uses the 'skip_by_adapter_type'

--- a/tests/functional/adapter/test_seeds.py
+++ b/tests/functional/adapter/test_seeds.py
@@ -1,4 +1,4 @@
-from dbt.tests.adapter.simple_seed.test_seed import SeedUniqueDelimiterTestBase
+from dbt.tests.adapter.simple_seed.test_seed import SeedUniqueDelimiterTestBase, BaseTestEmptySeed
 from dbt.tests.util import run_dbt
 import pytest
 
@@ -557,3 +557,7 @@ class TestDatabricksSeedWithEmptyDelimiter(DatabricksSeedUniqueDelimiterTestBase
         """Testing failure of running dbt seed with an empty configured delimiter value"""
         seed_result = run_dbt(["seed"], expect_pass=False)
         assert "compilation error" in seed_result.results[0].message.lower()
+
+
+class TestDatabricksEmptySeed(BaseTestEmptySeed):
+    pass


### PR DESCRIPTION
<!---
  Include the number of the issue addressed by this PR above if applicable.
  
  Example:
    resolves #1234

  Please review our pull request review process in CONTRIBUTING.md before your proceed.
-->

### Description

This PR includes
a.) change to get_catalog to account for changes that dbt made between 1.7.0rc1 and 1.7.0
b.) a fix for a PR I merged earlier that removed casts from seeding.  Turns out that with hive and parquet, the cast is necessary for numeric types; the tests passed initially because the old version of the copy_into tests didn't use seeds, and nowhere else in our project do we test parquet and seeds.
c.) a modification to our external location integration variable because something has changed (I think in the dbr) so that its extra sensitive to running in the top level of a container

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
