### PR TITLE
Support tblproperties (weakly) in python models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## dbt-databricks 1.7.12 (TBD)
 
+### Features
+
+- Apply tblproperties to python models (using alter table) ([633](https://github.com/databricks/dbt-databricks/pull/633))
+
 ### Fixes
 
 - Up default socket timeout to 10 minutes

--- a/dbt/include/databricks/macros/materializations/incremental/incremental.sql
+++ b/dbt/include/databricks/macros/materializations/incremental/incremental.sql
@@ -3,6 +3,7 @@
   {%- set raw_file_format = config.get('file_format', default='delta') -%}
   {%- set raw_strategy = config.get('incremental_strategy') or 'merge' -%}
   {%- set grant_config = config.get('grants') -%}
+  {%- set tblproperties = config.get('tblproperties') -%}
 
   {%- set file_format = dbt_databricks_validate_get_file_format(raw_file_format) -%}
   {%- set incremental_strategy = dbt_databricks_validate_get_incremental_strategy(raw_strategy, file_format) -%}
@@ -82,7 +83,7 @@
 
   {% set should_revoke = should_revoke(existing_relation, full_refresh_mode) %}
   {% do apply_grants(target_relation, grant_config, should_revoke) %}
-
+  {% do apply_tblproperties_python(target_relation, tblproperties, language) %}
   {% do persist_docs(target_relation, model) %}
   {% do optimize(target_relation) %}
 

--- a/dbt/include/databricks/macros/materializations/table.sql
+++ b/dbt/include/databricks/macros/materializations/table.sql
@@ -2,7 +2,7 @@
   {%- set language = model['language'] -%}
   {%- set identifier = model['alias'] -%}
   {%- set grant_config = config.get('grants') -%}
-
+  {%- set tblproperties = config.get('tblproperties') -%}
   {%- set old_relation = adapter.get_relation(database=database, schema=schema, identifier=identifier, needs_information=True) -%}
   {%- set target_relation = api.Relation.create(identifier=identifier,
                                                 schema=schema,
@@ -26,6 +26,7 @@
 
   {% set should_revoke = should_revoke(old_relation, full_refresh_mode=True) %}
   {% do apply_grants(target_relation, grant_config, should_revoke) %}
+  {% do apply_tblproperties_python(target_relation, tblproperties, language) %}
 
   {% do persist_docs(target_relation, model) %}
 

--- a/dbt/include/databricks/macros/relations/tblproperties.sql
+++ b/dbt/include/databricks/macros/relations/tblproperties.sql
@@ -12,3 +12,11 @@
     )
   {%- endif %}
 {%- endmacro -%}
+
+{% macro apply_tblproperties_python(relation, tblproperties, language) -%}
+  {%- if tblproperties and language == 'python' -%}
+    {%- call statement('python_tblproperties') -%}
+      alter table {{ relation }} set {{ tblproperties_clause() }}
+    {%- endcall -%}
+  {%- endif -%}
+{%- endmacro -%}

--- a/tests/functional/adapter/python_model/fixtures.py
+++ b/tests/functional/adapter/python_model/fixtures.py
@@ -93,6 +93,7 @@ def model(dbt, spark):
     dbt.config(materialized="incremental")
     dbt.config(partition_by="date")
     dbt.config(unique_key="name")
+    dbt.config(tblproperties={"a": "b", "c": "d"})
     if dbt.is_incremental:
         data = [[2, "Teo"], [2, "Fang"], [3, "Elbert"]]
     else:

--- a/tests/functional/adapter/python_model/test_python_model.py
+++ b/tests/functional/adapter/python_model/test_python_model.py
@@ -1,13 +1,10 @@
 import os
 
 import pytest
-
 from dbt.tests import util
-from dbt.tests.adapter.python_model.test_python_model import (
-    BasePythonIncrementalTests,
-    BasePythonModelTests,
-)
 from dbt.tests.adapter.python_model import test_python_model as fixtures
+from dbt.tests.adapter.python_model.test_python_model import BasePythonIncrementalTests
+from dbt.tests.adapter.python_model.test_python_model import BasePythonModelTests
 from tests.functional.adapter.python_model import fixtures as override_fixtures
 
 
@@ -93,3 +90,9 @@ class TestComplexConfig:
         util.run_dbt(["build", "-s", "complex_config"])
         util.run_dbt(["build", "-s", "complex_config"])
         util.check_relations_equal(project.adapter, ["complex_config", "expected_complex"])
+        results = project.run_sql(
+            "SHOW TBLPROPERTIES {database}.{schema}.complex_config", fetch="all"
+        )
+        result_dict = {result[0]: result[1] for result in results}
+        assert result_dict["a"] == "b"
+        assert result_dict["c"] == "d"


### PR DESCRIPTION
<!---
  Include the number of the issue addressed by this PR above if applicable.
  
  Example:
    resolves #1234

  Please review our pull request review process in CONTRIBUTING.md before your proceed.
-->

### Description

It was an oversight that python models did not support specifying tblproperties in any way.  This remedies that, but with a major caveat: because DataframeWriterV1 doesn't support tableProperty (and DataframeWriterV2 does not currently work in the execution env), we can't set tblproperties at table creation.  Or more aptly, we might be able to, but it would be a significant rewrite, where we create a table (including specifying column types, ugh) and the insert the data into it as separate steps, so that we could get tblproperties set using the SQL API.

What does that mean?  It means that if you want to use tblproperties to anotate your python-generated tables with metadata, you'll now be able to.  If, however, you were hoping to use tblproperties on python models to enable some advanced Databricks feature at table creation time, this change will probably not help you.

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
