### PR TITLE
Don't fail if we hit an error when closing a connection

### DIFF
--- a/dbt/adapters/databricks/connections.py
+++ b/dbt/adapters/databricks/connections.py
@@ -1067,7 +1067,11 @@ class DatabricksConnectionManager(SparkConnectionManager):
                 for conn in thread_conns.values():
                     if conn.acquire_release_count == 0 and conn._idle_too_long():
                         logger.debug(f"closing idle connection: {conn._get_conn_info_str()}")
-                        self.close(conn)
+                        try:
+                            self.close(conn)
+                        except Exception as e:
+                            logger.warning(f"ignoring error when closing connection: {e}")
+
                         conn.handle = LazyHandle(self._open2)
 
     def get_thread_connection(self) -> Connection:


### PR DESCRIPTION
<!---
  Include the number of the issue addressed by this PR above if applicable.
  
  Example:
    resolves #1234

  Please review our pull request review process in CONTRIBUTING.md before your proceed.
-->

### Description

If our opportunity to recreate the connection is delayed for too long, we'll error out at the closing step of remaking the connection.  This patch wraps that step in a try-catch.

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
