### PR TITLE
Handle empty comments on MV/ST better

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Streamline the process of determining materialization types ([655](https://github.com/databricks/dbt-databricks/pull/655))
 - Improve catalog performance by getting column description from project for UC ([658](https://github.com/databricks/dbt-databricks/pull/658))
 - Delay loading of agate library to improve startup (thanks @dwreeves for getting this started!) ([661](https://github.com/databricks/dbt-databricks/pull/661))
+- Handle empty comments on MV/ST better ([668](https://github.com/databricks/dbt-databricks/pull/668))
 
 ## dbt-databricks 1.7.14 (May 1, 2024)
 

--- a/dbt/adapters/databricks/relation_configs/comment.py
+++ b/dbt/adapters/databricks/relation_configs/comment.py
@@ -21,9 +21,15 @@ class CommentProcessor(DatabricksComponentProcessor[CommentConfig]):
         table = results["describe_extended"]
         for row in table.rows:
             if row[0] == "Comment":
-                return CommentConfig(comment=row[1])
+                if row[1]:
+                    return CommentConfig(comment=row[1])
+                else:
+                    return CommentConfig()
         return CommentConfig()
 
     @classmethod
     def from_relation_config(cls, relation_config: RelationConfig) -> CommentConfig:
-        return CommentConfig(comment=getattr(relation_config, "description"))
+        comment = getattr(relation_config, "description", None)
+        if comment:
+            return CommentConfig(comment=comment)
+        return CommentConfig()

--- a/tests/functional/adapter/materialized_view_tests/fixtures.py
+++ b/tests/functional/adapter/materialized_view_tests/fixtures.py
@@ -30,7 +30,6 @@ def query_relation_type(project, relation: BaseRelation) -> Optional[str]:
 materialized_view = """
 {{ config(
     materialized='materialized_view',
-    description='this is a materialized view',
     partition_by='id',
     schedule = {
         'cron': '0 0 * * * ? *',

--- a/tests/functional/adapter/streaming_tables/test_st_changes.py
+++ b/tests/functional/adapter/streaming_tables/test_st_changes.py
@@ -1,8 +1,6 @@
 from typing import Optional
 
 import pytest
-from dbt_common.contracts.config.materialization import OnConfigurationChangeOption
-
 from dbt.adapters.base.relation import BaseRelation
 from dbt.adapters.databricks.relation import DatabricksRelationType
 from dbt.adapters.databricks.relation_configs.streaming_table import (
@@ -13,6 +11,7 @@ from dbt.tests import util
 from dbt.tests.adapter.materialized_view.files import (
     MY_SEED,
 )
+from dbt_common.contracts.config.materialization import OnConfigurationChangeOption
 from tests.functional.adapter.streaming_tables import fixtures
 
 
@@ -33,6 +32,7 @@ class StreamingTableChanges:
         _check_tblproperties(results.config["tblproperties"], {"key": "value"})
         assert results.config["refresh"].cron == "0 0 * * * ? *"
         assert results.config["refresh"].time_zone_value == "Etc/UTC"
+        assert results.config["comment"].comment == None
 
     @staticmethod
     def change_config_via_alter(project, streaming_table):
@@ -49,6 +49,7 @@ class StreamingTableChanges:
         assert isinstance(results, StreamingTableConfig)
         assert results.config["refresh"].cron == "0 5 * * * ? *"
         assert results.config["refresh"].time_zone_value == "Etc/UTC"
+        assert results.config["comment"].comment == None
         _check_tblproperties(results.config["tblproperties"], {"pipeline": "altered"})
 
     @staticmethod

--- a/tests/functional/adapter/streaming_tables/test_st_changes.py
+++ b/tests/functional/adapter/streaming_tables/test_st_changes.py
@@ -32,7 +32,7 @@ class StreamingTableChanges:
         _check_tblproperties(results.config["tblproperties"], {"key": "value"})
         assert results.config["refresh"].cron == "0 0 * * * ? *"
         assert results.config["refresh"].time_zone_value == "Etc/UTC"
-        assert results.config["comment"].comment == None
+        assert results.config["comment"].comment is None
 
     @staticmethod
     def change_config_via_alter(project, streaming_table):
@@ -49,7 +49,7 @@ class StreamingTableChanges:
         assert isinstance(results, StreamingTableConfig)
         assert results.config["refresh"].cron == "0 5 * * * ? *"
         assert results.config["refresh"].time_zone_value == "Etc/UTC"
-        assert results.config["comment"].comment == None
+        assert results.config["comment"].comment is None
         _check_tblproperties(results.config["tblproperties"], {"pipeline": "altered"})
 
     @staticmethod

--- a/tests/unit/relation_configs/test_comment.py
+++ b/tests/unit/relation_configs/test_comment.py
@@ -1,8 +1,7 @@
 from agate import Table
-from mock import Mock
-
 from dbt.adapters.databricks.relation_configs.comment import CommentConfig
 from dbt.adapters.databricks.relation_configs.comment import CommentProcessor
+from mock import Mock
 
 
 class TestCommentProcessor:
@@ -51,7 +50,7 @@ class TestCommentProcessor:
         model_node = Mock()
         model_node.description = ""
         config = CommentProcessor.from_relation_config(model_node)
-        assert config == CommentConfig(comment="")
+        assert config == CommentConfig(comment=None)
 
     def test_from_model_node__comment(self):
         model_node = Mock()


### PR DESCRIPTION
<!---
  Include the number of the issue addressed by this PR above if applicable.
  
  Example:
    resolves #1234

  Please review our pull request review process in CONTRIBUTING.md before your proceed.
-->

### Description

Prior to this change, when a user had not put a description on his model, we actually set the table comment as ''.  This change ensures empty strings are not treated as legitimate comments.

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
