### PR TITLE
Fixed issue with streaming tables always being dropped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Added python model specific connection handling to prevent using invalid sessions ([547](https://github.com/databricks/dbt-databricks/pull/547)) 
 - Allow schema to be specified in testing (thanks @case-k-git!) ([538](https://github.com/databricks/dbt-databricks/pull/538))
 - Fix dbt incremental_strategy behavior by fixing schema table existing check (thanks @case-k-git!) ([530](https://github.com/databricks/dbt-databricks/pull/530))
+- Fixed bug that was causing streaming tables to be dropped and recreated instead of refreshed. ([552](https://github.com/databricks/dbt-databricks/pull/552))
 
 ## dbt-databricks 1.7.3 (Dec 12, 2023)
 

--- a/dbt/adapters/databricks/impl.py
+++ b/dbt/adapters/databricks/impl.py
@@ -23,7 +23,12 @@ from dbt.adapters.base import AdapterConfig, PythonJobHelper
 from dbt.adapters.base.impl import catch_as_completed
 from dbt.adapters.base.meta import available
 from dbt.adapters.base.relation import BaseRelation, InformationSchema
-from dbt.adapters.capability import CapabilityDict, CapabilitySupport, Support, Capability
+from dbt.adapters.capability import (
+    CapabilityDict,
+    CapabilitySupport,
+    Support,
+    Capability,
+)
 from dbt.adapters.spark.impl import (
     SparkAdapter,
     GET_COLUMNS_IN_RELATION_RAW_MACRO_NAME,
@@ -286,7 +291,8 @@ class DatabricksAdapter(SparkAdapter):
             with self._catalog(relation.database):
                 views = self.execute_macro(SHOW_VIEWS_MACRO_NAME, kwargs=kwargs)
                 tables = self.execute_macro(
-                    SHOW_TABLE_EXTENDED_MACRO_NAME, kwargs={"schema_relation": relation_all_tables}
+                    SHOW_TABLE_EXTENDED_MACRO_NAME,
+                    kwargs={"schema_relation": relation_all_tables},
                 )
             view_names: Dict[str, bool] = {
                 view["viewName"]: view.get("isMaterialized", False) for view in views
@@ -319,8 +325,11 @@ class DatabricksAdapter(SparkAdapter):
 
     def _parse_type(self, information: str) -> str:
         type_entry = [
-            entry.strip() for entry in information.split("\n") if entry.split(":")[0] == "Type"
+            entry.split(":")[1].strip()
+            for entry in information.split("\n")
+            if entry.startswith("Type:")
         ]
+
         return type_entry[0] if type_entry else ""
 
     def _type_from_names(

--- a/dbt/include/databricks/macros/relations/drop.sql
+++ b/dbt/include/databricks/macros/relations/drop.sql
@@ -9,3 +9,9 @@
         {{ drop_table(relation) }}
     {%- endif -%}
 {% endmacro %}
+
+{% macro databricks__drop_relation(relation) -%}
+    {% call statement('drop_relation', auto_begin=False) -%}
+        {{ get_drop_sql(relation) }}
+    {%- endcall %}
+{% endmacro %}


### PR DESCRIPTION
Streaming tables were always being dropped and recreated instead of being refreshed. This was due to streaming tables being incorrectly identified as regular tables. 
The _parse_type() function was returning a type string of "Type:STREAMING_TABLE".  The calling code was expecting just the string "STREAMING_TABLE" and so wasn't correctly identifying streaming tables.

Updated the _parse_type() function to return the expected type string, ie stripped away the "Type:" part. 

After fixing the table type parsing testing showed that this exposed an issue with dropping streaming tables.
Implemented macro databricks__drop_relation so that we use the correct sql to drop a streaming table 
Signed-off-by: Raymond Cypher <raymond.cypher@databricks.com>


- [X] I have run this code in development and it appears to resolve the stated issue
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [X] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
