### PR TITLE
Updates to warehouse-per-model logging and tests

### DIFF
--- a/dbt/adapters/databricks/connections.py
+++ b/dbt/adapters/databricks/connections.py
@@ -11,6 +11,7 @@ import sys
 import threading
 import time
 import requests
+from threading import get_ident
 from typing import (
     Any,
     Callable,
@@ -1120,21 +1121,31 @@ def _get_compute_name(node: Optional[ResultNode]) -> Optional[str]:
 
 
 def _get_http_path(node: Optional[ResultNode], creds: DatabricksCredentials) -> Optional[str]:
+    thread_id = (os.getpid(), get_ident())
     # Get the http path of the compute resource specified in the node's config.
     # If none is specified return the default path from creds.
     compute_name = _get_compute_name(node)
     if not node or not compute_name:
-        logger.debug("Using default compute resource.")
+        if node:
+            logger.debug(
+                f"On thread {thread_id}: {node.relation_name} using default compute resource."
+            )
+        else:
+            logger.debug(f"Thread {thread_id}: using default compute resource.")
+
         return creds.http_path
 
     http_path = None
     if creds.compute:
-        logger.debug(f"Using compute resource {compute_name}.")
         http_path = creds.compute.get(compute_name, {}).get("http_path", None)
 
     if not http_path:
         raise dbt.exceptions.DbtRuntimeError(
             f"Compute resource {compute_name} does not exist, relation: {node.relation_name}"
         )
+
+    logger.debug(
+        f"On thread {thread_id}: {node.relation_name} using compute resource '{compute_name}'."
+    )
 
     return http_path

--- a/tests/functional/adapter/warehouse_per_model/fixtures.py
+++ b/tests/functional/adapter/warehouse_per_model/fixtures.py
@@ -44,7 +44,33 @@ models:
       - name: date
 """
 
+seed_properties = """
+version: 2
+
+seeds:
+  - name: source
+    config:
+      databricks_compute: alternate_warehouse2
+"""
+
 expected_target = """id,name,date
 1,Alice,2022-01-01
 2,Bob,2022-01-02
+"""
+
+target_snap = """
+{% snapshot target_snap %}
+
+{{
+    config(
+      target_schema='snapshots',
+      unique_key='id',
+      strategy='check',
+      check_cols=['id', 'name', 'date'],
+      databricks_compute='alternate_warehouse3'
+    )
+}}
+select * from {{ ref('target') }}
+
+{% endsnapshot %}
 """

--- a/tests/functional/adapter/warehouse_per_model/test_warehouse_per_model.py
+++ b/tests/functional/adapter/warehouse_per_model/test_warehouse_per_model.py
@@ -113,8 +113,9 @@ class TestWarehousePerModel(BaseWarehousePerModel):
         _, log = util.run_dbt_and_capture(["--debug", "seed"])
         assert "`source` using compute resource 'alternate_warehouse2'" in log
 
-        _, log = util.run_dbt_and_capture(["--debug", "run", "--select", "target"])
+        _, log = util.run_dbt_and_capture(["--debug", "run", "--select", "target", "target3"])
         assert "`target` using compute resource 'alternate_warehouse'" in log
+        assert "`target3` using default compute resource" in log
 
         _, log = util.run_dbt_and_capture(["--debug", "snapshot"])
         assert "`target_snap` using compute resource 'alternate_warehouse3'" in log

--- a/tests/unit/test_compute_config.py
+++ b/tests/unit/test_compute_config.py
@@ -7,6 +7,10 @@ from dbt.adapters.databricks import connections
 class TestDatabricksConnectionHTTPPath(unittest.TestCase):
     """Test the various cases for determining a specified warehouse."""
 
+    errMsg = (
+        "Compute resource foo does not exist or does not specify http_path, " "relation: a_relation"
+    )
+
     def test_get_http_path_model(self):
         default_path = "my_http_path"
         creds = connections.DatabricksCredentials(http_path=default_path)
@@ -42,21 +46,21 @@ class TestDatabricksConnectionHTTPPath(unittest.TestCase):
         node.config._extra["databricks_compute"] = "foo"
         with self.assertRaisesRegex(
             dbt.exceptions.DbtRuntimeError,
-            "Compute resource foo does not exist, relation: a_relation",
+            self.errMsg,
         ):
             connections._get_http_path(node, creds)
 
         creds.compute = {}
         with self.assertRaisesRegex(
             dbt.exceptions.DbtRuntimeError,
-            "Compute resource foo does not exist, relation: a_relation",
+            self.errMsg,
         ):
             connections._get_http_path(node, creds)
 
         creds.compute = {"foo": {}}
         with self.assertRaisesRegex(
             dbt.exceptions.DbtRuntimeError,
-            "Compute resource foo does not exist, relation: a_relation",
+            self.errMsg,
         ):
             connections._get_http_path(node, creds)
 
@@ -99,21 +103,21 @@ class TestDatabricksConnectionHTTPPath(unittest.TestCase):
         node.config._extra["databricks_compute"] = "foo"
         with self.assertRaisesRegex(
             dbt.exceptions.DbtRuntimeError,
-            "Compute resource foo does not exist, relation: a_relation",
+            self.errMsg,
         ):
             connections._get_http_path(node, creds)
 
         creds.compute = {}
         with self.assertRaisesRegex(
             dbt.exceptions.DbtRuntimeError,
-            "Compute resource foo does not exist, relation: a_relation",
+            self.errMsg,
         ):
             connections._get_http_path(node, creds)
 
         creds.compute = {"foo": {}}
         with self.assertRaisesRegex(
             dbt.exceptions.DbtRuntimeError,
-            "Compute resource foo does not exist, relation: a_relation",
+            self.errMsg,
         ):
             connections._get_http_path(node, creds)
 
@@ -155,21 +159,21 @@ class TestDatabricksConnectionHTTPPath(unittest.TestCase):
         node.config._extra["databricks_compute"] = "foo"
         with self.assertRaisesRegex(
             dbt.exceptions.DbtRuntimeError,
-            "Compute resource foo does not exist, relation: a_relation",
+            self.errMsg,
         ):
             connections._get_http_path(node, creds)
 
         creds.compute = {}
         with self.assertRaisesRegex(
             dbt.exceptions.DbtRuntimeError,
-            "Compute resource foo does not exist, relation: a_relation",
+            self.errMsg,
         ):
             connections._get_http_path(node, creds)
 
         creds.compute = {"foo": {}}
         with self.assertRaisesRegex(
             dbt.exceptions.DbtRuntimeError,
-            "Compute resource foo does not exist, relation: a_relation",
+            self.errMsg,
         ):
             connections._get_http_path(node, creds)
 


### PR DESCRIPTION


### Description

- Updated the debug logging for warehouse-per-model to include thread id and relation name. 
- Updated the warehouse-per-model functional tests to include a seed and a snapshot that specify an alternate compute.  Changed the test conditions to include checking log output for messages that indicate the alternate compute was used.


### Checklist

- [X] I have run this code in development and it appears to resolve the stated issue
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
