### PR TITLE
Handle in-progress refresh for MV/ST

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+## dbt-databricks 1.8.1 (TBD)
+
+### Features
+
+- Support Liquid Clustering for python models ([663](https://github.com/databricks/dbt-databricks/pull/663))
+
+### Fixes
+
+- Rerunning seed with external location + persist_doc now more resilient ([662](https://github.com/databricks/dbt-databricks/pull/662))
+- Fix issue with running while a refresh is in progress with MV/ST ([674](https://github.com/databricks/dbt-databricks/pull/674))
+- Fix issue with running a refresh with MV/ST that need names to be escaped ([674](https://github.com/databricks/dbt-databricks/pull/674))
+
+### Under the Hood
+
+- Delay loading of agate library to improve startup (thanks @dwreeves for getting this started!) ([661](https://github.com/databricks/dbt-databricks/pull/661))
+
 ## dbt-databricks 1.8.0 (TBD)
 
 ### Features
@@ -6,11 +22,6 @@
 - Support `on_config_change` for streaming tables, expand the supported config options ([569](https://github.com/databricks/dbt-databricks/pull/569)))
 - Support insert overwrite on SQL Warehouses ([623](https://github.com/databricks/dbt-databricks/pull/623))
 - Support Databricks tags for tables/views/incrementals ([631](https://github.com/databricks/dbt-databricks/pull/631))
-- Support Liquid Clustering for python models ([663](https://github.com/databricks/dbt-databricks/pull/663))
-
-### Fixes
-
-- Rerunning seed with external location + persist_doc now more resilient ([662](https://github.com/databricks/dbt-databricks/pull/662))
 
 ### Under the Hood
 
@@ -19,7 +30,18 @@
 - Finish migrating integration tests ([623](https://github.com/databricks/dbt-databricks/pull/623))
 - Streamline the process of determining materialization types ([655](https://github.com/databricks/dbt-databricks/pull/655))
 - Improve catalog performance by getting column description from project for UC ([658](https://github.com/databricks/dbt-databricks/pull/658))
-- Delay loading of agate library to improve startup (thanks @dwreeves for getting this started!) ([661](https://github.com/databricks/dbt-databricks/pull/661))
+
+## dbt-databricks 1.7.16 (May 21, 2024)
+
+### Fixes
+
+- Fix the issue that 1.7.15 was intended to fix (conn not initialized exception) ([671](https://github.com/databricks/dbt-databricks/pull/671))
+
+## dbt-databricks 1.7.15 (May 16, 2024)
+
+### Fixes
+
+- Give sensible logs when connection errors ([666](https://github.com/databricks/dbt-databricks/pull/666))
 
 ## dbt-databricks 1.7.14 (May 1, 2024)
 

--- a/dbt/adapters/databricks/connections.py
+++ b/dbt/adapters/databricks/connections.py
@@ -232,10 +232,7 @@ class DatabricksSQLCursorWrapper:
         # the pipeline until the refresh is finished.
         self.pollRefreshPipeline(sql)
 
-    def pollRefreshPipeline(
-        self,
-        sql: str,
-    ) -> None:
+    def pollRefreshPipeline(self, sql: str) -> None:
         should_poll, model_name = _should_poll_refresh(sql)
         if not should_poll:
             return
@@ -636,6 +633,8 @@ class DatabricksConnectionManager(SparkConnectionManager):
 
                 table = agate_helper.empty_table()
             return response, table
+        except Error:
+            if 
         finally:
             cursor.close()
 

--- a/dbt/adapters/databricks/connections.py
+++ b/dbt/adapters/databricks/connections.py
@@ -633,8 +633,6 @@ class DatabricksConnectionManager(SparkConnectionManager):
 
                 table = agate_helper.empty_table()
             return response, table
-        except Error:
-            if 
         finally:
             cursor.close()
 

--- a/dbt/adapters/databricks/connections.py
+++ b/dbt/adapters/databricks/connections.py
@@ -228,7 +228,7 @@ class DatabricksSQLCursorWrapper:
             bindings = [self._fix_binding(binding) for binding in bindings]
         self._cursor.execute(sql, bindings)
 
-    def pollRefreshPipeline(self, pipeline_id: str) -> None:
+    def poll_refresh_pipeline(self, pipeline_id: str) -> None:
         # interval in seconds
         polling_interval = 10
 

--- a/dbt/adapters/databricks/connections.py
+++ b/dbt/adapters/databricks/connections.py
@@ -228,15 +228,7 @@ class DatabricksSQLCursorWrapper:
             bindings = [self._fix_binding(binding) for binding in bindings]
         self._cursor.execute(sql, bindings)
 
-        # if the command was to refresh a materialized view we need to poll
-        # the pipeline until the refresh is finished.
-        self.pollRefreshPipeline(sql)
-
-    def pollRefreshPipeline(self, sql: str) -> None:
-        should_poll, model_name = _should_poll_refresh(sql)
-        if not should_poll:
-            return
-
+    def pollRefreshPipeline(self, pipeline_id: str) -> None:
         # interval in seconds
         polling_interval = 10
 
@@ -251,8 +243,6 @@ class DatabricksSQLCursorWrapper:
         session = Session()
         session.auth = BearerAuth(headers)
         session.headers = {"User-Agent": self._user_agent}
-
-        pipeline_id = _get_table_view_pipeline_id(session, host, model_name)
         pipeline = _get_pipeline_state(session, host, pipeline_id)
         # get the most recently created update for the pipeline
         latest_update = _find_update(pipeline)
@@ -264,7 +254,7 @@ class DatabricksSQLCursorWrapper:
         update_id = latest_update.get("update_id", "")
         prev_state = state
 
-        logger.info(PipelineRefresh(pipeline_id, update_id, model_name, str(state)))
+        logger.info(PipelineRefresh(pipeline_id, update_id, str(state)))
 
         start = time.time()
         exceeded_timeout = False
@@ -286,7 +276,7 @@ class DatabricksSQLCursorWrapper:
 
             state = update.get("state")
             if state != prev_state:
-                logger.info(PipelineRefresh(pipeline_id, update_id, model_name, str(state)))
+                logger.info(PipelineRefresh(pipeline_id, update_id, str(state)))
                 prev_state = state
 
             if state == "FAILED":
@@ -314,10 +304,10 @@ class DatabricksSQLCursorWrapper:
 
         if state == "FAILED":
             msg = _get_update_error_msg(session, host, pipeline_id, update_id)
-            raise DbtRuntimeError(f"error refreshing model {model_name} {msg}")
+            raise DbtRuntimeError(f"Error refreshing pipeline {pipeline_id} {msg}")
 
         if state == "CANCELED":
-            raise DbtRuntimeError(f"refreshing model {model_name} cancelled")
+            raise DbtRuntimeError(f"Refreshing pipeline {pipeline_id} cancelled")
 
         return
 
@@ -1083,37 +1073,6 @@ class ExtendedSessionConnectionManager(DatabricksConnectionManager):
             retry_limit=creds.connect_retries,
             retry_timeout=(timeout if timeout is not None else exponential_backoff),
         )
-
-
-def _should_poll_refresh(sql: str) -> Tuple[bool, str]:
-    # if the command was to refresh a materialized view we need to poll
-    # the pipeline until the refresh is finished.
-    name = ""
-    refresh_search = mv_refresh_regex.search(sql)
-    if not refresh_search:
-        refresh_search = st_refresh_regex.search(sql)
-
-    if refresh_search:
-        name = refresh_search.group(1).replace("`", "")
-
-    return refresh_search is not None, name
-
-
-def _get_table_view_pipeline_id(session: Session, host: str, name: str) -> str:
-    table_url = f"https://{host}/api/2.1/unity-catalog/tables/{name}"
-    resp1 = session.get(table_url)
-    if resp1.status_code != 200:
-        raise DbtRuntimeError(
-            f"Error getting info for materialized view/streaming table {name}: {resp1.text}"
-        )
-
-    pipeline_id = resp1.json().get("pipeline_id", "")
-    if not pipeline_id:
-        raise DbtRuntimeError(
-            f"Materialized view/streaming table {name} does not have a pipeline id"
-        )
-
-    return pipeline_id
 
 
 def _get_pipeline_state(session: Session, host: str, pipeline_id: str) -> dict:

--- a/dbt/adapters/databricks/events/pipeline_events.py
+++ b/dbt/adapters/databricks/events/pipeline_events.py
@@ -14,10 +14,8 @@ class PipelineEvent(ABC):
 
 
 class PipelineRefresh(PipelineEvent):
-    def __init__(self, pipeline_id: str, update_id: str, model_name: str, state: str):
-        super().__init__(
-            pipeline_id, update_id, f"Refreshing model {model_name} with state {state}"
-        )
+    def __init__(self, pipeline_id: str, update_id: str, state: str):
+        super().__init__(pipeline_id, update_id, f"Refreshing - got state {state}")
 
 
 class PipelineRefreshError(PipelineEvent):

--- a/dbt/adapters/databricks/impl.py
+++ b/dbt/adapters/databricks/impl.py
@@ -8,6 +8,7 @@ from contextlib import contextmanager
 from dataclasses import dataclass
 from typing import Any
 from typing import Callable
+from typing import cast
 from typing import ClassVar
 from typing import Dict
 from typing import FrozenSet
@@ -38,6 +39,8 @@ from dbt.adapters.contracts.relation import RelationConfig
 from dbt.adapters.contracts.relation import RelationType
 from dbt.adapters.databricks.column import DatabricksColumn
 from dbt.adapters.databricks.connections import DatabricksConnectionManager
+from dbt.adapters.databricks.connections import DatabricksDBTConnection
+from dbt.adapters.databricks.connections import DatabricksSQLConnectionWrapper
 from dbt.adapters.databricks.connections import ExtendedSessionConnectionManager
 from dbt.adapters.databricks.connections import USE_LONG_SESSIONS
 from dbt.adapters.databricks.python_submissions import (
@@ -703,7 +706,23 @@ class RelationAPIBase(ABC, Generic[DatabricksRelationConfig]):
         raise NotImplementedError("Must be implemented by subclass")
 
 
-class MaterializedViewAPI(RelationAPIBase[MaterializedViewConfig]):
+class DeltaLiveTableAPIBase(RelationAPIBase[DatabricksRelationConfig]):
+    @classmethod
+    def get_from_relation(
+        cls, adapter: DatabricksAdapter, relation: DatabricksRelation
+    ) -> DatabricksRelationConfig:
+        """Get the relation config from the relation."""
+
+        relation_config = super(DeltaLiveTableAPIBase, cls).get_from_relation(adapter, relation)
+        connection = cast(DatabricksDBTConnection, adapter.connections.get_thread_connection())
+        wrapper: DatabricksSQLConnectionWrapper = connection.handle
+        wrapper.cursor().pollRefreshPipeline(
+            f"{relation.database}.{relation.schema}.{relation.name}"
+        )
+        return relation_config
+
+
+class MaterializedViewAPI(DeltaLiveTableAPIBase[MaterializedViewConfig]):
     relation_type = DatabricksRelationType.MaterializedView
 
     @classmethod
@@ -733,7 +752,7 @@ class MaterializedViewAPI(RelationAPIBase[MaterializedViewConfig]):
         return get_first_row(adapter.execute_macro("get_view_description_alt", kwargs=kwargs))
 
 
-class StreamingTableAPI(RelationAPIBase[StreamingTableConfig]):
+class StreamingTableAPI(DeltaLiveTableAPIBase[StreamingTableConfig]):
     relation_type = DatabricksRelationType.StreamingTable
 
     @classmethod

--- a/dbt/adapters/databricks/impl.py
+++ b/dbt/adapters/databricks/impl.py
@@ -716,9 +716,7 @@ class DeltaLiveTableAPIBase(RelationAPIBase[DatabricksRelationConfig]):
         relation_config = super(DeltaLiveTableAPIBase, cls).get_from_relation(adapter, relation)
         connection = cast(DatabricksDBTConnection, adapter.connections.get_thread_connection())
         wrapper: DatabricksSQLConnectionWrapper = connection.handle
-        wrapper.cursor().pollRefreshPipeline(
-            f"{relation.database}.{relation.schema}.{relation.name}"
-        )
+        wrapper.cursor().pollRefreshPipeline(relation_config.config["tblproperties"].pipeline_id)
         return relation_config
 
 

--- a/dbt/adapters/databricks/relation_configs/refresh.py
+++ b/dbt/adapters/databricks/relation_configs/refresh.py
@@ -2,13 +2,12 @@ import re
 from typing import ClassVar
 from typing import Optional
 
-from dbt_common.exceptions import DbtRuntimeError
-
 from dbt.adapters.contracts.relation import RelationConfig
 from dbt.adapters.databricks.relation_configs import base
 from dbt.adapters.databricks.relation_configs.base import DatabricksComponentConfig
 from dbt.adapters.databricks.relation_configs.base import DatabricksComponentProcessor
 from dbt.adapters.relation_configs.config_base import RelationResults
+from dbt_common.exceptions import DbtRuntimeError
 
 SCHEDULE_REGEX = re.compile(r"CRON '(.*)' AT TIME ZONE '(.*)'")
 

--- a/dbt/adapters/databricks/relation_configs/tblproperties.py
+++ b/dbt/adapters/databricks/relation_configs/tblproperties.py
@@ -18,7 +18,7 @@ class TblPropertiesConfig(DatabricksComponentConfig):
     """Component encapsulating the tblproperties of a relation."""
 
     tblproperties: Dict[str, str]
-    pipelineId: Optional[str] = None
+    pipeline_id: Optional[str] = None
 
     # List of tblproperties that should be ignored when comparing configs. These are generally
     # set by Databricks and are not user-configurable.
@@ -53,15 +53,15 @@ class TblPropertiesProcessor(DatabricksComponentProcessor[TblPropertiesConfig]):
     def from_relation_results(cls, results: RelationResults) -> TblPropertiesConfig:
         table = results.get("show_tblproperties")
         tblproperties = dict()
-        pipelineId = None
+        pipeline_id = None
 
         if table:
             for row in table.rows:
                 if str(row[0]) == "pipelines.pipelineId":
-                    pipelineId = str(row[1])
+                    pipeline_id = str(row[1])
                 tblproperties[str(row[0])] = str(row[1])
 
-        return TblPropertiesConfig(tblproperties=tblproperties, pipelineId=pipelineId)
+        return TblPropertiesConfig(tblproperties=tblproperties, pipeline_id=pipeline_id)
 
     @classmethod
     def from_relation_config(cls, relation_config: RelationConfig) -> TblPropertiesConfig:

--- a/dbt/adapters/databricks/relation_configs/tblproperties.py
+++ b/dbt/adapters/databricks/relation_configs/tblproperties.py
@@ -1,11 +1,9 @@
-from os import pipe
 from typing import Any
 from typing import ClassVar
 from typing import Dict
 from typing import List
 from typing import Optional
 
-import pip
 from dbt.adapters.contracts.relation import RelationConfig
 from dbt.adapters.databricks.relation_configs import base
 from dbt.adapters.databricks.relation_configs.base import DatabricksComponentConfig


### PR DESCRIPTION
### Description

If a scheduled refresh is already in progress when you request a refresh, you get an exception.  Exception handling during a materialization is gnarly, so instead, I ensure that any in progress pipelines are completed before we do any further processing of an MV/ST.

This PR also removes polling for completion of a create or refresh kicked off by dbt, as those operations are now synchronous by default.  Since I already have the pipeline id when I do need to check the refresh state, I can get rid of the API call we were using to get the pipeline id, which fixes another bug: refresh for MV/ST wasn't working in dbt-databricks if you needed to escape your relation name (since we had to strip off the escaping to call the API).

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
