### PR TITLE
Adding a default retry strategy in python submissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,13 @@
 
 ### Fixes
 
-- Added python model specific connection handling to prevent using invalid sessions ([547](https://github.com/databricks/dbt-databricks/pull/547)) 
+- Added python model specific connection handling to prevent using invalid sessions ([547](https://github.com/databricks/dbt-databricks/pull/547))
 - Allow schema to be specified in testing (thanks @case-k-git!) ([538](https://github.com/databricks/dbt-databricks/pull/538))
 - Fix dbt incremental_strategy behavior by fixing schema table existing check (thanks @case-k-git!) ([530](https://github.com/databricks/dbt-databricks/pull/530))
+
+### Under the Hood
+
+- Adding retries around API calls in python model submission ([549](https://github.com/databricks/dbt-databricks/pull/549))
 
 ## dbt-databricks 1.7.3 (Dec 12, 2023)
 

--- a/tests/unit/python/test_python_submissions.py
+++ b/tests/unit/python/test_python_submissions.py
@@ -1,7 +1,6 @@
 import unittest
 from unittest.mock import Mock
 
-from mock import PropertyMock
 from dbt.adapters.databricks.connections import DatabricksCredentials
 
 from dbt.adapters.databricks.python_submissions import DBContext, BaseDatabricksHelper

--- a/tests/unit/python/test_python_submissions.py
+++ b/tests/unit/python/test_python_submissions.py
@@ -1,25 +1,29 @@
 import unittest
-from unittest.mock import patch, Mock
+from unittest.mock import Mock
 
+from mock import PropertyMock
 from dbt.adapters.databricks.connections import DatabricksCredentials
 
 from dbt.adapters.databricks.python_submissions import DBContext, BaseDatabricksHelper
 
 
 class TestDatabricksPythonSubmissions(unittest.TestCase):
-    @patch("requests.get")
-    @patch("requests.post")
-    def test_start_cluster_returns_on_receiving_running_state(self, mock_post, mock_get):
+    def test_start_cluster_returns_on_receiving_running_state(self):
+        session_mock = Mock()
         # Mock the start command
-        mock_post.return_value.status_code = 200
+        post_mock = Mock()
+        post_mock.status_code = 200
+        session_mock.post.return_value = post_mock
         # Mock the status command
-        mock_get.return_value.status_code = 200
-        mock_get.return_value.json = Mock(return_value={"state": "RUNNING"})
+        get_mock = Mock()
+        get_mock.status_code = 200
+        get_mock.json.return_value = {"state": "RUNNING"}
+        session_mock.get.return_value = get_mock
 
-        context = DBContext(Mock(), None, None)
+        context = DBContext(Mock(), None, None, session_mock)
         context.start_cluster()
 
-        mock_get.assert_called_once()
+        session_mock.get.assert_called_once()
 
 
 class DatabricksTestHelper(BaseDatabricksHelper):


### PR DESCRIPTION
<!---
  Include the number of the issue addressed by this PR above if applicable.
  
  Example:
    resolves #1234

  Please review our pull request review process in CONTRIBUTING.md before your proceed.
-->

### Description

Make the python model code more resilient to random API failures by specifying a retry with backoff policy.

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
