### PR TITLE
Show details with connection errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Fixed Hive performance regression by streamlining materialization type acquisition ([557](https://github.com/databricks/dbt-databricks/pull/557))
 - Fix: Python models authentication could be overridden by a `.netrc` file in the user's home directory ([338](https://github.com/databricks/dbt-databricks/pull/338))
 - Fix: MV/ST REST api authentication could be overriden by a `.netrc` file in the user's home directory ([555](https://github.com/databricks/dbt-databricks/pull/555))
+- Show details in connection errors ([562](https://github.com/databricks/dbt-databricks/pull/562))
 
 ### Under the Hood
 

--- a/dbt/adapters/databricks/connections.py
+++ b/dbt/adapters/databricks/connections.py
@@ -1486,7 +1486,7 @@ def _get_table_view_pipeline_id(session: Session, host: str, name: str) -> str:
     resp1 = session.get(table_url)
     if resp1.status_code != 200:
         raise dbt.exceptions.DbtRuntimeError(
-            f"Error getting info for materialized view/streaming table: {name}"
+            f"Error getting info for materialized view/streaming table {name}: {resp1.text}"
         )
 
     pipeline_id = resp1.json().get("pipeline_id", "")
@@ -1503,7 +1503,7 @@ def _get_pipeline_state(session: Session, host: str, pipeline_id: str) -> dict:
 
     response = session.get(pipeline_url)
     if response.status_code != 200:
-        raise dbt.exceptions.DbtRuntimeError(f"Error getting pipeline info: {pipeline_id}")
+        raise dbt.exceptions.DbtRuntimeError(f"Error getting pipeline info for {pipeline_id}: {response.text}")
 
     return response.json()
 
@@ -1529,7 +1529,7 @@ def _get_update_error_msg(session: Session, host: str, pipeline_id: str, update_
     events_url = f"https://{host}/api/2.0/pipelines/{pipeline_id}/events"
     response = session.get(events_url)
     if response.status_code != 200:
-        raise dbt.exceptions.DbtRuntimeError(f"Error getting pipeline event info: {pipeline_id}")
+        raise dbt.exceptions.DbtRuntimeError(f"Error getting pipeline event info for {pipeline_id}: {response.text}")
 
     events = response.json().get("events", [])
     update_events = [

--- a/dbt/adapters/databricks/connections.py
+++ b/dbt/adapters/databricks/connections.py
@@ -1503,7 +1503,9 @@ def _get_pipeline_state(session: Session, host: str, pipeline_id: str) -> dict:
 
     response = session.get(pipeline_url)
     if response.status_code != 200:
-        raise dbt.exceptions.DbtRuntimeError(f"Error getting pipeline info for {pipeline_id}: {response.text}")
+        raise dbt.exceptions.DbtRuntimeError(
+            f"Error getting pipeline info for {pipeline_id}: {response.text}"
+        )
 
     return response.json()
 
@@ -1529,7 +1531,9 @@ def _get_update_error_msg(session: Session, host: str, pipeline_id: str, update_
     events_url = f"https://{host}/api/2.0/pipelines/{pipeline_id}/events"
     response = session.get(events_url)
     if response.status_code != 200:
-        raise dbt.exceptions.DbtRuntimeError(f"Error getting pipeline event info for {pipeline_id}: {response.text}")
+        raise dbt.exceptions.DbtRuntimeError(
+            f"Error getting pipeline event info for {pipeline_id}: {response.text}"
+        )
 
     events = response.json().get("events", [])
     update_events = [


### PR DESCRIPTION
This PR adds some additional logging for connection errors. While debugging dbt issues over the past few weeks, I ran into errors like "Access denied to clusters that don't have Unity Catalog enabled." Without this patch, they are not shown to the user.

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
