### PR TITLE
lazy load agate

### DIFF
--- a/dbt/adapters/databricks/connections.py
+++ b/dbt/adapters/databricks/connections.py
@@ -20,9 +20,9 @@ from typing import List
 from typing import Optional
 from typing import Sequence
 from typing import Tuple
+from typing import TYPE_CHECKING
 
 import databricks.sql as dbsql
-from agate import Table
 from databricks.sql.client import Connection as DatabricksSQLConnection
 from databricks.sql.client import Cursor as DatabricksSQLCursor
 from databricks.sql.exc import Error
@@ -48,13 +48,15 @@ from dbt.adapters.events.types import NewConnection
 from dbt.adapters.events.types import SQLQuery
 from dbt.adapters.events.types import SQLQueryStatus
 from dbt.adapters.spark.connections import SparkConnectionManager
-from dbt_common.clients import agate_helper
 from dbt_common.events.contextvars import get_node_info
 from dbt_common.events.functions import fire_event
 from dbt_common.exceptions import DbtInternalError
 from dbt_common.exceptions import DbtRuntimeError
 from dbt_common.utils import cast_to_str
 from requests import Session
+
+if TYPE_CHECKING:
+    from agate import Table
 
 mv_refresh_regex = re.compile(r"refresh\s+materialized\s+view\s+([`\w.]+)", re.IGNORECASE)
 st_refresh_regex = re.compile(
@@ -622,7 +624,7 @@ class DatabricksConnectionManager(SparkConnectionManager):
         auto_begin: bool = False,
         fetch: bool = False,
         limit: Optional[int] = None,
-    ) -> Tuple[DatabricksAdapterResponse, Table]:
+    ) -> Tuple[DatabricksAdapterResponse, "Table"]:
         sql = self._add_query_comment(sql)
         _, cursor = self.add_query(sql, auto_begin)
         try:
@@ -630,6 +632,8 @@ class DatabricksConnectionManager(SparkConnectionManager):
             if fetch:
                 table = self.get_result_from_cursor(cursor, limit)
             else:
+                from dbt_common.clients import agate_helper
+
                 table = agate_helper.empty_table()
             return response, table
         finally:
@@ -637,7 +641,7 @@ class DatabricksConnectionManager(SparkConnectionManager):
 
     def _execute_cursor(
         self, log_sql: str, f: Callable[[DatabricksSQLCursorWrapper], None]
-    ) -> Table:
+    ) -> "Table":
         connection = self.get_thread_connection()
 
         fire_event(ConnectionUsed(conn_type=self.TYPE, conn_name=cast_to_str(connection.name)))
@@ -672,7 +676,7 @@ class DatabricksConnectionManager(SparkConnectionManager):
                 if cursor is not None:
                     cursor.close()
 
-    def list_schemas(self, database: str, schema: Optional[str] = None) -> Table:
+    def list_schemas(self, database: str, schema: Optional[str] = None) -> "Table":
         database = database.strip("`")
         if schema:
             schema = schema.strip("`").lower()
@@ -681,7 +685,7 @@ class DatabricksConnectionManager(SparkConnectionManager):
             lambda cursor: cursor.schemas(catalog_name=database, schema_name=schema),
         )
 
-    def list_tables(self, database: str, schema: str, identifier: Optional[str] = None) -> Table:
+    def list_tables(self, database: str, schema: str, identifier: Optional[str] = None) -> "Table":
         database = database.strip("`")
         schema = schema.strip("`").lower()
         if identifier:

--- a/dbt/adapters/databricks/impl.py
+++ b/dbt/adapters/databricks/impl.py
@@ -126,7 +126,7 @@ def get_identifier_list_string(table_names: Set[str]) -> str:
 
 def _parse_callback_empty_table(*args, **kwargs) -> Tuple[str, "Table"]:
     # Lazy load agate_helper to avoid importing agate when it is not necessary.
-    from dbt.clients.agate_helper import empty_table
+    from dbt_common.agate_helper import empty_table
 
     return "", empty_table()
 
@@ -173,7 +173,7 @@ class DatabricksAdapter(SparkAdapter):
             if self.connections.query_header is not None:
                 self.connections.query_header.reset()
 
-    @available.parse(_parse_callback_empty_table)
+    @available.parse(lambda *a, **k: 0)
     def compare_dbr_version(self, major: int, minor: int) -> int:
         """
         Returns the comparison result between the version of the cluster and the specified version.

--- a/dbt/adapters/databricks/impl.py
+++ b/dbt/adapters/databricks/impl.py
@@ -124,9 +124,9 @@ def get_identifier_list_string(table_names: Set[str]) -> str:
     return _identifier
 
 
-def _parse_callback_empty_table(*args, **kwargs) -> Tuple[str, "Table"]:
+def _parse_callback_empty_table(*args: Any, **kwargs: Any) -> Tuple[str, "Table"]:
     # Lazy load agate_helper to avoid importing agate when it is not necessary.
-    from dbt_common.agate_helper import empty_table
+    from dbt.clients.agate_helper import empty_table
 
     return "", empty_table()
 


### PR DESCRIPTION
TLDR: lazy-loading `agate` speeds up the load time of dbt by about 3.5%. Most instances of `agate` are unnecessary as dbt only uses it in a select few situations, and most instances of `agate` can be placed behind `TYPE_CHECKING`.

Already implemented in `dbt-adapters` and `dbt-core`.

- https://github.com/dbt-labs/dbt-adapters/pull/126
- https://github.com/dbt-labs/dbt-core/pull/9744

---

Note: usually I perform the following check with each adapter. The following code _should_ return an empty list:

```python
import sys
import dbt.adapters.databricks.impl
print([i for i in sys.modules if "agate" in i])
```

However, because `dbt-databricks` has not yet been migrated to the dbt-core `1.8` ecosystem, this check is not successful:

```python
>>> print([i for i in sys.modules if "agate" in i])
['agate.exceptions', 'agate.csv_py3', 'agate.aggregations.base', 'agate.data_types.base', 'agate.data_types.boolean', 'agate.data_types.date', 'agate.data_types.date_time', 'agate.data_types.number', 'agate.data_types.text', 'agate.data_types.time_delta', 'agate.data_types', 'agate.aggregations.all', 'agate.aggregations.any', 'agate.warns', 'agate.utils', 'agate.aggregations.count', 'agate.aggregations.has_nulls', 'agate.aggregations.percentiles', 'agate.aggregations.deciles', 'agate.aggregations.first', 'agate.aggregations.iqr', 'agate.aggregations.median', 'agate.aggregations.mad', 'agate.aggregations.max', 'agate.aggregations.max_length', 'agate.aggregations.max_precision', 'agate.aggregations.sum', 'agate.aggregations.mean', 'agate.aggregations.min', 'agate.aggregations.mode', 'agate.aggregations.quartiles', 'agate.aggregations.quintiles', 'agate.aggregations.variance', 'agate.aggregations.stdev', 'agate.aggregations.summary', 'agate.aggregations', 'agate.mapped_sequence', 'agate.columns', 'agate.computations.base', 'agate.computations.change', 'agate.computations.formula', 'agate.computations.percent', 'agate.computations.percent_change', 'agate.computations.rank', 'agate.computations.percentile_rank', 'agate.computations.slug', 'agate.computations', 'agate.config', 'agate.rows', 'agate.type_tester', 'agate.table.aggregate', 'agate.table.bar_chart', 'agate.table.bins', 'agate.table.column_chart', 'agate.table.compute', 'agate.table.denormalize', 'agate.table.distinct', 'agate.table.exclude', 'agate.table.find', 'agate.table.from_csv', 'agate.fixed', 'agate.table.from_fixed', 'agate.table.from_json', 'agate.table.from_object', 'agate.tableset.aggregate', 'agate.tableset.bar_chart', 'agate.tableset.column_chart', 'agate.tableset.from_csv', 'agate.tableset.from_json', 'agate.tableset.having', 'agate.tableset.line_chart', 'agate.tableset.merge', 'agate.tableset.print_structure', 'agate.tableset.proxy_methods', 'agate.tableset.scatterplot', 'agate.tableset.to_csv', 'agate.tableset.to_json', 'agate.tableset', 'agate.table.group_by', 'agate.table.homogenize', 'agate.table.join', 'agate.table.limit', 'agate.table.line_chart', 'agate.table.merge', 'agate.table.normalize', 'agate.table.order_by', 'agate.table.pivot', 'agate.table.print_bars', 'agate.table.print_html', 'agate.table.print_structure', 'agate.table.print_table', 'agate.table.rename', 'agate.table.scatterplot', 'agate.table.select', 'agate.table.to_csv', 'agate.table.to_json', 'agate.table.where', 'agate.table', 'agate.testcase', 'agate', 'dbt.clients.agate_helper']
```

So, the actual code change is not blocked by #619, but it won't "work" until #619 is resolved.

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
