### PR TITLE
FIX #582: User Configurable OAuth Scopes in profiles.yml

### DIFF
--- a/dbt/adapters/databricks/connections.py
+++ b/dbt/adapters/databricks/connections.py
@@ -145,6 +145,7 @@ class DatabricksCredentials(Credentials):
     client_id: Optional[str] = None
     client_secret: Optional[str] = None
     oauth_redirect_url: Optional[str] = None
+    oauth_scopes: Optional[List[str]] = None
     session_properties: Optional[Dict[str, Any]] = None
     connection_parameters: Optional[Dict[str, Any]] = None
     auth_type: Optional[str] = None
@@ -210,6 +211,7 @@ class DatabricksCredentials(Credentials):
             "client_id",
             "client_secret",
             "oauth_redirect_url",
+            "oauth_scopes",
             "session_configuration",
             "catalog",
             "schema",
@@ -373,7 +375,7 @@ class DatabricksCredentials(Credentials):
                 client_id=self.client_id or CLIENT_ID,
                 client_secret="",
                 redirect_url=self.oauth_redirect_url or REDIRECT_URL,
-                scopes=SCOPES,
+                scopes=self.oauth_scopes or SCOPES,
             )
             # optional branch. Try and keep going if it does not work
             try:
@@ -490,7 +492,7 @@ class DatabricksCredentials(Credentials):
             client_id=self.client_id or CLIENT_ID,
             client_secret="",
             redirect_url=self.oauth_redirect_url or REDIRECT_URL,
-            scopes=SCOPES,
+            scopes=self.oauth_scopes or SCOPES,
         )
 
         return SessionCredentials.from_dict(

--- a/docs/oauth.md
+++ b/docs/oauth.md
@@ -22,5 +22,33 @@ jaffle_shop:
   target: dev
 ```
 
+## Troubleshooting
 
+DBT expects the OAuth application to have the "All APIs" scope and redirect URL `http://localhost:8020` by default.
+
+If the OAuth application has only been configured with SQL access scopes or a custom redirect URL, you may need to update your profile accordingly:
+
+``` YAML
+jaffle_shop:
+  outputs:
+    dev:
+      host: <databricks host name>
+      http_path: <http path for warehouse or cluster>
+      catalog: <UC catalog name>
+      schema: <schema name>
+      auth_type: oauth  # new
+      client_id: <azure application ID> # only necessary for Azure
+      oauth_redirect_url: https://example.com
+      oauth_scopes:
+        - sql
+        - offline_access
+      type: databricks
+  target: dev
+```
+
+You can find these settings in [Account Console](https://accounts.cloud.databricks.com) > [Settings](https://accounts.cloud.databricks.com/settings) > [App Connections](https://accounts.cloud.databricks.com/settings/app-integrations) > dbt adapter for Databricks
+
+
+
+If you encounter any issues, please refer to the [OAuth user-to-machine (U2M) authentication guide](https://docs.databricks.com/en/dev-tools/auth/oauth-u2m.html).
 


### PR DESCRIPTION
Resolves #582 

### Description
As @benc-db  mentioned [here](https://github.com/databricks/dbt-databricks/issues/582#issuecomment-2040622059), it could be worth adding user configurable options for oauth apps to profiles.

@benc-db adds `oauth_redirect_url` to profiles.yml in #638  but we also need to make `oauth_scopes` user-configurable.

### Usage

Given the app connection:
<img width="596" alt="Screenshot 2024-04-13 at 08 07 56" src="https://github.com/databricks/dbt-databricks/assets/16361214/59136104-4d6f-4c6a-90aa-9c60bebe5f45">

Profile configuration would be:
```yaml
jaffle_shop:
  outputs:
    test:
      catalog: CATALOG
      host: WORKSPACE_URL
      http_path: /sql/1.0/warehouses/WAREHOUSE_ID
      schema: SCHEMA
      threads: 10
      auth_type: oauth
      oauth_redirect_url: "http://localhost:8050"
      oauth_scopes:
        - sql
        - offline_access
      type: databricks
  target: test
```

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
