### PR TITLE
Improve incremental merge on partitioned models

### DIFF
--- a/dbt/include/databricks/macros/materializations/incremental/convert_to_list.sql
+++ b/dbt/include/databricks/macros/materializations/incremental/convert_to_list.sql
@@ -1,0 +1,9 @@
+{% macro convert_to_list(v, default_value=none) %}
+    {% if v is none %}
+        {{ return(default_value) }}
+    {% elif v is sequence and v is not mapping and v is not string %}
+        {{ return(v) }}
+    {% else %}
+        {{ return([v]) }}
+    {% endif %}
+{% endmacro %}

--- a/dbt/include/databricks/macros/materializations/incremental/strategies.sql
+++ b/dbt/include/databricks/macros/materializations/incremental/strategies.sql
@@ -57,7 +57,7 @@
 
 {% endmacro %}
 
-{% macro quote_value(val) %}
+{% macro _quote_value(val) %}
     {%- if val is number or val is boolean -%}
         {{ val }}
     {%- else -%}
@@ -65,7 +65,7 @@
     {%- endif -%}
 {% endmacro %}
 
-{% macro convert_to_list(v, default_value=none) %}
+{% macro _convert_to_list(v, default_value=none) %}
     {% if v is none %}
         {{ return(default_value) }}
     {% elif v is sequence and v is not mapping and v is not string %}
@@ -75,14 +75,14 @@
     {% endif %}
 {% endmacro %}
 
-{% macro add_dest_table_partition_predicates(predicates, partition_columns, source) %}
+{% macro _add_dest_table_partition_predicates(predicates, partition_columns, source) %}
     {%- set result_predicates = [] if predicates is none else [] + predicates -%}
 
     {% if not partition_columns or not execute %}
         {{ return(result_predicates) }}
     {% endif %}
 
-    {%- set _partition_columns = [] + convert_to_list(partition_columns, default_value=[]) -%}
+    {%- set _partition_columns = [] + _convert_to_list(partition_columns, default_value=[]) -%}
     {%- set partition_values_query %}
         select
         {%- for partition_column in _partition_columns %}
@@ -100,8 +100,8 @@
 
             {% if this_partition_min_value is not none and this_partition_max_value is not none %}
                 {%- set this_partition_filter %}
-                    DBT_INTERNAL_DEST.{{ _partition_columns[n] }} >= {{ quote_value(this_partition_min_value) }}
-                    and DBT_INTERNAL_DEST.{{ _partition_columns[n] }} <= {{ quote_value(this_partition_max_value) }}
+                    DBT_INTERNAL_DEST.{{ _partition_columns[n] }} >= {{ _quote_value(this_partition_min_value) }}
+                    and DBT_INTERNAL_DEST.{{ _partition_columns[n] }} <= {{ _quote_value(this_partition_max_value) }}
                 {%- endset %}
                 {% do result_predicates.append(this_partition_filter) %}
             {% endif %}
@@ -118,8 +118,8 @@
   {%- set merge_update_columns = config.get('merge_update_columns') -%}
   {%- set merge_exclude_columns = config.get('merge_exclude_columns') -%}
   {%- set update_columns = get_merge_update_columns(merge_update_columns, merge_exclude_columns, dest_columns) -%}
-  {%- set partition_by_columns = convert_to_list(config.get('partition_by', none), default_value=[]) -%}
-  {%- set liquid_clustered_columns = convert_to_list(config.get('liquid_clustered_by', none), default_value=[]) -%}
+  {%- set partition_by_columns = _convert_to_list(config.get('partition_by', none), default_value=[]) -%}
+  {%- set liquid_clustered_columns = _convert_to_list(config.get('liquid_clustered_by', none), default_value=[]) -%}
   {%- set partition_columns = partition_by_columns + liquid_clustered_columns -%}
 
   {% if unique_key %}
@@ -140,7 +140,7 @@
       {% do predicates.append('FALSE') %}
   {% endif %}
 
-  {%- set predicates = add_dest_table_partition_predicates(predicates=predicates, partition_columns=partition_columns, source=source) -%}
+  {%- set predicates = _add_dest_table_partition_predicates(predicates=predicates, partition_columns=partition_columns, source=source) -%}
 
   {{ sql_header if sql_header is not none }}
 

--- a/dbt/include/databricks/macros/materializations/incremental/strategies.sql
+++ b/dbt/include/databricks/macros/materializations/incremental/strategies.sql
@@ -103,6 +103,16 @@
     {{ return(result_predicates) }}
 {% endmacro %}
 
+{% macro convert_to_list(v, default_value=none) %}
+    {% if v is none %}
+        {{ return(default_value) }}
+    {% elif v is sequence and v is not mapping and v is not string %}
+        {{ return(v) }}
+    {% else %}
+        {{ return([v]) }}
+    {% endif %}
+{% endmacro %}
+
 {% macro databricks__get_merge_sql(target, source, unique_key, dest_columns, incremental_predicates) %}
   {# need dest_columns for merge_exclude_columns, default to use "*" #}
   {%- set predicates = [] if incremental_predicates is none else [] + incremental_predicates -%}
@@ -110,7 +120,9 @@
   {%- set merge_update_columns = config.get('merge_update_columns') -%}
   {%- set merge_exclude_columns = config.get('merge_exclude_columns') -%}
   {%- set update_columns = get_merge_update_columns(merge_update_columns, merge_exclude_columns, dest_columns) -%}
-  {%- set partition_columns = config.get('partition_by', []) + config.get('liquid_clustered_by', []) -%}
+  {%- set partition_by_columns = convert_to_list(config.get('partition_by', none), default_value=[]) -%}
+  {%- set liquid_clustered_columns = convert_to_list(config.get('liquid_clustered_by', none), default_value=[]) -%}
+  {%- set partition_columns = partition_by_columns + liquid_clustered_columns -%}
 
   {% if unique_key %}
       {% if unique_key is sequence and unique_key is not mapping and unique_key is not string %}

--- a/dbt/include/databricks/macros/materializations/incremental/strategies.sql
+++ b/dbt/include/databricks/macros/materializations/incremental/strategies.sql
@@ -57,35 +57,27 @@
 
 {% endmacro %}
 
-{% macro _quote_value(val) %}
-    {%- if val is number or val is boolean -%}
+{% macro to_literal(val) %}
+    {%- if val is none -%}
+        NULL
+    {%- elif val is number or val is boolean -%}
         {{ val }}
     {%- else -%}
         '{{ val }}'
     {%- endif -%}
 {% endmacro %}
 
-{% macro _convert_to_list(v, default_value=none) %}
-    {% if v is none %}
-        {{ return(default_value) }}
-    {% elif v is sequence and v is not mapping and v is not string %}
-        {{ return(v) }}
-    {% else %}
-        {{ return([v]) }}
-    {% endif %}
-{% endmacro %}
-
-{% macro _add_dest_table_partition_predicates(predicates, partition_columns, source) %}
-    {%- set result_predicates = [] if predicates is none else [] + predicates -%}
+{% macro add_dest_table_partition_predicates(predicates, partition_columns, source) %}
+    {%- set result_predicates = convert_to_list(predicates, default_value=[]) -%}
 
     {% if not partition_columns or not execute %}
         {{ return(result_predicates) }}
     {% endif %}
 
-    {%- set _partition_columns = [] + _convert_to_list(partition_columns, default_value=[]) -%}
+    {%- set partition_columns = convert_to_list(partition_columns, default_value=[]) -%}
     {%- set partition_values_query %}
         select
-        {%- for partition_column in _partition_columns %}
+        {%- for partition_column in partition_columns %}
             MIN({{ adapter.quote(partition_column) }}), 
             MAX({{ adapter.quote(partition_column) }}){%- if not loop.last %}, {%- endif %}
         {%- endfor %}
@@ -94,14 +86,14 @@
     {%- set partition_value_results = run_query(partition_values_query) -%}
 
     {% if partition_value_results|length > 0 %}
-        {%- for n in range(_partition_columns|length) %}
+        {%- for n in range(partition_columns|length) %}
             {%- set this_partition_min_value = partition_value_results.columns[n * 2][0] -%}
             {%- set this_partition_max_value = partition_value_results.columns[n * 2 + 1][0] -%}
 
             {% if this_partition_min_value is not none and this_partition_max_value is not none %}
                 {%- set this_partition_filter %}
-                    DBT_INTERNAL_DEST.{{ _partition_columns[n] }} >= {{ _quote_value(this_partition_min_value) }}
-                    and DBT_INTERNAL_DEST.{{ _partition_columns[n] }} <= {{ _quote_value(this_partition_max_value) }}
+                    DBT_INTERNAL_DEST.{{ partition_columns[n] }} >= {{ to_literal(this_partition_min_value) }}
+                    and DBT_INTERNAL_DEST.{{ partition_columns[n] }} <= {{ to_literal(this_partition_max_value) }}
                 {%- endset %}
                 {% do result_predicates.append(this_partition_filter) %}
             {% endif %}
@@ -118,8 +110,8 @@
   {%- set merge_update_columns = config.get('merge_update_columns') -%}
   {%- set merge_exclude_columns = config.get('merge_exclude_columns') -%}
   {%- set update_columns = get_merge_update_columns(merge_update_columns, merge_exclude_columns, dest_columns) -%}
-  {%- set partition_by_columns = _convert_to_list(config.get('partition_by', none), default_value=[]) -%}
-  {%- set liquid_clustered_columns = _convert_to_list(config.get('liquid_clustered_by', none), default_value=[]) -%}
+  {%- set partition_by_columns = convert_to_list(config.get('partition_by', none), default_value=[]) -%}
+  {%- set liquid_clustered_columns = convert_to_list(config.get('liquid_clustered_by', none), default_value=[]) -%}
   {%- set partition_columns = partition_by_columns + liquid_clustered_columns -%}
 
   {% if unique_key %}
@@ -140,7 +132,7 @@
       {% do predicates.append('FALSE') %}
   {% endif %}
 
-  {%- set predicates = _add_dest_table_partition_predicates(predicates=predicates, partition_columns=partition_columns, source=source) -%}
+  {%- set predicates = add_dest_table_partition_predicates(predicates=predicates, partition_columns=partition_columns, source=source) -%}
 
   {{ sql_header if sql_header is not none }}
 

--- a/dbt/include/databricks/macros/materializations/incremental/strategies.sql
+++ b/dbt/include/databricks/macros/materializations/incremental/strategies.sql
@@ -130,7 +130,7 @@
       {% do predicates.append('FALSE') %}
   {% endif %}
 
-  {%- set predicates = add_dest_table_partition_predicates(predicates, partition_columns, source) -%}
+  {%- set predicates = add_dest_table_partition_predicates(predicates=predicates, partition_columns=partition_columns, source=source) -%}
 
   {{ sql_header if sql_header is not none }}
 

--- a/tests/unit/macros/materializations/incremental/test_convert_to_list_macro.py
+++ b/tests/unit/macros/materializations/incremental/test_convert_to_list_macro.py
@@ -13,7 +13,15 @@ class TestConvertToListMacro(MacroTestBase):
         return "convert_to_list.sql"
 
     @pytest.mark.parametrize(
-        "func_input,expected", [(["a"], ["a"]), (None, []), ([], [])]
+        "func_input,expected",
+        [
+            (["a", "b", "c"], ["a", "b", "c"]),
+            (None, []),
+            ([], []),
+            ("a", ["a"]),
+            (True, [True]),
+            (1, [1]),
+        ],
     )
     def test_convert_to_list_default_empty_list(self, template, func_input, expected):
         actual = self.run_macro(template, "convert_to_list", func_input, [])

--- a/tests/unit/macros/materializations/incremental/test_convert_to_list_macro.py
+++ b/tests/unit/macros/materializations/incremental/test_convert_to_list_macro.py
@@ -1,0 +1,20 @@
+import pytest
+
+from tests.unit.macros.base import MacroTestBase
+
+
+class TestConvertToListMacro(MacroTestBase):
+    @pytest.fixture(scope="class")
+    def macro_folders_to_load(self) -> list:
+        return ["macros/materializations/incremental"]
+
+    @pytest.fixture(scope="class")
+    def template_name(self) -> str:
+        return "convert_to_list.sql"
+
+    @pytest.mark.parametrize(
+        "func_input,expected", [(["a"], ["a"]), (None, []), ([], [])]
+    )
+    def test_convert_to_list_default_empty_list(self, template, func_input, expected):
+        actual = self.run_macro(template, "convert_to_list", func_input, [])
+        assert actual == f"{expected}"

--- a/tests/unit/macros/materializations/incremental/test_strategy_macros.py
+++ b/tests/unit/macros/materializations/incremental/test_strategy_macros.py
@@ -26,9 +26,7 @@ class TestStrategytMacros(MacroTestBase):
         return "strategies.sql"
 
     @pytest.mark.parametrize("partition_columns", [["id"], [], None, "id"])
-    def test_add_dest_table_partition_predicates_returns_input(
-        self, template, partition_columns
-    ):
+    def test_add_dest_table_partition_predicates_returns_input(self, template, partition_columns):
         predicates = ["test", "123", "456"]
         expected = f"{predicates} {predicates}"
 
@@ -119,10 +117,7 @@ class TestStrategytMacroAddPartitionPredicatesExecutionWithQuery(MacroTestBase):
         )
 
         def side_effect(arg):
-            if (
-                re.sub(r"\s\s+", " ", arg).strip()
-                == re.sub(r"\s\s+", " ", expected_query).strip()
-            ):
+            if re.sub(r"\s\s+", " ", arg).strip() == re.sub(r"\s\s+", " ", expected_query).strip():
                 return run_query_return
 
             raise RuntimeError(f"Unexpected query: {arg}")

--- a/tests/unit/macros/materializations/incremental/test_strategy_macros.py
+++ b/tests/unit/macros/materializations/incremental/test_strategy_macros.py
@@ -1,0 +1,123 @@
+import re
+
+import pytest
+from agate import Date, Number, Table, Text
+from mock.mock import Mock
+
+from tests.unit.macros.base import MacroTestBase
+
+
+class TestStrategytMacros(MacroTestBase):
+    @pytest.fixture(scope="class")
+    def macro_folders_to_load(self) -> list:
+        return ["macros/materializations/incremental"]
+
+    @pytest.fixture(scope="class")
+    def template_name(self) -> str:
+        return "strategies.sql"
+
+    def run_add_predicates_macro(
+        self, template, context, predicates, partition_columns
+    ) -> str:
+        context["adapter"].quote.side_effect = lambda x: x
+        context["convert_to_list"] = lambda x, default_value=None: x if x else []
+        return self.run_macro(
+            template,
+            "add_dest_table_partition_predicates",
+            predicates,
+            partition_columns,
+            "test_relation",
+        )
+
+    @pytest.mark.parametrize("partition_columns", [["id"], [], None, "id"])
+    def test_add_dest_table_partition_predicates_returns_input(
+        self, template, context, partition_columns
+    ):
+        context["execute"] = False
+        context["run_query"] = Mock(return_value=[])
+        predicates = ["test", "123", "456"]
+        expected = f"{predicates} {predicates}"
+
+        actual = self.run_add_predicates_macro(
+            template, context, predicates, partition_columns
+        )
+
+        assert actual == expected
+
+    @pytest.mark.parametrize("partition_columns", [[], None])
+    def test_add_dest_table_partition_predicates_no_query_with_no_partition_columns(
+        self, template, context, partition_columns
+    ):
+        context["execute"] = True
+        context["run_query"] = Mock(return_value=[])
+        predicates = ["test", "123", "456"]
+        expected = f"{predicates} {predicates}"
+
+        actual = self.run_add_predicates_macro(
+            template, context, predicates, partition_columns
+        )
+
+        assert actual == expected
+
+    def test_add_dest_table_partition_predicates_correct_query(self, template, context):
+        partition_columns = ["date", "code", "id"]
+        soure_name = "test_relation"
+        partition_query_statements = ",\n\t    ".join(
+            [f"MIN({c})," + "\n\t    " + f"MAX({c})" for c in partition_columns]
+        )
+        expected_query = f"""
+        select
+            {partition_query_statements}
+        from {soure_name}"""
+        partition_column_return = ["2024-01-01", "2024-01-10", "a", "z", 0, 9832]
+        partition_column_output_formatted = [
+            "'2024-01-01'",
+            "'2024-01-10'",
+            "'a'",
+            "'z'",
+            0,
+            9832,
+        ]
+        run_query_return = Table(
+            [partition_column_return],
+            column_names=[f"c{n}" for n in range(len(partition_column_return))],
+            column_types=[Date(), Date(), Text(), Text(), Number(), Number()],
+        )
+
+        def side_effect(arg):
+            if (
+                re.sub(r"\s\s+", " ", arg).strip()
+                == re.sub(r"\s\s+", " ", expected_query).strip()
+            ):
+                return run_query_return
+
+            raise RuntimeError(f"Unexpected query: {arg}")
+
+        context["execute"] = True
+        context["run_query"] = Mock(side_effect=side_effect)
+        predicates = None
+        expected_predicates = []
+
+        for i, col_name in enumerate(partition_columns):
+            min_val = partition_column_output_formatted[i * 2]
+            max_val = partition_column_output_formatted[i * 2 + 1]
+            expected_predicates += [
+                f" DBT_INTERNAL_DEST.{col_name} >= {min_val} "
+                f"and DBT_INTERNAL_DEST.{col_name} <= {max_val}"
+            ]
+
+        expected = f"{expected_predicates}"
+
+        actual = self.run_add_predicates_macro(
+            template, context, predicates, partition_columns
+        ).replace(r"\n", "")
+
+        assert actual == expected
+
+    @pytest.mark.parametrize(
+        "func_input, expected", [(1, "1"), (None, "NULL"), ("1", "'1'"), (True, "True")]
+    )
+    def test_to_literal(self, template, func_input, expected):
+        actual = self.run_macro(template, "to_literal", func_input)
+
+        assert actual == expected

--- a/tests/unit/macros/materializations/incremental/test_strategy_macros.py
+++ b/tests/unit/macros/materializations/incremental/test_strategy_macros.py
@@ -8,6 +8,15 @@ from tests.unit.macros.base import MacroTestBase
 
 
 class TestStrategytMacros(MacroTestBase):
+    @pytest.fixture(scope="class", autouse=True)
+    def modify_context(self, default_context) -> None:
+        default_context["adapter"].quote.side_effect = lambda x: x
+        default_context["convert_to_list"] = Mock(
+            side_effect=lambda x, default_value=None: x if x else []
+        )
+        default_context["execute"] = False
+        default_context["run_query"] = Mock(return_value=[])
+
     @pytest.fixture(scope="class")
     def macro_folders_to_load(self) -> list:
         return ["macros/materializations/incremental"]
@@ -16,12 +25,14 @@ class TestStrategytMacros(MacroTestBase):
     def template_name(self) -> str:
         return "strategies.sql"
 
-    def run_add_predicates_macro(
-        self, template, context, predicates, partition_columns
-    ) -> str:
-        context["adapter"].quote.side_effect = lambda x: x
-        context["convert_to_list"] = lambda x, default_value=None: x if x else []
-        return self.run_macro(
+    @pytest.mark.parametrize("partition_columns", [["id"], [], None, "id"])
+    def test_add_dest_table_partition_predicates_returns_input(
+        self, template, partition_columns
+    ):
+        predicates = ["test", "123", "456"]
+        expected = f"{predicates} {predicates}"
+
+        actual = self.run_macro(
             template,
             "add_dest_table_partition_predicates",
             predicates,
@@ -29,37 +40,60 @@ class TestStrategytMacros(MacroTestBase):
             "test_relation",
         )
 
-    @pytest.mark.parametrize("partition_columns", [["id"], [], None, "id"])
-    def test_add_dest_table_partition_predicates_returns_input(
-        self, template, context, partition_columns
-    ):
-        context["execute"] = False
-        context["run_query"] = Mock(return_value=[])
-        predicates = ["test", "123", "456"]
-        expected = f"{predicates} {predicates}"
+        assert actual == expected
 
-        actual = self.run_add_predicates_macro(
-            template, context, predicates, partition_columns
-        )
+    @pytest.mark.parametrize(
+        "func_input, expected", [(1, "1"), (None, "NULL"), ("1", "'1'"), (True, "True")]
+    )
+    def test_to_literal(self, template, func_input, expected):
+        actual = self.run_macro(template, "to_literal", func_input)
 
         assert actual == expected
+
+
+class TestStrategytMacroAddPartitionPredicatesExecutionWithoutQuery(MacroTestBase):
+    @pytest.fixture(scope="class")
+    def macro_folders_to_load(self) -> list:
+        return ["macros/materializations/incremental"]
+
+    @pytest.fixture(scope="class")
+    def template_name(self) -> str:
+        return "strategies.sql"
 
     @pytest.mark.parametrize("partition_columns", [[], None])
     def test_add_dest_table_partition_predicates_no_query_with_no_partition_columns(
-        self, template, context, partition_columns
+        self, template_bundle, partition_columns
     ):
-        context["execute"] = True
-        context["run_query"] = Mock(return_value=[])
+        template_bundle.context["adapter"].quote.side_effect = lambda x: x
+        template_bundle.context["convert_to_list"] = Mock(
+            side_effect=lambda x, default_value=None: x if x else []
+        )
+        template_bundle.context["execute"] = True
+        template_bundle.context["run_query"] = Mock(return_value=[])
         predicates = ["test", "123", "456"]
         expected = f"{predicates} {predicates}"
 
-        actual = self.run_add_predicates_macro(
-            template, context, predicates, partition_columns
+        actual = self.run_macro(
+            template_bundle.template,
+            "add_dest_table_partition_predicates",
+            predicates,
+            partition_columns,
+            "test_relation",
         )
 
         assert actual == expected
 
-    def test_add_dest_table_partition_predicates_correct_query(self, template, context):
+
+class TestStrategytMacroAddPartitionPredicatesExecutionWithQuery(MacroTestBase):
+    @pytest.fixture(scope="class")
+    def macro_folders_to_load(self) -> list:
+        return ["macros/materializations/incremental"]
+
+    @pytest.fixture(scope="class")
+    def template_name(self) -> str:
+        return "strategies.sql"
+
+    def test_add_dest_table_partition_predicates_correct_query(self, template_bundle):
         partition_columns = ["date", "code", "id"]
         soure_name = "test_relation"
         partition_query_statements = ",\n\t    ".join(
@@ -93,8 +127,13 @@ class TestStrategytMacros(MacroTestBase):
 
             raise RuntimeError(f"Unexpected query: {arg}")
 
-        context["execute"] = True
-        context["run_query"] = Mock(side_effect=side_effect)
+        run_query_mock = Mock(side_effect=side_effect)
+        template_bundle.context["execute"] = True
+        template_bundle.context["adapter"].quote.side_effect = lambda x: x
+        template_bundle.context["convert_to_list"] = Mock(
+            side_effect=lambda x, default_value=None: x if x else []
+        )
+        template_bundle.context["run_query"] = run_query_mock
         predicates = None
         expected_predicates = []
 
@@ -108,16 +147,13 @@ class TestStrategytMacros(MacroTestBase):
 
         expected = f"{expected_predicates}"
 
-        actual = self.run_add_predicates_macro(
-            template, context, predicates, partition_columns
+        actual = self.run_macro(
+            template_bundle.template,
+            "add_dest_table_partition_predicates",
+            predicates,
+            partition_columns,
+            soure_name,
         ).replace(r"\n", "")
 
-        assert actual == expected
-
-    @pytest.mark.parametrize(
-        "func_input, expected", [(1, "1"), (None, "NULL"), ("1", "'1'"), (True, "True")]
-    )
-    def test_to_literal(self, template, func_input, expected):
-        actual = self.run_macro(template, "to_literal", func_input)
-
+        run_query_mock.assert_called_once()
         assert actual == expected


### PR DESCRIPTION
### Description

At Otrium I have been seeing very poor incremental merge performance on large tables that have partitions. For some reason, Databricks doesn't do partition pruning on the destination table when merging a set of data that only touches a few partitions. I fixed this in our production dbt project by:

1. Executing a simple query that gets the min and max value of each partition column of the update/source dataset.
2. Adding a filter on the destination table's partition columns using the min and max values previously retrieved.

The code doesn't change the merge statement when no `partition_by` or `liquid_clustered_by` is specified.

I tested this code on Otrium's Databricks for AWS workspace using a SQL Classic Warehouse (preview channel - v 2023.50).
I didn't add tests yet, as I am not sure how thoroughly you want this tested but I'm happy to add some :)

### Checklist

- [yes] I have run this code in development and it appears to resolve the stated issue
- [yes] This PR includes tests, or tests are not required/relevant for this PR
- [no] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
