### PR TITLE
Backport fix to log events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-## dbt-databricks 1.7.15 (TBD)
+## dbt-databricks 1.7.15 (May 16, 2024)
+
+### Fixes
+
+- Give sensible logs when connection errors ([666](https://github.com/databricks/dbt-databricks/pull/666))
 
 ## dbt-databricks 1.7.14 (May 1, 2024)
 

--- a/dbt/adapters/databricks/events/connection_events.py
+++ b/dbt/adapters/databricks/events/connection_events.py
@@ -1,14 +1,14 @@
 from abc import ABC
+from typing import Any
 from typing import Optional
 from typing import Tuple
 
 from databricks.sql.client import Connection
 from dbt.adapters.databricks.events.base import SQLErrorEvent
-from dbt.contracts.graph.nodes import ResultNode
 
 
 class ConnectionEvent(ABC):
-    def __init__(self, connection: Connection, message: str):
+    def __init__(self, connection: Optional[Connection], message: str):
         self.message = message
         self.session_id = "Unknown"
         if connection:
@@ -19,31 +19,31 @@ class ConnectionEvent(ABC):
 
 
 class ConnectionCancel(ConnectionEvent):
-    def __init__(self, connection: Connection):
+    def __init__(self, connection: Optional[Connection]):
         super().__init__(connection, "Cancelling connection")
 
 
 class ConnectionClose(ConnectionEvent):
-    def __init__(self, connection: Connection):
+    def __init__(self, connection: Optional[Connection]):
         super().__init__(connection, "Closing connection")
 
 
 class ConnectionCancelError(ConnectionEvent):
-    def __init__(self, connection: Connection, exception: Exception):
+    def __init__(self, connection: Optional[Connection], exception: Exception):
         super().__init__(
             connection, str(SQLErrorEvent(exception, "Exception while trying to cancel connection"))
         )
 
 
 class ConnectionCloseError(ConnectionEvent):
-    def __init__(self, connection: Connection, exception: Exception):
+    def __init__(self, connection: Optional[Connection], exception: Exception):
         super().__init__(
             connection, str(SQLErrorEvent(exception, "Exception while trying to close connection"))
         )
 
 
 class ConnectionCreateError(ConnectionEvent):
-    def __init__(self, connection: Connection, exception: Exception):
+    def __init__(self, connection: Optional[Connection], exception: Exception):
         super().__init__(
             connection, str(SQLErrorEvent(exception, "Exception while trying to create connection"))
         )
@@ -62,7 +62,7 @@ class ConnectionAcquire(ConnectionWrapperEvent):
     def __init__(
         self,
         description: str,
-        model: Optional[ResultNode],
+        model: Optional[Any],
         compute_name: Optional[str],
         thread_identifier: Tuple[int, int],
     ):


### PR DESCRIPTION
<!---
  Include the number of the issue addressed by this PR above if applicable.
  
  Example:
    resolves #1234

  Please review our pull request review process in CONTRIBUTING.md before your proceed.
-->

### Description

Users have reported that the logged message on connection opening errors is confusing.  This is due to passing None for the connection and then getting an error about the connection not being defined.

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
