### PR TITLE
Prefer DEFAULT to NULL when inserting into, actually validate append

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## dbt-databricks 1.7.10 (TBD)
+
+### Fixes
+
+- Fix a corner case for insert into where NULL should be DEFAULT ([607](https://github.com/databricks/dbt-databricks/pull/607))
+
 ## dbt-databricks 1.7.9 (Mar 5, 2024)
 
 ### Fixes

--- a/dbt/include/databricks/macros/materializations/incremental/strategies.sql
+++ b/dbt/include/databricks/macros/materializations/incremental/strategies.sql
@@ -60,7 +60,7 @@
       {%- if dest_col in source_columns -%}
         {%- do common_columns.append(dest_col) -%}
       {%- else -%}
-        {%- do common_columns.append('NULL') -%}
+        {%- do common_columns.append('DEFAULT') -%}
       {%- endif -%}
     {%- endfor -%}
     {%- set dest_cols_csv = dest_columns | join(', ') -%}

--- a/tests/functional/adapter/incremental/test_incremental_on_schema_change.py
+++ b/tests/functional/adapter/incremental/test_incremental_on_schema_change.py
@@ -31,6 +31,10 @@ class TestIncrementalOnSchemaChange(BaseIncrementalOnSchemaChange):
 
 class TestIncrementalOnSchemaChangeAppend(BaseIncrementalOnSchemaChange):
     @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {"models": {"+incremental_strategy": "append"}}
+
+    @pytest.fixture(scope="class")
     def models(self):
         return {
             "incremental_sync_remove_only.sql": fixtures._MODELS__INCREMENTAL_SYNC_REMOVE_ONLY,

--- a/tests/unit/macros/relations/test_incremental_macros.py
+++ b/tests/unit/macros/relations/test_incremental_macros.py
@@ -87,7 +87,7 @@ class TestGeInsertIntoSQL(MacroTestBase):
 
     def test_insert_into_sql_impl__target_has_extra_columns(self, template):
         sql = self.render_insert_into(template, dest_columns=["a", "b"], source_columns=["b"])
-        expected = "insert into table target (a, b)\nselect NULL, b from source"
+        expected = "insert into table target (a, b)\nselect DEFAULT, b from source"
         assert sql == expected
 
     def test_insert_into_sql_impl__source_has_extra_columns(self, template):


### PR DESCRIPTION
<!---
  Include the number of the issue addressed by this PR above if applicable.
  
  Example:
    resolves #1234

  Please review our pull request review process in CONTRIBUTING.md before your proceed.
-->

### Description

A github user pointed out that technically using NULL could lead to different behavior than *, where DEFAULT would be honored for missing columns, so I have adjusted `insert into` to use DEFAULT instead.  Also, noticed that at some point I lost my config that made the append tests actually test append, so added that back.  The second half of the 'append columns' test for the append strategy validates that DEFAULT is used and does not break.

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
