### PR TITLE
Up default socket timeout to 600

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## dbt-databricks 1.7.12 (TBD)
+
+### Fixes
+
+- Up default socket timeout to 10 minutes
+
 ## dbt-databricks 1.7.11 (Mar 26, 2024)
 
 ### Fixes

--- a/dbt/adapters/databricks/connections.py
+++ b/dbt/adapters/databricks/connections.py
@@ -238,7 +238,7 @@ class DatabricksCredentials(Credentials):
                     f"{http_headers}."
                 )
         if "_socket_timeout" not in connection_parameters:
-            connection_parameters["_socket_timeout"] = 180
+            connection_parameters["_socket_timeout"] = 600
         self.connection_parameters = connection_parameters
 
     def validate_creds(self) -> None:


### PR DESCRIPTION
### Description

Resolves issue where serverless requests were dying just before the query completed due to socket timeout set at 3 minutes.  I think this has to do with either compute availability or direct result choice by Thrift server, but either way, we have seen instances where the query is killed at 3 minutes, but since closing the session doesn't actually cancel the work, the query completes successfully at around 4 minutes.

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
