### PR TITLE
Fix for rerunning seed with persist_doc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 - Support Databricks tags for tables/views/incrementals ([631](https://github.com/databricks/dbt-databricks/pull/631))
 - Support Liquid Clustering for python models ([663](https://github.com/databricks/dbt-databricks/pull/663))
 
+### Fixes
+
+- Rerunning seed with external location + persist_doc now more resilient ([662](https://github.com/databricks/dbt-databricks/pull/662))
+
 ### Under the Hood
 
 - Upgrade databricks-sql-connector to 3.1.0 ([593](https://github.com/databricks/dbt-databricks/pull/593))

--- a/dbt/include/databricks/macros/materializations/seeds/helpers.sql
+++ b/dbt/include/databricks/macros/materializations/seeds/helpers.sql
@@ -45,15 +45,33 @@
   {{ return(statements[0]) }}
 {% endmacro %}
 
-{% macro databricks__create_csv_table(model, agate_table) %}
+{% macro databricks__reset_csv_table(model, full_refresh, old_relation, agate_table) %}
+    {% if old_relation %}
+      {% if old_relation.is_delta and config.get('file_format', default='delta') == 'delta' %}
+        {% set sql = create_or_replace_csv_table(model, agate_table, True) %}
+      {% else %}
+        {{ adapter.drop_relation(old_relation) }}
+        {% set sql = create_csv_table(model, agate_table) %}
+      {% endif %}
+    {% else %}
+      {% set sql = create_csv_table(model, agate_table) %}
+    {% endif %}
+    {{ return(sql) }}
+{% endmacro %}
+
+{% macro create_or_replace_csv_table(model, agate_table, replace=False) %}
   {%- set column_override = model['config'].get('column_types', {}) -%}
   {%- set quote_seed_column = model['config'].get('quote_columns', None) -%}
   {%- set column_comment = config.persist_column_docs() and model.columns %}
   {%- set identifier = model['alias'] -%}
   {%- set relation = api.Relation.create(database=database, schema=schema, identifier=identifier, type='table') -%}
+  {%- set replace_clause = "" -%}
+  {%- if replace -%}
+    {%- set replace_clause = "or replace" -%}
+  {%- endif -%}
 
   {% set sql %}
-    create table {{ this.render() }} (
+    create {{replace_clause}} table {{ this.render() }} (
         {%- for col_name in agate_table.column_names -%}
             {%- set inferred_type = adapter.convert_type(agate_table, loop.index0) -%}
             {%- set type = column_override.get(col_name, inferred_type) -%}
@@ -81,4 +99,8 @@
   {%- endcall %}
 
   {{ return(sql) }}
+{% endmacro %}
+
+{% macro databricks__create_csv_table(model, agate_table) %}
+  {{ return(create_or_replace_csv_table(model, agate_table)) }}
 {% endmacro %}

--- a/dbt/include/databricks/macros/materializations/seeds/helpers.sql
+++ b/dbt/include/databricks/macros/materializations/seeds/helpers.sql
@@ -48,6 +48,7 @@
 {% macro databricks__create_csv_table(model, agate_table) %}
   {%- set column_override = model['config'].get('column_types', {}) -%}
   {%- set quote_seed_column = model['config'].get('quote_columns', None) -%}
+  {%- set column_comment = config.persist_column_docs() and model.columns %}
   {%- set identifier = model['alias'] -%}
   {%- set relation = api.Relation.create(database=database, schema=schema, identifier=identifier, type='table') -%}
 
@@ -57,7 +58,14 @@
             {%- set inferred_type = adapter.convert_type(agate_table, loop.index0) -%}
             {%- set type = column_override.get(col_name, inferred_type) -%}
             {%- set column_name = (col_name | string) -%}
-            {{ adapter.quote_seed_column(column_name, quote_seed_column) }} {{ type }} {%- if not loop.last -%}, {%- endif -%}
+            {%- set column_comment_clause = "" -%}
+            {%- if column_comment -%}       
+              {%- set comment = model.columns[col_name]['description'] | replace("'", "\\'") -%}
+              {%- if comment and comment != "" -%}
+                {%- set column_comment_clause = "comment '" ~ comment ~ "'" -%}
+              {%- endif -%}
+            {%- endif -%}
+            {{ adapter.quote_seed_column(column_name, quote_seed_column) }} {{ type }} {{ column_comment_clause }}{%- if not loop.last -%}, {%- endif -%}
         {%- endfor -%}
     )
     {{ file_format_clause() }}

--- a/dbt/include/databricks/macros/materializations/seeds/seeds.sql
+++ b/dbt/include/databricks/macros/materializations/seeds/seeds.sql
@@ -44,8 +44,7 @@
 
   {% set should_revoke = should_revoke(old_relation, full_refresh_mode) %}
   {% do apply_grants(target_relation, grant_config, should_revoke=should_revoke) %}
-
-  {% do persist_docs(target_relation, model) %}
+  -- No need to persist docs, already handled in seed create
 
   {% if full_refresh_mode or not exists_as_table %}
     {% do create_indexes(target_relation) %}

--- a/dbt/include/databricks/macros/materializations/seeds/seeds.sql
+++ b/dbt/include/databricks/macros/materializations/seeds/seeds.sql
@@ -3,7 +3,7 @@
   {%- set identifier = model['alias'] -%}
   {%- set full_refresh_mode = (should_full_refresh()) -%}
 
-  {%- set old_relation = adapter.get_relation(database=database, schema=schema, identifier=identifier) -%}
+  {%- set old_relation = adapter.get_relation(database=database, schema=schema, identifier=identifier, needs_information=True) -%}
 
   {%- set exists_as_table = (old_relation is not none and old_relation.is_table) -%}
   {%- set exists_as_view = (old_relation is not none and (old_relation.is_view or old_relation.is_materialized_view)) -%}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ pytest_plugins = ["dbt.tests.fixtures.project"]
 
 
 def pytest_addoption(parser):
-    parser.addoption("--profile", action="store", default="databricks_uc_cluster", type=str)
+    parser.addoption("--profile", action="store", default="databricks_uc_sql_endpoint", type=str)
 
 
 # Using @pytest.mark.skip_profile('databricks_cluster') uses the 'skip_by_adapter_type'

--- a/tests/functional/adapter/persist_docs/fixtures.py
+++ b/tests/functional/adapter/persist_docs/fixtures.py
@@ -12,7 +12,7 @@ seeds:
       - name: id
         description: 'An id column'
       - name: name
-        description: 'A name column'    
+        description: 'A name column'
 """
 
 _HIVE__SCHEMA_YML = """
@@ -29,5 +29,5 @@ seeds:
       - name: id
         description: 'An id column'
       - name: name
-        description: 'A name column'    
+        description: 'A name column'
 """

--- a/tests/functional/adapter/persist_docs/fixtures.py
+++ b/tests/functional/adapter/persist_docs/fixtures.py
@@ -14,3 +14,20 @@ seeds:
       - name: name
         description: 'A name column'    
 """
+
+_HIVE__SCHEMA_YML = """
+version: 2
+seeds:
+  - name: seed
+    description: 'A seed description'
+    config:
+      location_root: '/mnt/dbt_databricks/seeds'
+      persist_docs:
+        relation: True
+        columns: True
+    columns:
+      - name: id
+        description: 'An id column'
+      - name: name
+        description: 'A name column'    
+"""

--- a/tests/functional/adapter/persist_docs/fixtures.py
+++ b/tests/functional/adapter/persist_docs/fixtures.py
@@ -1,0 +1,16 @@
+_SEEDS__SCHEMA_YML = """
+version: 2
+seeds:
+  - name: seed
+    description: 'A seed description'
+    config:
+      location_root: '{{ env_var("DBT_DATABRICKS_LOCATION_ROOT") }}'
+      persist_docs:
+        relation: True
+        columns: True
+    columns:
+      - name: id
+        description: 'An id column'
+      - name: name
+        description: 'A name column'    
+"""

--- a/tests/functional/adapter/persist_docs/test_persist_docs.py
+++ b/tests/functional/adapter/persist_docs/test_persist_docs.py
@@ -251,11 +251,20 @@ class TestPersistDocsWithSeeds:
         util.run_dbt(["seed"])
 
     @pytest.fixture(scope="class")
-    def seeds(self):
-        return {
-            "seed.csv": fixtures._SEEDS__SEED,
-            "schema.yml": override_fixtures._SEEDS__SCHEMA_YML,
-        }
+    def seeds(self, adapter):
+        if (
+            adapter.config.credentials.database
+            and adapter.config.credentials.database != "hive_metastore"
+        ):
+            return {
+                "seed.csv": fixtures._SEEDS__SEED,
+                "schema.yml": override_fixtures._SEEDS__SCHEMA_YML,
+            }
+        else:
+            return {
+                "seed.csv": fixtures._SEEDS__SEED,
+                "schema.yml": override_fixtures._HIVE__SCHEMA_YML,
+            }
 
     @pytest.fixture(scope="class")
     def table_relation(self, project):


### PR DESCRIPTION
<!-- Please review our pull request review process in CONTRIBUTING.md before your proceed. -->

Resolves #296 

<!---
  Include the number of the issue addressed by this PR above if applicable.
  
  Example:
    resolves #1234

  Please review our pull request review process in CONTRIBUTING.md before your proceed.
-->

### Description

This PR fixes an issue that users hit when repeatedly using `dbt build` with `persist_docs` and `seeds`.  Spark treats the lack of comments (since historically comments were applied with an ALTER statement) as a schema change, and since dropping an external location doesn't get rid of the backing data, Spark acts as though the table still exists with the previous schema after dropping.  I noticed while running my tests to verify the behavior that our create table command was specifying the column types, even when my model config did not; this is because dbt infers the types for seeds from the data in the seed file.  Having column type info in our create request means that we can also specify our comments during create for seeds, something we cannot do with normal table creation.

Specifying comments during creation, rather than alter, has two positive consequences:

1. If the seed has not changed, the schema between the old table and new table is now viewed as compatible (because they both include comments)
2. I believe that applying comments at create time is more performant that doing a sequence of alters (which can be very slow).

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
