### PR TITLE
Fixing idle issue and improving debug logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Fixes
 
 - Auth headers should now evaluate at call time ([648](https://github.com/databricks/dbt-databricks/pull/648))
+- User-configurable OAuth Scopes (currently limited to AWS) (thanks @stevenayers!) ([641](https://github.com/databricks/dbt-databricks/pull/641))
 
 ### Under the hood
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## dbt-databricks 1.7.14 (TBD)
+
+### Fixes
+
+- Auth headers should now evaluate at call time ([648](https://github.com/databricks/dbt-databricks/pull/648))
+
+### Under the hood
+
+- Reduce default idle limit for connection reuse to 60s and start organizing event logging ([648](https://github.com/databricks/dbt-databricks/pull/648))
+
 ## dbt-databricks 1.7.13 (April 8, 2024)
 
 ### Features

--- a/dbt/adapters/databricks/events/base.py
+++ b/dbt/adapters/databricks/events/base.py
@@ -21,8 +21,8 @@ class SQLErrorEvent:
         properties = ""
         if isinstance(self.exception, Error):
             properties = "\nError properties: "
-            properties += ",".join(
-                [f"{key}: {value}" for key, value in sorted(self.exception.context.items())]
+            properties += ", ".join(
+                [f"{key}={value}" for key, value in sorted(self.exception.context.items())]
             )
 
         return f"{self.message}: {self.exception}{properties}"

--- a/dbt/adapters/databricks/events/base.py
+++ b/dbt/adapters/databricks/events/base.py
@@ -1,0 +1,28 @@
+from abc import ABC
+
+from databricks.sql.exc import Error
+
+
+class ErrorEvent(ABC):
+    def __init__(self, exception: Exception, message: str):
+        self.message = message
+        self.exception = exception
+
+    def __str__(self) -> str:
+        return f"{self.message}: {self.exception}"
+
+
+class SQLErrorEvent:
+    def __init__(self, exception: Exception, message: str):
+        self.message = message
+        self.exception = exception
+
+    def __str__(self) -> str:
+        properties = ""
+        if isinstance(self.exception, Error):
+            properties = "\nError properties: "
+            properties += ",".join(
+                [f"{key}: {value}" for key, value in sorted(self.exception.context.items())]
+            )
+
+        return f"{self.message}: {self.exception}{properties}"

--- a/dbt/adapters/databricks/events/connection_events.py
+++ b/dbt/adapters/databricks/events/connection_events.py
@@ -1,0 +1,122 @@
+from abc import ABC
+from typing import Optional
+from typing import Tuple
+
+from databricks.sql.client import Connection
+from dbt.adapters.databricks.events.base import SQLErrorEvent
+from dbt.contracts.graph.nodes import ResultNode
+
+
+class ConnectionEvent(ABC):
+    def __init__(self, connection: Connection, message: str):
+        self.message = message
+        if connection:
+            self.session_id = connection.get_session_id_hex()
+        else:
+            self.session_id = "Unknown"
+
+    def __str__(self) -> str:
+        return f"Connection(session-id={self.session_id}) - {self.message}"
+
+
+class ConnectionCancel(ConnectionEvent):
+    def __init__(self, connection: Connection):
+        super().__init__(connection, "Cancelling connection")
+
+
+class ConnectionClose(ConnectionEvent):
+    def __init__(self, connection: Connection):
+        super().__init__(connection, "Closing connection")
+
+
+class ConnectionCancelError(ConnectionEvent):
+    def __init__(self, connection: Connection, exception: Exception):
+        super().__init__(
+            connection, str(SQLErrorEvent(exception, "Exception while trying to cancel connection"))
+        )
+
+
+class ConnectionCloseError(ConnectionEvent):
+    def __init__(self, connection: Connection, exception: Exception):
+        super().__init__(
+            connection, str(SQLErrorEvent(exception, "Exception while trying to close connection"))
+        )
+
+
+class ConnectionCreateError(ConnectionEvent):
+    def __init__(self, connection: Connection, exception: Exception):
+        super().__init__(
+            connection, str(SQLErrorEvent(exception, "Exception while trying to create connection"))
+        )
+
+
+class ConnectionWrapperEvent(ABC):
+    def __init__(self, description: str, message: str):
+        self.message = message
+        self.description = description
+
+    def __str__(self) -> str:
+        return f"{self.description} - {self.message}"
+
+
+class ConnectionAcquire(ConnectionWrapperEvent):
+    def __init__(
+        self,
+        description: str,
+        model: Optional[ResultNode],
+        compute_name: Optional[str],
+        thread_identifier: Tuple[int, int],
+    ):
+        message = f"Acquired connection on thread {thread_identifier}, using "
+        if not compute_name:
+            message += "default compute resource"
+        else:
+            message += f"compute resource '{compute_name}'"
+
+        if model:
+            # ResultNode *should* have relation_name attr, but we work around a core
+            # issue by checking.
+            relation_name = getattr(model, "relation_name", "[unknown]")
+            message += f" for model '{relation_name}'"
+
+        super().__init__(description, message)
+
+
+class ConnectionRelease(ConnectionWrapperEvent):
+    def __init__(self, description: str):
+        super().__init__(description, "Released connection")
+
+
+class ConnectionReset(ConnectionWrapperEvent):
+    def __init__(self, description: str):
+        super().__init__(description, "Reset connection handle")
+
+
+class ConnectionReuse(ConnectionWrapperEvent):
+    def __init__(self, description: str, prior_name: str):
+        super().__init__(description, f"Reusing connection previously named {prior_name}")
+
+
+class ConnectionCreate(ConnectionWrapperEvent):
+    def __init__(self, description: str):
+        super().__init__(description, "Creating connection")
+
+
+class ConnectionIdleCheck(ConnectionWrapperEvent):
+    def __init__(self, description: str):
+        super().__init__(description, "Checking idleness")
+
+
+class ConnectionIdleClose(ConnectionWrapperEvent):
+    def __init__(self, description: str):
+        super().__init__(description, "Closing for idleness")
+
+
+class ConnectionRetrieve(ConnectionWrapperEvent):
+    def __init__(self, description: str):
+        super().__init__(description, "Retrieving connection")
+
+
+class ConnectionCreated(ConnectionWrapperEvent):
+    def __init__(self, description: str):
+        super().__init__(description, "Connection created")

--- a/dbt/adapters/databricks/events/connection_events.py
+++ b/dbt/adapters/databricks/events/connection_events.py
@@ -10,10 +10,9 @@ from dbt.contracts.graph.nodes import ResultNode
 class ConnectionEvent(ABC):
     def __init__(self, connection: Connection, message: str):
         self.message = message
+        self.session_id = "Unknown"
         if connection:
-            self.session_id = connection.get_session_id_hex()
-        else:
-            self.session_id = "Unknown"
+            self.session_id = connection.get_session_id_hex() or "Unknown"
 
     def __str__(self) -> str:
         return f"Connection(session-id={self.session_id}) - {self.message}"
@@ -76,7 +75,7 @@ class ConnectionAcquire(ConnectionWrapperEvent):
         if model:
             # ResultNode *should* have relation_name attr, but we work around a core
             # issue by checking.
-            relation_name = getattr(model, "relation_name", "[unknown]")
+            relation_name = getattr(model, "relation_name", "[Unknown]")
             message += f" for model '{relation_name}'"
 
         super().__init__(description, message)

--- a/dbt/adapters/databricks/events/credential_events.py
+++ b/dbt/adapters/databricks/events/credential_events.py
@@ -1,0 +1,19 @@
+from dbt.adapters.databricks.events.base import ErrorEvent
+
+
+class CredentialLoadError(ErrorEvent):
+    def __init__(self, exception: Exception):
+        super().__init__(exception, "Exception while trying to load credentials")
+
+
+class CredentialSaveError(ErrorEvent):
+    def __init__(self, exception: Exception):
+        super().__init__(exception, "Exception while trying to save credentials")
+
+
+class CredentialShardEvent:
+    def __init__(self, password_len: int):
+        self.password_len = password_len
+
+    def __str__(self) -> str:
+        return f"Password is {self.password_len} characters, sharding it"

--- a/dbt/adapters/databricks/events/cursor_events.py
+++ b/dbt/adapters/databricks/events/cursor_events.py
@@ -8,11 +8,11 @@ from dbt.adapters.databricks.events.base import SQLErrorEvent
 class CursorEvent(ABC):
     def __init__(self, cursor: Cursor, message: str):
         self.message = message
+        self.session_id = "Unknown"
+        self.command_id = "Unknown"
         if cursor:
             if cursor.connection:
                 self.session_id = cursor.connection.get_session_id_hex()
-            else:
-                self.session_id = "Unknown"
             if (
                 cursor.active_result_set
                 and cursor.active_result_set.command_id
@@ -22,8 +22,6 @@ class CursorEvent(ABC):
                     str(UUID(bytes=cursor.active_result_set.command_id.operationId.guid))
                     or "Unknown"
                 )
-            else:
-                self.command_id = "Unknown"
 
     def __str__(self) -> str:
         return (

--- a/dbt/adapters/databricks/events/cursor_events.py
+++ b/dbt/adapters/databricks/events/cursor_events.py
@@ -1,0 +1,60 @@
+from abc import ABC
+from uuid import UUID
+
+from databricks.sql.client import Cursor
+from dbt.adapters.databricks.events.base import SQLErrorEvent
+
+
+class CursorEvent(ABC):
+    def __init__(self, cursor: Cursor, message: str):
+        self.message = message
+        if cursor:
+            if cursor.connection:
+                self.session_id = cursor.connection.get_session_id_hex()
+            else:
+                self.session_id = "Unknown"
+            if (
+                cursor.active_result_set
+                and cursor.active_result_set.command_id
+                and cursor.active_result_set.command_id.operationId
+            ):
+                self.command_id = (
+                    str(UUID(bytes=cursor.active_result_set.command_id.operationId.guid))
+                    or "Unknown"
+                )
+            else:
+                self.command_id = "Unknown"
+
+    def __str__(self) -> str:
+        return (
+            f"Cursor(session-id={self.session_id}, command-id={self.command_id}) - {self.message}"
+        )
+
+
+class CursorCloseError(CursorEvent):
+    def __init__(self, cursor: Cursor, exception: Exception):
+        super().__init__(
+            cursor, str(SQLErrorEvent(exception, "Exception while trying to close cursor"))
+        )
+
+
+class CursorCancelError(CursorEvent):
+    def __init__(self, cursor: Cursor, exception: Exception):
+        super().__init__(
+            cursor, str(SQLErrorEvent(exception, "Exception while trying to cancel cursor"))
+        )
+
+
+class CursorCreate(CursorEvent):
+    def __init__(self, cursor: Cursor):
+        super().__init__(cursor, "Created cursor")
+
+
+class CursorClose(CursorEvent):
+    def __init__(self, cursor: Cursor):
+        super().__init__(cursor, "Closing cursor")
+
+
+class CursorCancel(CursorEvent):
+    def __init__(self, cursor: Cursor):
+        super().__init__(cursor, "Cancelling cursor")

--- a/dbt/adapters/databricks/events/other_events.py
+++ b/dbt/adapters/databricks/events/other_events.py
@@ -1,0 +1,6 @@
+from dbt.adapters.databricks.events.base import SQLErrorEvent
+
+
+class QueryError(SQLErrorEvent):
+    def __init__(self, log_sql: str, exception: Exception):
+        super().__init__(exception, f"Exception while trying to execute query\n{log_sql}\n")

--- a/dbt/adapters/databricks/events/pipeline_events.py
+++ b/dbt/adapters/databricks/events/pipeline_events.py
@@ -1,0 +1,25 @@
+from abc import ABC
+
+
+class PipelineEvent(ABC):
+    def __init__(self, pipeline_id: str, update_id: str, message: str):
+        self.pipeline_id = pipeline_id
+        self.update_id = update_id
+        self.message = message
+
+    def __str__(self) -> str:
+        return (
+            f"Pipeline(pipeline-id={self.pipeline_id}, update-id={self.update_id}) - {self.message}"
+        )
+
+
+class PipelineRefresh(PipelineEvent):
+    def __init__(self, pipeline_id: str, update_id: str, model_name: str, state: str):
+        super().__init__(
+            pipeline_id, update_id, f"Refreshing model {model_name} with state {state}"
+        )
+
+
+class PipelineRefreshError(PipelineEvent):
+    def __init__(self, pipeline_id: str, update_id: str, message: str):
+        super().__init__(pipeline_id, update_id, f"Error refreshing pipeline: {message}")

--- a/tests/functional/adapter/long_sessions/test_long_sessions.py
+++ b/tests/functional/adapter/long_sessions/test_long_sessions.py
@@ -1,6 +1,7 @@
-import pytest
 import os
 from unittest import mock
+
+import pytest
 from dbt.tests import util
 from tests.functional.adapter.long_sessions import fixtures
 
@@ -96,5 +97,5 @@ class TestLongSessionsIdleCleanup(TestLongSessionsMultipleCompute):
         util.run_dbt(["--debug", "seed", "--target", "idle_sessions"])
 
         _, log = util.run_dbt_and_capture(["--debug", "run", "--target", "idle_sessions"])
-        idle_count = log.count("closing idle connection") / 2
+        idle_count = log.count("Closing for idleness") / 2
         assert idle_count > 0

--- a/tests/functional/adapter/warehouse_per_model/test_warehouse_per_model.py
+++ b/tests/functional/adapter/warehouse_per_model/test_warehouse_per_model.py
@@ -117,7 +117,11 @@ class TestWarehousePerModel(BaseWarehousePerModel):
                 "alternate_warehouse",
             ]
         )
-        assert "`source` using compute resource 'alternate_warehouse2'" in log
+
+        assert (
+            "using compute resource 'alternate_warehouse2' for model "
+            f"'`{project.database}`.`{project.test_schema}`.`source`'" in log
+        )
 
         _, log = util.run_dbt_and_capture(
             [
@@ -132,8 +136,14 @@ class TestWarehousePerModel(BaseWarehousePerModel):
                 "alternate_warehouse",
             ]
         )
-        assert "`target` using compute resource 'alternate_warehouse'" in log
-        assert "`target3` using default compute resource" in log
+        assert (
+            "using compute resource 'alternate_warehouse' for model "
+            f"'`{project.database}`.`{project.test_schema}`.`target`'" in log
+        )
+        assert (
+            f"using default compute resource for model '`{project.database}`."
+            f"`{project.test_schema}`.`target3`'" in log
+        )
 
         _, log = util.run_dbt_and_capture(
             [
@@ -145,6 +155,9 @@ class TestWarehousePerModel(BaseWarehousePerModel):
                 "alternate_warehouse",
             ]
         )
-        assert "`target_snap` using compute resource 'alternate_warehouse3'" in log
+        assert (
+            "using compute resource 'alternate_warehouse3' for model "
+            f"'`{project.database}`.`snapshots`.`target_snap`'" in log
+        )
 
         util.check_relations_equal(project.adapter, ["target", "source"])

--- a/tests/unit/events/test_base_events.py
+++ b/tests/unit/events/test_base_events.py
@@ -1,0 +1,34 @@
+from databricks.sql.exc import Error
+from dbt.adapters.databricks.events.base import ErrorEvent
+from dbt.adapters.databricks.events.base import SQLErrorEvent
+
+
+class ErrorTestEvent(ErrorEvent):
+    def __init__(self, exception):
+        super().__init__(exception, "This is a test")
+
+
+class TestErrorEvent:
+    def test_error_event__without_exception(self):
+        event = ErrorTestEvent(None)
+        assert str(event) == "This is a test: None"
+
+    def test_error_event__with_exception(self):
+        e = Exception("This is an exception")
+        event = ErrorTestEvent(e)
+        assert str(event) == "This is a test: This is an exception"
+
+
+class TestSQLErrorEvent:
+    def test_sql_error_event__with_exception(self):
+        e = Exception("This is an exception")
+        event = SQLErrorEvent(e)
+        assert str(event) == "This is a test: This is an exception"
+
+    def test_sql_error_event__with_pysql_error(self):
+        e = Error("This is a pysql error", {"key": "value", "other": "other_value"})
+        event = SQLErrorEvent(e, "This is a test")
+        assert (
+            str(event) == "This is a test: This is a pysql error\n"
+            "Error properties: key=value, other=other_value"
+        )

--- a/tests/unit/events/test_base_events.py
+++ b/tests/unit/events/test_base_events.py
@@ -22,7 +22,7 @@ class TestErrorEvent:
 class TestSQLErrorEvent:
     def test_sql_error_event__with_exception(self):
         e = Exception("This is an exception")
-        event = SQLErrorEvent(e)
+        event = SQLErrorEvent(e, "This is a test")
         assert str(event) == "This is a test: This is an exception"
 
     def test_sql_error_event__with_pysql_error(self):

--- a/tests/unit/events/test_connection_events.py
+++ b/tests/unit/events/test_connection_events.py
@@ -1,0 +1,71 @@
+from dbt.adapters.databricks.events.connection_events import ConnectionAcquire
+from dbt.adapters.databricks.events.connection_events import ConnectionCloseError
+from dbt.adapters.databricks.events.connection_events import ConnectionEvent
+from mock import Mock
+
+
+class ConnectionTestEvent(ConnectionEvent):
+    def __init__(self, connection):
+        super().__init__(connection, "This is a test")
+
+
+class TestConnectionEvents:
+    def test_cursor_event__no_connection(self):
+        event = ConnectionTestEvent(None)
+        assert str(event) == "Connection(session-id=Unknown) - This is a test"
+
+    def test_connection_event__no_id(self):
+        mock = Mock()
+        mock.get_session_id_hex.return_value = None
+        event = ConnectionTestEvent(mock)
+        assert str(event) == "Connection(session-id=Unknown) - This is a test"
+
+    def test_connection_event__with_id(self):
+        mock = Mock()
+        mock.get_session_id_hex.return_value = "1234"
+        event = ConnectionTestEvent(mock)
+        assert str(event) == "Connection(session-id=1234) - This is a test"
+
+
+class TestConnectionCloseError:
+    def test_connection_close_error(self):
+        e = Exception("This is an exception")
+        event = ConnectionCloseError(None, e)
+        assert (
+            str(event) == "Connection(session-id=Unknown) "
+            "- Exception while trying to close connection: This is an exception"
+        )
+
+
+class TestConnectionAcquire:
+    def test_connection_acquire__missing_data(self):
+        event = ConnectionAcquire(None, None, None, (0, 0))
+        assert (
+            str(event)
+            == "None - Acquired connection on thread (0, 0), using default compute resource"
+        )
+
+    def test_connection_acquire__with_compute_name(self):
+        event = ConnectionAcquire(None, None, "Eniac", (0, 0))
+        assert (
+            str(event)
+            == "None - Acquired connection on thread (0, 0), using compute resource 'Eniac'"
+        )
+
+    def test_connection_acquire__with_nonmodel_node(self):
+        event = ConnectionAcquire(None, Mock([]), None, (0, 0))
+        assert (
+            str(event)
+            == "None - Acquired connection on thread (0, 0), using default compute resource"
+            " for model '[Unknown]'"
+        )
+
+    def test_connection_acquire__with_everything(self):
+        model = Mock()
+        model.relation_name = "MyModel"
+        event = ConnectionAcquire("Connection", model, "Eniac", (0, 0))
+        assert (
+            str(event)
+            == "Connection - Acquired connection on thread (0, 0), using compute resource 'Eniac'"
+            " for model 'MyModel'"
+        )

--- a/tests/unit/events/test_cursor_events.py
+++ b/tests/unit/events/test_cursor_events.py
@@ -1,4 +1,3 @@
-import pytest
 from dbt.adapters.databricks.events.cursor_events import CursorCloseError
 from dbt.adapters.databricks.events.cursor_events import CursorEvent
 from mock import Mock
@@ -27,8 +26,8 @@ class TestCursorEvents:
         mock.active_result_set.command_id.operationId.guid = (1234).to_bytes(16)
         event = CursorTestEvent(mock)
         assert (
-            str(event)
-            == "Cursor(session-id=1234, command-id=00000000-0000-0000-0000-0000000004d2) - This is a test"
+            str(event) == "Cursor(session-id=1234, command-id=00000000-0000-0000-0000-0000000004d2)"
+            " - This is a test"
         )
 
 

--- a/tests/unit/events/test_cursor_events.py
+++ b/tests/unit/events/test_cursor_events.py
@@ -1,0 +1,42 @@
+import pytest
+from dbt.adapters.databricks.events.cursor_events import CursorCloseError
+from dbt.adapters.databricks.events.cursor_events import CursorEvent
+from mock import Mock
+
+
+class CursorTestEvent(CursorEvent):
+    def __init__(self, cursor):
+        super().__init__(cursor, "This is a test")
+
+
+class TestCursorEvents:
+    def test_cursor_event__no_cursor(self):
+        event = CursorTestEvent(None)
+        assert str(event) == "Cursor(session-id=Unknown, command-id=Unknown) - This is a test"
+
+    def test_cursor_event__no_ids(self):
+        mock = Mock()
+        mock.connection = None
+        mock.active_result_set = None
+        event = CursorTestEvent(mock)
+        assert str(event) == "Cursor(session-id=Unknown, command-id=Unknown) - This is a test"
+
+    def test_cursor_event__with_ids(self):
+        mock = Mock()
+        mock.connection.get_session_id_hex.return_value = "1234"
+        mock.active_result_set.command_id.operationId.guid = (1234).to_bytes(16)
+        event = CursorTestEvent(mock)
+        assert (
+            str(event)
+            == "Cursor(session-id=1234, command-id=00000000-0000-0000-0000-0000000004d2) - This is a test"
+        )
+
+
+class TestCursorCloseError:
+    def test_cursor_close_error(self):
+        e = Exception("This is an exception")
+        event = CursorCloseError(None, e)
+        assert (
+            str(event) == "Cursor(session-id=Unknown, command-id=Unknown) "
+            "- Exception while trying to close cursor: This is an exception"
+        )

--- a/tests/unit/events/test_cursor_events.py
+++ b/tests/unit/events/test_cursor_events.py
@@ -23,7 +23,7 @@ class TestCursorEvents:
     def test_cursor_event__with_ids(self):
         mock = Mock()
         mock.connection.get_session_id_hex.return_value = "1234"
-        mock.active_result_set.command_id.operationId.guid = (1234).to_bytes(16)
+        mock.active_result_set.command_id.operationId.guid = (1234).to_bytes(16, "big")
         event = CursorTestEvent(mock)
         assert (
             str(event) == "Cursor(session-id=1234, command-id=00000000-0000-0000-0000-0000000004d2)"


### PR DESCRIPTION
<!-- Please review our pull request review process in CONTRIBUTING.md before your proceed. -->

Hopefully resolves #647

<!---
  Include the number of the issue addressed by this PR above if applicable.
  
  Example:
    resolves #1234

  Please review our pull request review process in CONTRIBUTING.md before your proceed.
-->

### Description

Customers with high concurrency on SQL Warehouses have been hitting an issue where they see 'Remote disconnected' as the error.  It appears somewhere in the stack, connections that have been idle for 180+s hit this issue when we attempt to reuse them.  This PR has the following:

* Move default time for considering a connection stale to 60s (most of the benefit of reusing connections comes from having many quick operations anyway, since the overhead of creating and closing connections is sub-second).
* Significant refactoring of logging to improve clarity and consistency in debug logs
* I noticed that BearerAuth was invoking the header factory on create rather than call, which I believe is what was causing #647

### Checklist

I should probably add tests for the logging, but I will hold that for when I bring this code into 2.0.0 branch (to reduce the significant pain that will already be).

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
