### PR TITLE
Python model specific session handling to prevent using invalid sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Fixes
 
 - Fix for issue where long-running python models led to invalid session errors ([544](https://github.com/databricks/dbt-databricks/pull/544))
+- Added python model specific connection handling to prevent using invalid sessions ([547](https://github.com/databricks/dbt-databricks/pull/547)) 
 
 ## dbt-databricks 1.7.3 (Dec 12, 2023)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ### Fixes
 
-- Fix for issue where long-running python models led to invalid session errors ([544](https://github.com/databricks/dbt-databricks/pull/544))
 - Added python model specific connection handling to prevent using invalid sessions ([547](https://github.com/databricks/dbt-databricks/pull/547)) 
 - Allow schema to be specified in testing (thanks @case-k-git!) ([538](https://github.com/databricks/dbt-databricks/pull/538))
 

--- a/dbt/adapters/databricks/connections.py
+++ b/dbt/adapters/databricks/connections.py
@@ -918,6 +918,19 @@ class DatabricksConnectionManager(SparkConnectionManager):
         conn._release()
 
     # override
+    @classmethod
+    def close(cls, connection: Connection) -> Connection:
+        if not USE_LONG_SESSIONS:
+            return super().close(connection)
+
+        try:
+            return super().close(connection)
+        except Exception as e:
+            logger.warning(f"ignoring error when closing connection: {e}")
+            connection.state = ConnectionState.CLOSED
+            return connection
+
+    # override
     def cleanup_all(self) -> None:
         if not USE_LONG_SESSIONS:
             return super().cleanup_all()

--- a/dbt/adapters/databricks/connections.py
+++ b/dbt/adapters/databricks/connections.py
@@ -800,7 +800,7 @@ class DatabricksDBTConnection(Connection):
         else:
             logger.debug(f"Thread {self.thread_identifier} using default compute resource.")
 
-    def _reset_handle(self, open):
+    def _reset_handle(self, open: Callable[[Connection], Connection]) -> None:
         logger.debug(f"DatabricksDBTConnection._reset_handle: {self._get_conn_info_str()}")
         self.handle = LazyHandle(open)
         # Reset last_used_time to None because by refreshing this connection becomes associated
@@ -853,10 +853,6 @@ class DatabricksConnectionManager(SparkConnectionManager):
                 raise dbt.exceptions.DbtRuntimeError(msg) from exc
             else:
                 raise dbt.exceptions.DbtRuntimeError(str(exc)) from exc
-
-    def get_thread_connection(self) -> Connection:
-        self._cleanup_idle_connections()
-        return super().get_thread_connection()
 
     # override/overload
     def set_connection_name(

--- a/dbt/adapters/databricks/connections.py
+++ b/dbt/adapters/databricks/connections.py
@@ -116,7 +116,7 @@ USE_LONG_SESSIONS = os.getenv("DBT_DATABRICKS_LONG_SESSIONS", "True").upper() ==
 
 # Number of idle seconds before a connection is automatically closed. Only applicable if
 # USE_LONG_SESSIONS is true.
-DEFAULT_MAX_IDLE_TIME = 250
+DEFAULT_MAX_IDLE_TIME = 600
 
 
 @dataclass


### PR DESCRIPTION
<!-- Please review our pull request review process in CONTRIBUTING.md before your proceed. -->

Resolves:
[ES-985588: dbt-databricks data models timeout](https://databricks.atlassian.net/browse/ES-985588)

### Description
A long running python model can leave a connection/session idle for long enough that it times out and is closed.
Subsequent use of the connection results in an 'Invalid Sessionhandle' error.
#### Cause
For non-python data models the model is executed using sql statements.  So even if the sql statement takes a long time to run, the connection is in active use and doesn't timeout on the server.  For a python model a connection is acquired, but the model is run using rpc calls. Thus, if the python model takes a long time to run, the session can timeout on the back end.
The code to cleanup idle connections was not catching this because when a connection is released, after running a model, the last used time is set.  So even though running the python model didn't use the connection as far as the cleanup code was concerned it had been in active use.
There are two cases where the invalid connection would be used.
- Depending on the python model additional sql needs to be run before the model is considered complete. So there would be an attempt to use the connection within the bounds of the connection being acquired/released to run the python model.
- After the python model is finished the connection is re-used by another model. 
#### Fix
Updated the DatabricksDBTConnection class to track the language of the model being executed.  If the language is python we do not update the last used time when the connection is released.  This is to reflect the fact that the python model isn't necessarily using the connection.
This change allows the idle cleanup code to correctly cleanup the idle connection.

### Checklist

- [X] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [X] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
