### PR TITLE
Use null safe comparison for merge sql

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,10 @@
 ## dbt-databricks 1.7.8 (TBD)
 
-### Features
-
-- Support `on_config_change` for materialized views, expand the supported config options ([536](https://github.com/databricks/dbt-databricks/pull/536)))
-
 ### Fixes
 
 - Fixed the behavior of the incremental schema change ignore option to properly handle the scenario when columns are dropped (thanks @case-k-git!) ([580](https://github.com/databricks/dbt-databricks/pull/580))
 - Fixed export of saved queries (thanks @peterallenwebb!) ([588](https://github.com/databricks/dbt-databricks/pull/588))
+- Properly match against null for merging matching rows ([590](https://github.com/databricks/dbt-databricks/pull/590))
 
 ## dbt-databricks 1.7.7 (Feb 6, 2024)
 

--- a/dbt/include/databricks/macros/materializations/incremental/strategies.sql
+++ b/dbt/include/databricks/macros/materializations/incremental/strategies.sql
@@ -75,13 +75,13 @@
       {% if unique_key is sequence and unique_key is not mapping and unique_key is not string %}
           {% for key in unique_key %}
               {% set this_key_match %}
-                  DBT_INTERNAL_SOURCE.{{ key }} = DBT_INTERNAL_DEST.{{ key }}
+                  DBT_INTERNAL_SOURCE.{{ key }} <=> DBT_INTERNAL_DEST.{{ key }}
               {% endset %}
               {% do predicates.append(this_key_match) %}
           {% endfor %}
       {% else %}
           {% set unique_key_match %}
-              DBT_INTERNAL_SOURCE.{{ unique_key }} = DBT_INTERNAL_DEST.{{ unique_key }}
+              DBT_INTERNAL_SOURCE.{{ unique_key }} <=> DBT_INTERNAL_DEST.{{ unique_key }}
           {% endset %}
           {% do predicates.append(unique_key_match) %}
       {% endif %}


### PR DESCRIPTION
<!---
  Include the number of the issue addressed by this PR above if applicable.
  
  Example:
    resolves #1234

  Please review our pull request review process in CONTRIBUTING.md before your proceed.
-->

### Description

Using the previous form, if there was a null value in a unique key when trying to merge an incremental run, it would lead to a duplicate row (since NULL = NULL evaluates to false).

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
