### PR TITLE
Fix the integration runner to correctly find workspace_id

### DIFF
--- a/.github/workflows/build_cluster_http_path.py
+++ b/.github/workflows/build_cluster_http_path.py
@@ -1,13 +1,19 @@
 import os
+import re
 
-workspace_id = os.getenv("DBT_DATABRICKS_HOST_NAME")[4:18]
+workspace_re = re.compile(r"^.*-(\d+)\..*$")
+hostname = os.getenv("DBT_DATABRICKS_HOST_NAME", "")
+matches = workspace_re.match(hostname)
+if matches:
+    workspace_id = matches.group(1)
+    print(workspace_id)
 cluster_id = os.getenv("TEST_PECO_CLUSTER_ID")
 uc_cluster_id = os.getenv("TEST_PECO_UC_CLUSTER_ID")
 http_path = f"sql/protocolv1/o/{workspace_id}/{cluster_id}"
 uc_http_path = f"sql/protocolv1/o/{workspace_id}/{uc_cluster_id}"
 
 # https://stackoverflow.com/a/72225291/5093960
-env_file = os.getenv("GITHUB_ENV")
+env_file = os.getenv("GITHUB_ENV", "")
 with open(env_file, "a") as myfile:
     myfile.write(f"DBT_DATABRICKS_CLUSTER_HTTP_PATH={http_path}\n")
     myfile.write(f"DBT_DATABRICKS_UC_CLUSTER_HTTP_PATH={uc_http_path}\n")


### PR DESCRIPTION
<!---
  Include the number of the issue addressed by this PR above if applicable.
  
  Example:
    resolves #1234

  Please review our pull request review process in CONTRIBUTING.md before your proceed.
-->

### Description

By switching the method we use to find the workspace id, we are now immune to the fact that workspace ids may be of different lengths.  If we ever switch to testing on AWS, we'll need to revisit this.  Also added some fluff to make mypy happy, since I've turned on mypy checking in my IDE.

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
