### PR TITLE
Shard long passwords on Windows

### DIFF
--- a/dbt/adapters/databricks/connections.py
+++ b/dbt/adapters/databricks/connections.py
@@ -445,7 +445,7 @@ class DatabricksCredentials(Credentials):
             keyring.set_password(service_name, username, json.dumps(shard_info))
             # then store all shards with the shard number as postfix
             for i, s in enumerate(password_shards):
-                keyring.set_password(service_name, f"{username}|{i}", s)
+                keyring.set_password(service_name, f"{username}__{i}", s)
 
     def get_sharded_password(self, service_name: str, username: str) -> Optional[str]:
         password = keyring.get_password(service_name, username)
@@ -459,7 +459,7 @@ class DatabricksCredentials(Credentials):
 
                 password = ""
                 for i in range(shard_count):
-                    password += str(keyring.get_password(service_name, f"{username}|{i}"))
+                    password += str(keyring.get_password(service_name, f"{username}__{i}"))
         except ValueError:
             pass
 
@@ -474,7 +474,7 @@ class DatabricksCredentials(Credentials):
             if password_as_dict.get("sharded_password"):
                 shard_count = int(password_as_dict.get("shard_count"))
                 for i in range(shard_count):
-                    keyring.delete_password(service_name, f"{username}|{i}")
+                    keyring.delete_password(service_name, f"{username}__{i}")
         except ValueError:
             pass
 

--- a/dbt/adapters/databricks/connections.py
+++ b/dbt/adapters/databricks/connections.py
@@ -117,6 +117,7 @@ DBT_DATABRICKS_HTTP_SESSION_HEADERS = "DBT_DATABRICKS_HTTP_SESSION_HEADERS"
 REDIRECT_URL = "http://localhost:8020"
 CLIENT_ID = "dbt-databricks"
 SCOPES = ["all-apis", "offline_access"]
+MAX_NT_PASSWORD_SIZE = 1280
 
 # toggle for session managements that minimizes the number of sessions opened/closed
 USE_LONG_SESSIONS = os.getenv("DBT_DATABRICKS_LONG_SESSIONS", "True").upper() == "TRUE"
@@ -385,7 +386,7 @@ class DatabricksCredentials(Credentials):
             # optional branch. Try and keep going if it does not work
             try:
                 # try to get cached credentials
-                credsdict = keyring.get_password("dbt-databricks", host)
+                credsdict = self.get_sharded_password("dbt-databricks", host)
 
                 if credsdict:
                     provider = SessionCredentials.from_dict(oauth_client, json.loads(credsdict))
@@ -396,7 +397,7 @@ class DatabricksCredentials(Credentials):
                     except Exception as e:
                         logger.debug(e)
                         # whatever it is, get rid of the cache
-                        keyring.delete_password("dbt-databricks", host)
+                        self.delete_sharded_password("dbt-databricks", host)
 
             # error with keyring. Maybe machine has no password persistency
             except Exception as e:
@@ -410,7 +411,9 @@ class DatabricksCredentials(Credentials):
             # save for later
             self._credentials_provider = provider.as_dict()
             try:
-                keyring.set_password("dbt-databricks", host, json.dumps(self._credentials_provider))
+                self.set_sharded_password(
+                    "dbt-databricks", host, json.dumps(self._credentials_provider)
+                )
             # error with keyring. Maybe machine has no password persistency
             except Exception as e:
                 logger.debug(e)
@@ -420,6 +423,63 @@ class DatabricksCredentials(Credentials):
 
         finally:
             self._lock.release()
+
+    def set_sharded_password(self, service_name: str, username: str, password: str) -> None:
+        max_size = MAX_NT_PASSWORD_SIZE
+
+        # if not Windows or "small" password, stick to the default
+        if os.name != "nt" or len(password) < max_size:
+            keyring.set_password(service_name, username, password)
+        else:
+            logger.debug(f"password is {len(password)} characters, sharding it.")
+
+            password_shards = [
+                password[i : i + max_size] for i in range(0, len(password), max_size)
+            ]
+            shard_info = {
+                "sharded_password": True,
+                "shard_count": len(password_shards),
+            }
+
+            # store the "shard info" as the "base" password
+            keyring.set_password(service_name, username, json.dumps(shard_info))
+            # then store all shards with the shard number as postfix
+            for i, s in enumerate(password_shards):
+                keyring.set_password(service_name, f"{username}|{i}", s)
+
+    def get_sharded_password(self, service_name: str, username: str) -> Optional[str]:
+        password = keyring.get_password(service_name, username)
+
+        # check for "shard info" stored as json
+        try:
+            password_as_dict = json.loads(str(password))
+            if password_as_dict.get("sharded_password"):
+                # if password was stored shared, reconstruct it
+                shard_count = int(password_as_dict.get("shard_count"))
+
+                password = ""
+                for i in range(shard_count):
+                    password += str(keyring.get_password(service_name, f"{username}|{i}"))
+        except ValueError:
+            pass
+
+        return password
+
+    def delete_sharded_password(self, service_name: str, username: str) -> None:
+        password = keyring.get_password(service_name, username)
+
+        # check for "shard info" stored as json. If so delete all shards
+        try:
+            password_as_dict = json.loads(str(password))
+            if password_as_dict.get("sharded_password"):
+                shard_count = int(password_as_dict.get("shard_count"))
+                for i in range(shard_count):
+                    keyring.delete_password(service_name, f"{username}|{i}")
+        except ValueError:
+            pass
+
+        # delete "base" password
+        keyring.delete_password(service_name, username)
 
     def _provider_from_dict(self) -> Optional[TCredentialProvider]:
         if self.token:

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -71,3 +71,31 @@ class TestTokenAuth(unittest.TestCase):
         headers_fn2 = provider_b()
         headers2 = headers_fn2()
         self.assertEqual(headers, headers2)
+
+
+class TestShardedPassword(unittest.TestCase):
+    def test_store_short_password(self):
+        service = "dbt-databricks"
+        host = "my.cloud.databricks.com"
+        long_password = "x" * 10
+
+        creds = DatabricksCredentials(
+            host=host, token="foo", database="andre", http_path="http://foo", schema="dbt"
+        )
+        creds.set_sharded_password(service, host, long_password)
+
+        retrieved_password = creds.get_sharded_password(service, host)
+        self.assertEqual(long_password, retrieved_password)
+
+    def test_store_long_password(self):
+        service = "dbt-databricks"
+        host = "my.cloud.databricks.com"
+        long_password = "x" * 2000
+
+        creds = DatabricksCredentials(
+            host=host, token="foo", database="andre", http_path="http://foo", schema="dbt"
+        )
+        creds.set_sharded_password(service, host, long_password)
+
+        retrieved_password = creds.get_sharded_password(service, host)
+        self.assertEqual(long_password, retrieved_password)

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -127,6 +127,7 @@ class MockKeyring(keyring.backend.KeyringBackend):
 
     def _generate_test_root_dir(self):
         import tempfile
+
         return tempfile.mkdtemp(prefix="dbt-unit-test-")
 
     def file_path(self, servicename, username):

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -1,5 +1,6 @@
 import unittest
 from dbt.adapters.databricks.connections import DatabricksCredentials
+import keyring.backend
 import pytest
 
 
@@ -74,7 +75,10 @@ class TestTokenAuth(unittest.TestCase):
 
 
 class TestShardedPassword(unittest.TestCase):
-    def test_store_short_password(self):
+    def test_store_and_delete_short_password(self):
+        # set the keyring to mock class
+        keyring.set_keyring(MockKeyring())
+
         service = "dbt-databricks"
         host = "my.cloud.databricks.com"
         long_password = "x" * 10
@@ -87,10 +91,18 @@ class TestShardedPassword(unittest.TestCase):
         retrieved_password = creds.get_sharded_password(service, host)
         self.assertEqual(long_password, retrieved_password)
 
-    def test_store_long_password(self):
+        # delete password
+        creds.delete_sharded_password(service, host)
+        retrieved_password = creds.get_sharded_password(service, host)
+        self.assertIsNone(retrieved_password)
+
+    def test_store_and_delete_long_password(self):
+        # set the keyring to mock class
+        keyring.set_keyring(MockKeyring())
+
         service = "dbt-databricks"
         host = "my.cloud.databricks.com"
-        long_password = "x" * 2000
+        long_password = "x" * 3000
 
         creds = DatabricksCredentials(
             host=host, token="foo", database="andre", http_path="http://foo", schema="dbt"
@@ -99,3 +111,54 @@ class TestShardedPassword(unittest.TestCase):
 
         retrieved_password = creds.get_sharded_password(service, host)
         self.assertEqual(long_password, retrieved_password)
+
+        # delete password
+        creds.delete_sharded_password(service, host)
+        retrieved_password = creds.get_sharded_password(service, host)
+        self.assertIsNone(retrieved_password)
+
+
+class MockKeyring(keyring.backend.KeyringBackend):
+    def __init__(self):
+        self.file_location = self._generate_test_root_dir()
+
+    def priority(self):
+        return 1
+
+    def _generate_test_root_dir(self):
+        import tempfile
+        return tempfile.mkdtemp(prefix="dbt-unit-test-")
+
+    def file_path(self, servicename, username):
+        from os.path import join
+
+        file_location = self.file_location
+        file_name = f"{servicename}_{username}.txt"
+        return join(file_location, file_name)
+
+    def set_password(self, servicename, username, password):
+        file_path = self.file_path(servicename, username)
+
+        with open(file_path, "w") as file:
+            file.write(password)
+
+    def get_password(self, servicename, username):
+        import os
+
+        file_path = self.file_path(servicename, username)
+        if not os.path.exists(file_path):
+            return None
+
+        with open(file_path, "r") as file:
+            password = file.read()
+
+        return password
+
+    def delete_password(self, servicename, username):
+        import os
+
+        file_path = self.file_path(servicename, username)
+        if not os.path.exists(file_path):
+            return None
+
+        os.remove(file_path)


### PR DESCRIPTION
Resolves #563 

### Description

When using the oAuth U2M flow on a windows laptop, the credentials are not stored in the Windows Credential Store because it exceed 1280 characters. Therefore, each call to Databricks results in a new authentication request (and opens a new tab in your browser). In this PR, all interaction with keyring (get, set and delete) is redirect to a custom function that will check the length and platform before storing the credentials. If on Windows and credentials are longer then 1280 characters, it will shard the password in chunk of 1280 and store those along with some meta data. When getting or deleting the credentials, it will check for this metadata and, if so fetch all shards and return the concatenated result or delete them all in case of a delete.

I have tested my code on a windows laptop as well as on a mac. On the mac, I first got the credentials with the current version in 1.7.8 so that it is stored, then replaced connections.py with the new version and ran a 'dbt debug' again to see if the stored credentials was fetched an used. It was.
I have added 2 Unit Tests to test both storing a long and a short password. All Unit Test succeeded.
I tried running the integration test but couldn't get them to run. The tox command seems to not like the bash commands on a windows laptop and running the python command directly causes all integration to fail on not finding the 'test' profile. 

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
