### PR TITLE
Do not fail when we cannot determine the table type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fix for U2M flow on windows (sharding long passwords) (thanks @thijs-nijhuis-shell!) ([597](https://github.com/databricks/dbt-databricks/pull/597))
 - Fix regression in incremental behavior, and align more with dbt-core expectations ([604](https://github.com/databricks/dbt-databricks/pull/604))
+- Don't fail for unknown types when listing schema ([600](https://github.com/databricks/dbt-databricks/pull/600))
 
 ## dbt-databricks 1.7.8 (Feb 22, 2024)
 

--- a/dbt/adapters/databricks/impl.py
+++ b/dbt/adapters/databricks/impl.py
@@ -387,9 +387,7 @@ class DatabricksAdapter(SparkAdapter):
                 else DatabricksRelationType.Table
             )
         else:
-            raise dbt.exceptions.DbtRuntimeError(
-                f"Unexpected relation type discovered: Database:{database}, Relation:{name}"
-            )
+            return DatabricksRelationType.Unknown
 
     def get_relation(
         self,

--- a/dbt/adapters/databricks/relation.py
+++ b/dbt/adapters/databricks/relation.py
@@ -35,6 +35,7 @@ class DatabricksRelationType(StrEnum):
     MaterializedView = "materializedview"
     External = "external"
     StreamingTable = "streamingtable"
+    Unknown = "unknown"
 
 
 @dataclass(frozen=True, eq=False, repr=False)


### PR DESCRIPTION
<!-- Please review our pull request review process in CONTRIBUTING.md before your proceed. -->

Resolves #598 

<!---
  Include the number of the issue addressed by this PR above if applicable.
  
  Example:
    resolves #1234

  Please review our pull request review process in CONTRIBUTING.md before your proceed.
-->

### Description

After discussing with @mikealfare I believe this should have minimal issues, given that the tables in question are temporary and should not be interacted with by a separate thread than the one that produced them.  If having an unknown type is actually problematic, this merely moves where the error will be realized, so should be no worse than current behavior, while at the same time improving behavior when the table is irrelevant.

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
