### PR TITLE
Fixing Python-related timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## dbt-databricks 1.7.4 (TBD)
 
+### Fixes
+
+- Fix for issue where long-running python models led to invalid session errors ([544](https://github.com/databricks/dbt-databricks/pull/544))
+
 ## dbt-databricks 1.7.3 (Dec 12, 2023)
 
 ### Fixes

--- a/dbt/adapters/databricks/connections.py
+++ b/dbt/adapters/databricks/connections.py
@@ -1070,6 +1070,12 @@ class DatabricksConnectionManager(SparkConnectionManager):
                         self.close(conn)
                         conn.handle = LazyHandle(self._open2)
 
+    def get_thread_connection(self) -> Connection:
+        if USE_LONG_SESSIONS:
+            self._cleanup_idle_connections()
+
+        return super().get_thread_connection()
+
     def add_query(
         self,
         sql: str,


### PR DESCRIPTION
<!---
  Include the number of the issue addressed by this PR above if applicable.
  
  Example:
    resolves #1234

  Please review our pull request review process in CONTRIBUTING.md before your proceed.
-->

### Description

When python models run for 15+ minutes, the user may get an error related to a previously open session having been closed.  This PR fixes that issue by ensuring we recreate connections that are older than 10 minutes before use.

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
