### PR TITLE
Pinning pandas to stop test errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 - Adding retries around API calls in python model submission ([549](https://github.com/databricks/dbt-databricks/pull/549))
 - Upgrade to databricks-sql-connector 3.0.0 ([554](https://github.com/databricks/dbt-databricks/pull/554))
-- Pinning pandas to 2.1.x to keep from breaking multiple tests ([564](https://github.com/databricks/dbt-databricks/pull/554))
+- Pinning pandas to < 2.2.0 to keep from breaking multiple tests ([564](https://github.com/databricks/dbt-databricks/pull/554))
 
 ## dbt-databricks 1.7.3 (Dec 12, 2023)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 - Adding retries around API calls in python model submission ([549](https://github.com/databricks/dbt-databricks/pull/549))
 - Upgrade to databricks-sql-connector 3.0.0 ([554](https://github.com/databricks/dbt-databricks/pull/554))
+- Pinning pandas to 2.1.x to keep from breaking multiple tests ([564](https://github.com/databricks/dbt-databricks/pull/554))
 
 ## dbt-databricks 1.7.3 (Dec 12, 2023)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ databricks-sql-connector>=3.0.0, <3.1.0
 dbt-spark~=1.7.1
 databricks-sdk>=0.9.0, <0.16.0
 keyring>=23.13.0
+pandas>=2.1.0,<2.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ databricks-sql-connector>=3.0.0, <3.1.0
 dbt-spark~=1.7.1
 databricks-sdk>=0.9.0, <0.16.0
 keyring>=23.13.0
-pandas>=2.1.0,<2.2.0
+pandas<2.2.0

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
         "databricks-sql-connector>=3.0.0, <3.1.0",
         "databricks-sdk>=0.9.0, <0.16.0",
         "keyring>=23.13.0",
-        "pandas>=2.1.0,<2.2.0",
+        "pandas<2.2.0",
     ],
     zip_safe=False,
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,7 @@ setup(
         "databricks-sql-connector>=3.0.0, <3.1.0",
         "databricks-sdk>=0.9.0, <0.16.0",
         "keyring>=23.13.0",
+        "pandas>=2.1.0,<2.2.0",
     ],
     zip_safe=False,
     classifiers=[


### PR DESCRIPTION
<!---
  Include the number of the issue addressed by this PR above if applicable.
  
  Example:
    resolves #1234

  Please review our pull request review process in CONTRIBUTING.md before your proceed.
-->

### Description

We started getting a variety of tests failing with pandas 2.2.0; for now, pinning the version to 2.1.x, and monitoring the situation on pandas.

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
