### PR TITLE
Remove dependence on unittest from Adapter tests

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -4,7 +4,7 @@ on:
     paths-ignore:
       - "**.MD"
       - "**.md"
-      - "tests/unit"
+      - "tests/unit/**"
 jobs:
   run-tox-tests-uc-cluster:
     runs-on: ubuntu-latest

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -4,6 +4,7 @@ on:
     paths-ignore:
       - "**.MD"
       - "**.md"
+      - "tests/unit"
 jobs:
   run-tox-tests-uc-cluster:
     runs-on: ubuntu-latest

--- a/tests/unit/test_adapter.py
+++ b/tests/unit/test_adapter.py
@@ -927,7 +927,6 @@ class TestCheckNotFound:
 class TestGetPersistDocColumns(DatabricksAdapterBase):
     @pytest.fixture(scope="class")
     def adapter(self) -> DatabricksAdapter:
-        self.setUp()
         return DatabricksAdapter(self._get_config(), get_context("spawn"))
 
     def create_column(self, name, comment) -> DatabricksColumn:

--- a/tests/unit/test_adapter.py
+++ b/tests/unit/test_adapter.py
@@ -925,8 +925,8 @@ class TestCheckNotFound:
 
 
 class TestGetPersistDocColumns(DatabricksAdapterBase):
-    @pytest.fixture(scope="class")
-    def adapter(self) -> DatabricksAdapter:
+    @pytest.fixture
+    def adapter(self, setUp) -> DatabricksAdapter:
         return DatabricksAdapter(self._get_config(), get_context("spawn"))
 
     def create_column(self, name, comment) -> DatabricksColumn:


### PR DESCRIPTION
<!---
  Include the number of the issue addressed by this PR above if applicable.
  
  Example:
    resolves #1234

  Please review our pull request review process in CONTRIBUTING.md before your proceed.
-->

### Description

Remove dependence of the adapter tests on unittest (and instead depend on pytest).  Also updates some lagging references to the shared adapter libraries, that were still pointing at dbt-core.

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
