### PR TITLE
Refactor logger out

### DIFF
--- a/dbt/adapters/databricks/impl.py
+++ b/dbt/adapters/databricks/impl.py
@@ -46,7 +46,6 @@ from dbt.adapters.spark.impl import (
 from dbt_common.clients.agate_helper import DEFAULT_TYPE_TESTER, empty_table
 from dbt.adapters.contracts.connection import AdapterResponse, Connection
 from dbt.adapters.contracts.relation import RelationType
-from dbt.adapters.events.logging import AdapterLogger
 from dbt_common.utils import executor
 
 from dbt.adapters.databricks.column import DatabricksColumn
@@ -70,9 +69,7 @@ from dbt.adapters.databricks.utils import redact_credentials, undefined_proof, g
 from dbt.adapters.relation_configs import RelationResults
 from dbt.adapters.contracts.relation import RelationConfig
 from dbt_common.exceptions import DbtRuntimeError
-
-
-logger = AdapterLogger("Databricks")
+from dbt.adapters.databricks.logging import logger
 
 CURRENT_CATALOG_MACRO_NAME = "current_catalog"
 USE_CATALOG_MACRO_NAME = "use_catalog"

--- a/dbt/adapters/databricks/logging.py
+++ b/dbt/adapters/databricks/logging.py
@@ -1,0 +1,28 @@
+import logging
+import os
+from typing import Union
+from dbt.adapters.events.logging import AdapterLogger
+
+logger = AdapterLogger("Databricks")
+
+
+class DbtCoreHandler(logging.Handler):
+    def __init__(self, level: Union[str, int], dbt_logger: AdapterLogger):
+        super().__init__(level=level)
+        self.logger = dbt_logger
+
+    def emit(self, record: logging.LogRecord) -> None:
+        # record.levelname will be debug, info, warning, error, or critical
+        # these map 1-to-1 with methods of the AdapterLogger
+        log_func = getattr(self.logger, record.levelname.lower())
+        log_func(record.msg)
+
+
+dbt_adapter_logger = AdapterLogger("databricks-sql-connector")
+
+pysql_logger = logging.getLogger("databricks.sql")
+pysql_logger_level = os.environ.get("DBT_DATABRICKS_CONNECTOR_LOG_LEVEL", "WARN").upper()
+pysql_logger.setLevel(pysql_logger_level)
+
+pysql_handler = DbtCoreHandler(dbt_logger=dbt_adapter_logger, level=pysql_logger_level)
+pysql_logger.addHandler(pysql_handler)

--- a/dbt/adapters/databricks/python_submissions.py
+++ b/dbt/adapters/databricks/python_submissions.py
@@ -12,15 +12,13 @@ import uuid
 
 from urllib3.util.retry import Retry
 
-from dbt.adapters.events.logging import AdapterLogger
+from dbt.adapters.databricks.logging import logger
 from dbt.adapters.base import PythonJobHelper
 
 from requests.adapters import HTTPAdapter
 from dbt.adapters.databricks.connections import BearerAuth
 from dbt_common.exceptions import DbtRuntimeError
 
-
-logger = AdapterLogger("Databricks")
 
 DEFAULT_POLLING_INTERVAL = 10
 SUBMISSION_LANGUAGE = "python"


### PR DESCRIPTION
### Description

Refactors logger construction out into a single location to reduce code replication and isolate logging logic from otherwise complicated files.

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
