### PR TITLE
Fix left over seed schema

### DIFF
--- a/tests/functional/adapter/simple_seed/test_seeds.py
+++ b/tests/functional/adapter/simple_seed/test_seeds.py
@@ -48,7 +48,13 @@ class TestSeedConfigFullRefreshOff(DatabricksSetup, BaseSeedConfigFullRefreshOff
 
 
 class TestSeedCustomSchema(DatabricksSetup, BaseSeedCustomSchema):
-    pass
+    @pytest.fixture(scope="class", autouse=True)
+    def setUp(self, project):
+        """Create table for ensuring seeds and models used in tests build correctly"""
+        project.run_sql(fixtures.seeds__expected_table_sql)
+        project.run_sql(fixtures.seeds__expected_insert_sql)
+        yield
+        project.run_sql(f"drop schema if exists {project.test_schema}_custom_schema cascade")
 
 
 class TestDatabricksSeedWithEmptyDelimiter(DatabricksSetup, BaseSeedWithEmptyDelimiter):


### PR DESCRIPTION
### Description

Drops the extra custom schema from the custom schema seed test after the test.

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
