### PR TITLE
Update `get_relation_without_caching` to use show with wildcard search in place of describe extended

### DIFF
--- a/dbt/adapters/databricks/impl.py
+++ b/dbt/adapters/databricks/impl.py
@@ -284,9 +284,7 @@ class DatabricksAdapter(SparkAdapter):
 
             # a function to resolve an unknown table type
             def typeFromNames(database: Optional[str], name: str) -> DatabricksRelationType:
-                if is_hive_metastore(database):
-                    return DatabricksRelationType.Table
-                elif name in view_names:
+                if name in view_names:
                     # it is either a view or a materialized view
                     return (
                         DatabricksRelationType.MaterializedView
@@ -300,6 +298,8 @@ class DatabricksAdapter(SparkAdapter):
                         if table_names[name]
                         else DatabricksRelationType.Table
                     )
+                elif is_hive_metastore(database):
+                    return DatabricksRelationType.Table
                 else:
                     raise dbt.exceptions.DbtRuntimeError(
                         f"Unexpected relation type discovered: Database:{database}, Relation:{name}"

--- a/dbt/adapters/databricks/impl.py
+++ b/dbt/adapters/databricks/impl.py
@@ -257,9 +257,7 @@ class DatabricksAdapter(SparkAdapter):
         if any(not row[3] for row in new_rows):
             # Get view names and tables and create a dictionary of name to materialization
             relation_all_tables = self.Relation.create(
-                database=relation.database,
-                schema=relation.schema,
-                identifier="*"
+                database=relation.database, schema=relation.schema, identifier="*"
             )
             with self._catalog(relation.database):
                 views = self.execute_macro(SHOW_VIEWS_MACRO_NAME, kwargs=kwargs)
@@ -285,9 +283,7 @@ class DatabricksAdapter(SparkAdapter):
             }
 
             # a function to resolve an unknown table type
-            def typeFromNames(
-                database: Optional[str], name: str
-            ) -> DatabricksRelationType:
+            def typeFromNames(database: Optional[str], name: str) -> DatabricksRelationType:
                 if is_hive_metastore(database):
                     return DatabricksRelationType.Table
                 elif name in view_names:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 databricks-sql-connector>=2.9.3, <3.0.0
 dbt-spark==1.7.1
-databricks-sdk==0.9.0
+databricks-sdk>=0.9.0
 keyring>=23.13.0


### PR DESCRIPTION
<!-- Please review our pull request review process in CONTRIBUTING.md before your proceed. -->

Resolves #

<!---
  Include the number of the issue addressed by this PR above if applicable.
  
  Example:
    resolves #1234

  Please review our pull request review process in CONTRIBUTING.md before your proceed.
-->

### Description

I'm attempting to replace the `describe extended` scenario with a wildcard search in `show table extended`. The current behavior is to inspect each table one at a time to determine whether it is a streaming table or a traditional table. However, I think this can be replaced:

Instead of:
```sql
describe extended my_schema.my_table_1
describe extended my_schema.my_table_2
describe extended my_schema.my_table_3
...
```

Do this:
```sql
show table extended in my_schema like '*'
```

This PR is meant to be for discovery. I have not tested this via unit test, integration tests, etc. But I have confirmed that the wildcard search returns all tables in the schema. It's also possible it only returns the first X number of objects; I haven't created thousands of tables to test that.

### Checklist

- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
