### PR TITLE
Update dbt-spark requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 databricks-sql-connector>=2.9.3, <3.0.0
-dbt-spark==1.6.1
+dbt-spark~=1.6.2
 databricks-sdk==0.9.0
 keyring>=23.13.0


### PR DESCRIPTION
This will bring in the sasl fix in `dbt-spark` and allow `dbt-databricks` to work with python 3.11.
dot-spark 1.6.2 release and changelog [here](https://github.com/dbt-labs/dbt-spark/releases/tag/v1.6.2). 
