### PR TITLE
Fixing list_schemas so that we stop trying to create schemas that exist

### DIFF
--- a/dbt/adapters/databricks/connections.py
+++ b/dbt/adapters/databricks/connections.py
@@ -1179,12 +1179,19 @@ class DatabricksConnectionManager(SparkConnectionManager):
                     cursor.close()
 
     def list_schemas(self, database: str, schema: Optional[str] = None) -> Table:
+        database = database.strip("`")
+        if schema:
+            schema = schema.strip("`")
         return self._execute_cursor(
             f"GetSchemas(database={database}, schema={schema})",
             lambda cursor: cursor.schemas(catalog_name=database, schema_name=schema),
         )
 
     def list_tables(self, database: str, schema: str, identifier: Optional[str] = None) -> Table:
+        database = database.strip("`")
+        schema = schema.strip("`")
+        if identifier:
+            identifier = identifier.strip("`")
         return self._execute_cursor(
             f"GetTables(database={database}, schema={schema}, identifier={identifier})",
             lambda cursor: cursor.tables(


### PR DESCRIPTION
<!-- Please review our pull request review process in CONTRIBUTING.md before your proceed. -->

Resolves #464

<!---
  Include the number of the issue addressed by this PR above if applicable.
  
  Example:
    resolves #1234

  Please review our pull request review process in CONTRIBUTING.md before your proceed.
-->

### Description

The inclusion of the backticks was causing list_schemas to return only 'global_temp'.  This meant that the precaution in dbt-core to not try to create schemas that already exist wasn't seeing the correct list of schemas.

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
