### PR TITLE
Eliminate the conversion of the schema to lowercase for schema-related test

### DIFF
--- a/tests/integration/base.py
+++ b/tests/integration/base.py
@@ -171,7 +171,7 @@ class DBTIntegrationTest(unittest.TestCase):
 
         to_return = "{}_{}".format(self.prefix, schema)
 
-        return to_return.lower()
+        return to_return
 
     @property
     def default_database(self):


### PR DESCRIPTION
<!-- Please review our pull request review process in CONTRIBUTING.md before your proceed. -->

Resolves #

<!---
  Include the number of the issue addressed by this PR above if applicable.
  
  Example:
    resolves #1234

  Please review our pull request review process in CONTRIBUTING.md before your proceed.
-->

### Description
Currently we can not test schema uppercase. There are some issue when we pass the schema uppercase. Talking in this PR.
https://github.com/databricks/dbt-databricks/pull/530#issuecomment-1851214791

This change will pass the schema without converting to lowercase and will  help to test schema uppercase. 

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.


Execute integration test and confirm from query history that this change apply as I expected. Schema is passed by upper case `test17038406285517460420_Incremental_strategies `

```
insert
  overwrite `catalog_demo`.`test17038406285517460420_Incremental_strategies`.`expected_append`
values
  (1.0, 'hello'),(2.0, 'goodbye'),(2.0, 'yo'),(3.0, 'anyway')
```
