### PR TITLE
Fix issue with conn not initialized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## dbt-databricks 1.7.16 (May 21, 2024)
+
+### Fixes
+
+- Fix the issue that 1.7.15 was intended to fix (conn not initialized exception) ([671](https://github.com/databricks/dbt-databricks/pull/671))
+
 ## dbt-databricks 1.7.15 (May 16, 2024)
 
 ### Fixes

--- a/dbt/adapters/databricks/__version__.py
+++ b/dbt/adapters/databricks/__version__.py
@@ -1,1 +1,1 @@
-version: str = "1.7.15"
+version: str = "1.7.16"

--- a/dbt/adapters/databricks/connections.py
+++ b/dbt/adapters/databricks/connections.py
@@ -1441,7 +1441,7 @@ class DatabricksConnectionManager(SparkConnectionManager):
                     user_agent=user_agent_entry,
                 )
             except Error as exc:
-                logger.error(ConnectionCreateError(conn, exc))
+                logger.error(ConnectionCreateError(exc))
                 raise
 
         def exponential_backoff(attempt: int) -> int:
@@ -1524,7 +1524,7 @@ class DatabricksConnectionManager(SparkConnectionManager):
                     user_agent=user_agent_entry,
                 )
             except Error as exc:
-                logger.error(ConnectionCreateError(conn, exc))
+                logger.error(ConnectionCreateError(exc))
                 raise
 
         def exponential_backoff(attempt: int) -> int:

--- a/dbt/adapters/databricks/events/connection_events.py
+++ b/dbt/adapters/databricks/events/connection_events.py
@@ -43,9 +43,9 @@ class ConnectionCloseError(ConnectionEvent):
 
 
 class ConnectionCreateError(ConnectionEvent):
-    def __init__(self, connection: Optional[Connection], exception: Exception):
+    def __init__(self, exception: Exception):
         super().__init__(
-            connection, str(SQLErrorEvent(exception, "Exception while trying to create connection"))
+            None, str(SQLErrorEvent(exception, "Exception while trying to create connection"))
         )
 
 


### PR DESCRIPTION
<!---
  Include the number of the issue addressed by this PR above if applicable.
  
  Example:
    resolves #1234

  Please review our pull request review process in CONTRIBUTING.md before your proceed.
-->

### Description

I didn't realize that even if an input is optional, Python complains if you use a variable that hasn't been initialized, which gets in the way of users seeing the exception about why the connection couldn't be established.

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
