### PR TITLE
[PECO-1387] mv/st: Fix typo in #555

### DIFF
--- a/dbt/adapters/databricks/connections.py
+++ b/dbt/adapters/databricks/connections.py
@@ -579,7 +579,7 @@ class DatabricksSQLCursorWrapper:
 
         stopped_states = ("COMPLETED", "FAILED", "CANCELED")
         host: str = self._creds.host or ""
-        headers = self._cursor.connection.thrift_backend._auth_provider._header_factory()
+        headers = self._cursor.connection.thrift_backend._auth_provider._header_factory
 
         session = Session()
         session.auth = BearerAuth(headers)


### PR DESCRIPTION
### Description

This is a follow-up to #555 to fix a typo in `connections.py`. I have confirmed that this PR now passes the `TestMaterializedView` tests. The value of `self._cursor.connection.thrift_backend._auth_provider._header_factory` is a callable which is instantiated by `BearerAuth` and returns a dictionary. So we don't need to call it from `connections.py`.

No addition to the changelog since the previous PR hasn't been released yet.


<!--- Describe the Pull Request here -->

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
