### PR TITLE
Supporting tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Support `on_config_change` for materialized views, expand the supported config options ([536](https://github.com/databricks/dbt-databricks/pull/536)))
 - Support `on_config_change` for streaming tables, expand the supported config options ([569](https://github.com/databricks/dbt-databricks/pull/569)))
 - Support insert overwrite on SQL Warehouses ([623](https://github.com/databricks/dbt-databricks/pull/623))
+- Support Databricks tags for tables/views/incrementals ([631](https://github.com/databricks/dbt-databricks/pull/631))
 
 ### Under the Hood
 

--- a/dbt/adapters/databricks/impl.py
+++ b/dbt/adapters/databricks/impl.py
@@ -871,13 +871,9 @@ class IncrementalTableAPI(RelationAPIBase[IncrementalTableConfig]):
     def _describe_relation(
         cls, adapter: DatabricksAdapter, relation: DatabricksRelation
     ) -> RelationResults:
-        kwargs = {"table_name": relation}
-        results: RelationResults = dict()
-        results["describe_extended"] = adapter.execute_macro(
-            DESCRIBE_TABLE_EXTENDED_MACRO_NAME, kwargs=kwargs
-        )
-
+        results = {}
         kwargs = {"relation": relation}
 
-        results["information_schema.tags"] = adapter.execute_macro("fetch_tags", kwargs=kwargs)
+        if not relation.is_hive_metastore():
+            results["information_schema.tags"] = adapter.execute_macro("fetch_tags", kwargs=kwargs)
         return results

--- a/dbt/adapters/databricks/relation_configs/incremental.py
+++ b/dbt/adapters/databricks/relation_configs/incremental.py
@@ -1,0 +1,27 @@
+from typing import Dict
+from typing import Optional
+
+from dbt.adapters.databricks.relation_configs.base import DatabricksComponentConfig
+from dbt.adapters.databricks.relation_configs.base import DatabricksRelationChangeSet
+from dbt.adapters.databricks.relation_configs.base import DatabricksRelationConfigBase
+from dbt.adapters.databricks.relation_configs.tags import TagsProcessor
+
+
+class IncrementalTableConfig(DatabricksRelationConfigBase):
+    config_components = [TagsProcessor]
+
+    def get_changeset(
+        self, existing: "IncrementalTableConfig"
+    ) -> Optional[DatabricksRelationChangeSet]:
+        changes: Dict[str, DatabricksComponentConfig] = {}
+
+        for component in self.config_components:
+            key = component.name
+            value = self.config[key]
+            diff = value.get_diff(existing.config[key])
+            if diff:
+                changes[key] = diff
+
+        if len(changes) > 0:
+            return DatabricksRelationChangeSet(changes=changes, requires_full_refresh=False)
+        return None

--- a/dbt/adapters/databricks/relation_configs/tags.py
+++ b/dbt/adapters/databricks/relation_configs/tags.py
@@ -1,0 +1,51 @@
+from typing import ClassVar
+from typing import Dict
+from typing import List
+from typing import Optional
+
+from dbt.adapters.contracts.relation import RelationConfig
+from dbt.adapters.databricks.relation_configs import base
+from dbt.adapters.databricks.relation_configs.base import DatabricksComponentConfig
+from dbt.adapters.databricks.relation_configs.base import DatabricksComponentProcessor
+from dbt.adapters.relation_configs.config_base import RelationResults
+from dbt_common.exceptions import DbtRuntimeError
+
+
+class TagsConfig(DatabricksComponentConfig):
+    """Component encapsulating the tblproperties of a relation."""
+
+    set_tags: Dict[str, str]
+    unset_tags: List[str] = []
+
+    def get_diff(self, other: "TagsConfig") -> Optional["TagsConfig"]:
+        to_unset = []
+        for k in other.set_tags.keys():
+            if k not in self.set_tags:
+                to_unset.append(k)
+        return TagsConfig(set_tags=self.set_tags, unset_tags=to_unset)
+
+
+class TagsProcessor(DatabricksComponentProcessor[TagsConfig]):
+    name: ClassVar[str] = "tags"
+
+    @classmethod
+    def from_relation_results(cls, results: RelationResults) -> TagsConfig:
+        table = results.get("information_schema.tags")
+        tags = dict()
+
+        if table:
+            for row in table.rows:
+                tags[str(row[0])] = str(row[1])
+
+        return TagsConfig(set_tags=tags)
+
+    @classmethod
+    def from_relation_config(cls, relation_config: RelationConfig) -> TagsConfig:
+        tags = base.get_config_value(relation_config, "databricks_tags")
+        if not tags:
+            return TagsConfig(set_tags=dict())
+        if isinstance(tags, Dict):
+            tags = {str(k): str(v) for k, v in tags.items()}
+            return TagsConfig(set_tags=tags)
+        else:
+            raise DbtRuntimeError("databricks_tags must be a dictionary")

--- a/dbt/include/databricks/macros/materializations/incremental/incremental.sql
+++ b/dbt/include/databricks/macros/materializations/incremental/incremental.sql
@@ -3,6 +3,7 @@
   {%- set raw_file_format = config.get('file_format', default='delta') -%}
   {%- set raw_strategy = config.get('incremental_strategy') or 'merge' -%}
   {%- set grant_config = config.get('grants') -%}
+  {%- set tags = config.get('databricks_tags') -%}
 
   {%- set file_format = dbt_databricks_validate_get_file_format(raw_file_format) -%}
   {%- set incremental_strategy = dbt_databricks_validate_get_incremental_strategy(raw_strategy, file_format) -%}
@@ -14,7 +15,7 @@
   {%- set partition_by = config.get('partition_by', none) -%}
   {%- set language = model['language'] -%}
   {%- set on_schema_change = incremental_validate_on_schema_change(config.get('on_schema_change'), default='ignore') -%}
-  {%- set target_relation = this -%}
+  {%- set target_relation = this.incorporate(type='table') -%}
   {%- set existing_relation = adapter.get_relation(database=this.database, schema=this.schema, identifier=this.identifier, needs_information=True) -%}
 
   {#-- Run pre-hooks --#}
@@ -27,6 +28,7 @@
       {{ create_table_as(False, target_relation, compiled_code, language) }}
     {%- endcall -%}
     {% do persist_constraints(target_relation, model) %}
+    {% do apply_tags(target_relation, tags) %}
   {%- elif existing_relation.is_view or existing_relation.is_materialized_view or existing_relation.is_streaming_table or should_full_refresh() -%}
     {#-- Relation must be dropped & recreated --#}
     {% set is_delta = (file_format == 'delta' and existing_relation.is_delta) %}
@@ -40,8 +42,12 @@
     {% if not existing_relation.is_view %}
       {% do persist_constraints(target_relation, model) %}
     {% endif %}
+    {% do apply_tags(target_relation, tags) %}
   {%- else -%}
     {#-- Relation must be merged --#}
+    {%- set _existing_config = adapter.get_relation_config(existing_relation) -%}
+    {%- set model_config = adapter.get_config_from_model(config.model) -%}
+    {%- set _configuration_changes = model_config.get_changeset(_existing_config) -%}
     {%- set temp_relation = databricks__make_temp_relation(target_relation, as_table=language != 'sql') -%}
     {%- call statement('create_temp_relation', language=language) -%}
       {{ create_table_as(True, temp_relation, compiled_code, language) }}
@@ -70,6 +76,12 @@
 
       Also, why does not either drop_relation or adapter.drop_relation work here?!
       --#}
+    {%- endif -%}
+    {% if _configuration_changes is not none %}
+      {% set tags = _configuration_changes.changes["tags"] %}
+      {% if tags is not none %}
+        {% do apply_tags(target_relation, tags.set_tags, tags.unset_tags) %}
+      {%- endif -%}
     {%- endif -%}
   {%- endif -%}
 

--- a/dbt/include/databricks/macros/materializations/table.sql
+++ b/dbt/include/databricks/macros/materializations/table.sql
@@ -3,6 +3,7 @@
   {%- set language = model['language'] -%}
   {%- set identifier = model['alias'] -%}
   {%- set grant_config = config.get('grants') -%}
+  {%- set tags = config.get('databricks_tags') -%}
 
   {%- set old_relation = adapter.get_relation(database=database, schema=schema, identifier=identifier, needs_information=True) -%}
   {%- set target_relation = api.Relation.create(identifier=identifier,
@@ -28,6 +29,8 @@
   {% set should_revoke = should_revoke(old_relation, full_refresh_mode=True) %}
   {% do apply_grants(target_relation, grant_config, should_revoke) %}
 
+  {%- do apply_tags(target_relation, tags) -%}
+  
   {% do persist_docs(target_relation, model) %}
 
   {% do persist_constraints(target_relation, model) %}

--- a/dbt/include/databricks/macros/materializations/view.sql
+++ b/dbt/include/databricks/macros/materializations/view.sql
@@ -8,6 +8,7 @@
       identifier=identifier, schema=schema, database=database,
       type='view') -%}
   {% set grant_config = config.get('grants') %}
+  {% set tags = config.get('databricks_tags') %}
 
   {{ run_hooks(pre_hooks) }}
 
@@ -25,6 +26,8 @@
 
   {% set should_revoke = should_revoke(exists_as_view, full_refresh_mode=True) %}
   {% do apply_grants(target_relation, grant_config, should_revoke=True) %}
+
+  {%- do apply_tags(target_relation, tags) -%}
 
   {{ run_hooks(post_hooks) }}
 

--- a/dbt/include/databricks/macros/relations/tags.sql
+++ b/dbt/include/databricks/macros/relations/tags.sql
@@ -1,0 +1,47 @@
+{% macro fetch_tags(relation) -%}
+  {% if relation.is_hive_metastore() %}
+    {{ exceptions.raise_compiler_error("Tags are only supported for Unity Catalog") }}
+  {%- endif %}
+  {% call statement('list_tags', fetch_result=True) -%}
+    {{ fetch_tags_sql(relation) }}
+  {% endcall %}
+  {% do return(load_result('list_tags').table) %}
+{%- endmacro -%}
+
+{% macro fetch_tags_sql(relation) -%}
+  SELECT tag_name, tag_value
+  FROM `{{ relation.database }}`.`information_schema`.`table_tags`
+  WHERE schema_name = '{{ relation.schema }}' AND table_name = '{{ relation.identifier }}'
+{%- endmacro -%}
+
+{% macro apply_tags(relation, set_tags, unset_tags=[]) -%}
+  {%- if (set_tags is not none or unset_tags is not none) and relation.is_hive_metastore() -%}
+    {{ exceptions.raise_compiler_error("Tags are only supported for Unity Catalog") }}
+  {%- endif -%}
+  {%- if set_tags %}
+    {%- call statement('set_tags') -%}
+       {{ alter_set_tags(relation, set_tags) }}
+    {%- endcall -%}
+  {%- endif %}
+  {%- if unset_tags %}
+    {%- call statement('unset_tags') -%}
+       {{ alter_unset_tags(relation, unset_tags) }}
+    {%- endcall -%}
+  {%- endif %}
+{%- endmacro -%}
+
+{% macro alter_set_tags(relation, tags) -%}
+  ALTER {{ relation.type }} {{ relation }} SET TAGS (
+    {% for tag in tags -%}
+      '{{ tag }}' = '{{ tags[tag] }}' {%- if not loop.last %}, {% endif -%}
+    {%- endfor %}
+  )
+{%- endmacro -%}
+
+{% macro alter_unset_tags(relation, tags) -%}
+  ALTER {{ relation.type }} {{ relation }} UNSET TAGS (
+    {% for tag in tags -%}
+      '{{ tag }}' {%- if not loop.last %}, {%- endif %}
+    {%- endfor %}
+  )
+{%- endmacro -%}

--- a/dbt/include/databricks/macros/relations/tags.sql
+++ b/dbt/include/databricks/macros/relations/tags.sql
@@ -15,7 +15,7 @@
 {%- endmacro -%}
 
 {% macro apply_tags(relation, set_tags, unset_tags=[]) -%}
-  {%- if (set_tags is not none or unset_tags is not none) and relation.is_hive_metastore() -%}
+  {%- if (set_tags or unset_tags) and relation.is_hive_metastore() -%}
     {{ exceptions.raise_compiler_error("Tags are only supported for Unity Catalog") }}
   {%- endif -%}
   {%- if set_tags %}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ pytest_plugins = ["dbt.tests.fixtures.project"]
 
 
 def pytest_addoption(parser):
-    parser.addoption("--profile", action="store", default="databricks_cluster", type=str)
+    parser.addoption("--profile", action="store", default="databricks_uc_sql_endpoint", type=str)
 
 
 # Using @pytest.mark.skip_profile('databricks_cluster') uses the 'skip_by_adapter_type'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ pytest_plugins = ["dbt.tests.fixtures.project"]
 
 
 def pytest_addoption(parser):
-    parser.addoption("--profile", action="store", default="databricks_uc_sql_endpoint", type=str)
+    parser.addoption("--profile", action="store", default="databricks_cluster", type=str)
 
 
 # Using @pytest.mark.skip_profile('databricks_cluster') uses the 'skip_by_adapter_type'

--- a/tests/functional/adapter/incremental/fixtures.py
+++ b/tests/functional/adapter/incremental/fixtures.py
@@ -253,3 +253,37 @@ select cast(3 as bigint) as id, 'anyway' as msg, 'purple' as color
 
 {% endif %}
 """
+
+
+simple_python_model = """
+import pandas
+
+def model(dbt, spark):
+    dbt.config(
+        materialized='incremental',
+    )
+    data = [[1,2]] * 10
+    return spark.createDataFrame(data, schema=['test', 'test2'])
+"""
+
+python_schema = """version: 2
+models:
+  - name: tags
+    config:
+      tags: ["python"]
+      databricks_tags:
+        a: b
+        c: d
+      http_path: "{{ env_var('DBT_DATABRICKS_UC_CLUSTER_HTTP_PATH') }}"
+"""
+
+python_schema2 = """version: 2
+models:
+  - name: tags
+    config:
+      tags: ["python"]
+      databricks_tags:
+        c: e
+        d: f
+      http_path: "{{ env_var('DBT_DATABRICKS_UC_CLUSTER_HTTP_PATH') }}"
+"""

--- a/tests/functional/adapter/incremental/fixtures.py
+++ b/tests/functional/adapter/incremental/fixtures.py
@@ -45,6 +45,36 @@ models:
         - name: color
 """
 
+tags_a = """
+version: 2
+
+models:
+  - name: merge_update_columns_sql
+    config:
+        databricks_tags:
+            a: b
+            c: d
+    columns:
+        - name: id
+        - name: msg
+        - name: color
+"""
+
+tags_b = """
+version: 2
+
+models:
+  - name: merge_update_columns_sql
+    config:
+        databricks_tags:
+            c: e
+            d: f
+    columns:
+        - name: id
+        - name: msg
+        - name: color
+"""
+
 _MODELS__INCREMENTAL_SYNC_ALL_COLUMNS = """
 {{
     config(

--- a/tests/functional/adapter/incremental/test_incremental_tags.py
+++ b/tests/functional/adapter/incremental/test_incremental_tags.py
@@ -1,0 +1,27 @@
+import pytest
+from dbt.tests import util
+from tests.functional.adapter.incremental import fixtures
+
+
+class TestIncrementalPersistDocs:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "merge_update_columns_sql.sql": fixtures.merge_update_columns_sql,
+            "schema.yml": fixtures.tags_a,
+        }
+
+    def test_changing_tags(self, project):
+        util.run_dbt(["run"])
+        util.write_file(fixtures.tags_b, "models", "schema.yml")
+        util.run_dbt(["run"])
+        results = project.run_sql(
+            "select tag_name, tag_value from {database}.information_schema.table_tags "
+            "where schema_name = '{schema}' and table_name='merge_update_columns_sql'",
+            fetch="all",
+        )
+        assert len(results) == 2
+        results_dict = {}
+        results_dict[results[0].tag_name] = results[0].tag_value
+        results_dict[results[1].tag_name] = results[1].tag_value
+        assert results_dict == {"c": "e", "d": "f"}

--- a/tests/functional/adapter/incremental/test_incremental_tags.py
+++ b/tests/functional/adapter/incremental/test_incremental_tags.py
@@ -3,6 +3,7 @@ from dbt.tests import util
 from tests.functional.adapter.incremental import fixtures
 
 
+@pytest.mark.skip_profile("databricks_cluster")
 class TestIncrementalPersistDocs:
     @pytest.fixture(scope="class")
     def models(self):

--- a/tests/functional/adapter/tags/fixtures.py
+++ b/tests/functional/adapter/tags/fixtures.py
@@ -1,0 +1,8 @@
+tags_sql = """
+{{ config(
+    materialized = 'table',
+    databricks_tags = {'a': 'b', 'c': 'd'},
+) }}
+
+select cast(1 as bigint) as id, 'hello' as msg, 'blue' as color
+"""

--- a/tests/functional/adapter/tags/fixtures.py
+++ b/tests/functional/adapter/tags/fixtures.py
@@ -6,3 +6,25 @@ tags_sql = """
 
 select cast(1 as bigint) as id, 'hello' as msg, 'blue' as color
 """
+
+simple_python_model = """
+import pandas
+
+def model(dbt, spark):
+    dbt.config(
+        materialized='table',
+    )
+    data = [[1,2]] * 10
+    return spark.createDataFrame(data, schema=['test', 'test2'])
+"""
+
+python_schema = """version: 2
+models:
+  - name: tags
+    config:
+      tags: ["python"]
+      databricks_tags:
+        a: b
+        c: d
+      http_path: "{{ env_var('DBT_DATABRICKS_UC_CLUSTER_HTTP_PATH') }}"
+"""

--- a/tests/functional/adapter/tags/test_databricks_tags.py
+++ b/tests/functional/adapter/tags/test_databricks_tags.py
@@ -1,0 +1,33 @@
+import pytest
+from dbt.tests import util
+from tests.functional.adapter.tags import fixtures
+
+
+class TestTags:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "tags.sql": fixtures.tags_sql,
+        }
+
+    def test_tags(self, project):
+        _ = util.run_dbt(["run"])
+        _ = util.run_dbt(["run"])
+        results = project.run_sql(
+            "select tag_name, tag_value from {database}.information_schema.table_tags "
+            "where schema_name = '{schema}' and table_name='tags'",
+            fetch="all",
+        )
+        assert len(results) == 2
+
+
+class TestViewTags(TestTags):
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"tags.sql": fixtures.tags_sql.replace("table", "view")}
+
+
+class TestIncrementalTags(TestTags):
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"tags.sql": fixtures.tags_sql.replace("table", "incremental")}

--- a/tests/functional/adapter/tags/test_databricks_tags.py
+++ b/tests/functional/adapter/tags/test_databricks_tags.py
@@ -34,3 +34,13 @@ class TestIncrementalTags(TestTags):
     @pytest.fixture(scope="class")
     def models(self):
         return {"tags.sql": fixtures.tags_sql.replace("table", "incremental")}
+
+
+@pytest.mark.skip_profile("databricks_cluster")
+class TestPythonTags(TestTags):
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "tags.py": fixtures.simple_python_model,
+            "schema.yml": fixtures.python_schema,
+        }

--- a/tests/functional/adapter/tags/test_databricks_tags.py
+++ b/tests/functional/adapter/tags/test_databricks_tags.py
@@ -3,6 +3,7 @@ from dbt.tests import util
 from tests.functional.adapter.tags import fixtures
 
 
+@pytest.mark.skip_profile("databricks_cluster")
 class TestTags:
     @pytest.fixture(scope="class")
     def models(self):
@@ -21,12 +22,14 @@ class TestTags:
         assert len(results) == 2
 
 
+@pytest.mark.skip_profile("databricks_cluster")
 class TestViewTags(TestTags):
     @pytest.fixture(scope="class")
     def models(self):
         return {"tags.sql": fixtures.tags_sql.replace("table", "view")}
 
 
+@pytest.mark.skip_profile("databricks_cluster")
 class TestIncrementalTags(TestTags):
     @pytest.fixture(scope="class")
     def models(self):

--- a/tests/unit/macros/relations/test_tags_macros.py
+++ b/tests/unit/macros/relations/test_tags_macros.py
@@ -1,0 +1,36 @@
+import pytest
+from tests.unit.macros.base import MacroTestBase
+
+
+class TestTagsMacros(MacroTestBase):
+    @pytest.fixture
+    def template_name(self) -> str:
+        return "tags.sql"
+
+    @pytest.fixture(scope="class")
+    def macro_folders_to_load(self) -> list:
+        return ["macros/relations", "macros"]
+
+    def test_macros_fetch_tags_sql(self, template_bundle):
+        sql = self.render_bundle(template_bundle, "fetch_tags_sql")
+        expected = (
+            "SELECT tag_name, tag_value "
+            "FROM `some_database`.`information_schema`.`table_tags` "
+            "WHERE schema_name = 'some_schema' AND table_name = 'some_table'"
+        )
+        assert sql == expected
+
+    def test_macros_alter_set_tags(self, template_bundle):
+        sql = self.render_bundle(template_bundle, "alter_set_tags", {"a": "valA", "b": "valB"})
+        expected = (
+            "ALTER None `some_database`.`some_schema`.`some_table` "
+            "SET TAGS ( 'a' = 'valA', 'b' = 'valB' )"
+        )
+
+        assert sql == expected
+
+    def test_macros_alter_unset_tags(self, template_bundle):
+        sql = self.render_bundle(template_bundle, "alter_unset_tags", ["a", "b"])
+        expected = "ALTER None `some_database`.`some_schema`.`some_table` UNSET TAGS ( 'a','b' )"
+
+        assert sql == expected

--- a/tests/unit/relation_configs/test_incremental_config.py
+++ b/tests/unit/relation_configs/test_incremental_config.py
@@ -1,0 +1,27 @@
+from agate import Table
+
+from dbt.adapters.databricks.relation_configs.incremental import IncrementalTableConfig
+from dbt.adapters.databricks.relation_configs.tags import TagsConfig
+
+
+class TestIncrementalConfig:
+    def test_from_results(self):
+        results = {
+            "information_schema.tags": {
+                Table(
+                    rows=[
+                        ["tag1", "value1"],
+                        ["tag2", "value2"],
+                    ],
+                    column_names=["tag_name", "tag_value"],
+                )
+            }
+        }
+
+        config = IncrementalTableConfig.from_results(results)
+
+        assert config == IncrementalTableConfig(
+            config={
+                "tags": TagsConfig(set_tags={"tag1": "value1", "tag2": "value2"}),
+            }
+        )

--- a/tests/unit/relation_configs/test_incremental_config.py
+++ b/tests/unit/relation_configs/test_incremental_config.py
@@ -7,15 +7,13 @@ from dbt.adapters.databricks.relation_configs.tags import TagsConfig
 class TestIncrementalConfig:
     def test_from_results(self):
         results = {
-            "information_schema.tags": {
-                Table(
-                    rows=[
-                        ["tag1", "value1"],
-                        ["tag2", "value2"],
-                    ],
-                    column_names=["tag_name", "tag_value"],
-                )
-            }
+            "information_schema.tags": Table(
+                rows=[
+                    ["tag1", "value1"],
+                    ["tag2", "value2"],
+                ],
+                column_names=["tag_name", "tag_value"],
+            )
         }
 
         config = IncrementalTableConfig.from_results(results)

--- a/tests/unit/relation_configs/test_materialized_view_config.py
+++ b/tests/unit/relation_configs/test_materialized_view_config.py
@@ -1,7 +1,5 @@
 from agate import Row
 from agate import Table
-from mock import Mock
-
 from dbt.adapters.databricks.relation_configs.comment import CommentConfig
 from dbt.adapters.databricks.relation_configs.materialized_view import (
     MaterializedViewConfig,
@@ -10,6 +8,7 @@ from dbt.adapters.databricks.relation_configs.partitioning import PartitionedByC
 from dbt.adapters.databricks.relation_configs.query import QueryConfig
 from dbt.adapters.databricks.relation_configs.refresh import RefreshConfig
 from dbt.adapters.databricks.relation_configs.tblproperties import TblPropertiesConfig
+from mock import Mock
 
 
 class TestMaterializedViewConfig:

--- a/tests/unit/relation_configs/test_tags.py
+++ b/tests/unit/relation_configs/test_tags.py
@@ -1,0 +1,66 @@
+import pytest
+from agate import Table
+from dbt.adapters.databricks.relation_configs.tags import TagsConfig
+from dbt.adapters.databricks.relation_configs.tags import TagsProcessor
+from dbt.exceptions import DbtRuntimeError
+from mock import Mock
+
+
+class TestTagsProcessor:
+    def test_from_relation_results__none(self):
+        results = {
+            "information_schema.tags": Table(rows=[], column_names=["tag_name", "tag_value"])
+        }
+        spec = TagsProcessor.from_relation_results(results)
+        assert spec == TagsConfig(set_tags={})
+
+    def test_from_relation_results__some(self):
+        results = {
+            "information_schema.tags": Table(
+                rows=[["a", "valA"], ["b", "valB"]], column_names=["tag_name", "tag_value"]
+            )
+        }
+        spec = TagsProcessor.from_relation_results(results)
+        assert spec == TagsConfig(set_tags={"a": "valA", "b": "valB"})
+
+    def test_from_relation_config__without_tags(self):
+        model = Mock()
+        model.config.extra = {}
+        spec = TagsProcessor.from_relation_config(model)
+        assert spec == TagsConfig(set_tags={})
+
+    def test_from_relation_config__with_tags(self):
+        model = Mock()
+        model.config.extra = {"databricks_tags": {"a": "valA", "b": 1}}
+        spec = TagsProcessor.from_relation_config(model)
+        assert spec == TagsConfig(set_tags={"a": "valA", "b": "1"})
+
+    def test_from_relation_config__with_incorrect_tags(self):
+        model = Mock()
+        model.config.extra = {"databricks_tags": ["a", "b"]}
+
+        with pytest.raises(
+            DbtRuntimeError,
+            match="databricks_tags must be a dictionary",
+        ):
+            _ = TagsProcessor.from_relation_config(model)
+
+
+class TestTagsConfig:
+    def test_get_diff__empty_and_some_exist(self):
+        config = TagsConfig(set_tags={})
+        other = TagsConfig(set_tags={"tag": "value"})
+        diff = config.get_diff(other)
+        assert diff == TagsConfig(set_tags={}, unset_tags=["tag"])
+
+    def test_get_diff__some_new_and_empty_existing(self):
+        config = TagsConfig(set_tags={"tag": "value"})
+        other = TagsConfig(set_tags={})
+        diff = config.get_diff(other)
+        assert diff == TagsConfig(set_tags={"tag": "value"}, unset_tags=[])
+
+    def test_get_diff__mixed_case(self):
+        config = TagsConfig(set_tags={"a": "value", "b": "value"})
+        other = TagsConfig(set_tags={"b": "other_value", "c": "value"})
+        diff = config.get_diff(other)
+        assert diff == TagsConfig(set_tags={"a": "value", "b": "value"}, unset_tags=["c"])

--- a/tests/unit/relation_configs/test_tblproperties.py
+++ b/tests/unit/relation_configs/test_tblproperties.py
@@ -1,12 +1,11 @@
 import pytest
 from agate import Table
-from mock import Mock
-
 from dbt.adapters.databricks.relation_configs.tblproperties import TblPropertiesConfig
 from dbt.adapters.databricks.relation_configs.tblproperties import (
     TblPropertiesProcessor,
 )
 from dbt.exceptions import DbtRuntimeError
+from mock import Mock
 
 
 class TestTblPropertiesProcessor:


### PR DESCRIPTION
Resolves #606

### Description

Adds support for setting tags (for discovery, governance) on tables/views.  Unfortunately not yet supported on MV/STs, but I built the support in the same way I do on_config_change for them, so it should be trivial to add when they become supported.

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
