### PR TITLE
Reverting the decision to remove dynamic setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## dbt-databricks 1.8.2 (TBD)
+
+### Fixes
+
+- Undo the removal of spark.sql.sources.partitionOverwriteMode = DYNAMIC ([688](https://github.com/databricks/dbt-databricks/pull/688))
+
 ## dbt-databricks 1.8.1 (May 29, 2024)
 
 ### Features
@@ -21,7 +27,6 @@
 
 - Support `on_config_change` for materialized views, expand the supported config options ([536](https://github.com/databricks/dbt-databricks/pull/536)))
 - Support `on_config_change` for streaming tables, expand the supported config options ([569](https://github.com/databricks/dbt-databricks/pull/569)))
-- Support insert overwrite on SQL Warehouses ([623](https://github.com/databricks/dbt-databricks/pull/623))
 - Support Databricks tags for tables/views/incrementals ([631](https://github.com/databricks/dbt-databricks/pull/631))
 
 ### Under the Hood

--- a/dbt/include/databricks/macros/materializations/incremental/incremental.sql
+++ b/dbt/include/databricks/macros/materializations/incremental/incremental.sql
@@ -19,6 +19,14 @@
   {%- set target_relation = this.incorporate(type='table') -%}
   {%- set existing_relation = adapter.get_relation(database=this.database, schema=this.schema, identifier=this.identifier, needs_information=True) -%}
 
+
+  {#-- Set Overwrite Mode - does not yet work for warehouses --#}
+  {%- if incremental_strategy == 'insert_overwrite' and partition_by -%}
+    {%- call statement() -%}
+      set spark.sql.sources.partitionOverwriteMode = DYNAMIC
+    {%- endcall -%}
+  {%- endif -%}
+
   {#-- Run pre-hooks --#}
   {{ run_hooks(pre_hooks) }}
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ pytest_plugins = ["dbt.tests.fixtures.project"]
 
 
 def pytest_addoption(parser):
-    parser.addoption("--profile", action="store", default="databricks_uc_sql_endpoint", type=str)
+    parser.addoption("--profile", action="store", default="databricks_uc_cluster", type=str)
 
 
 # Using @pytest.mark.skip_profile('databricks_cluster') uses the 'skip_by_adapter_type'

--- a/tests/functional/adapter/incremental/fixtures.py
+++ b/tests/functional/adapter/incremental/fixtures.py
@@ -163,7 +163,6 @@ append_expected = """id,msg
 """
 
 overwrite_expected = """id,msg
-1,hello
 2,yo
 3,anyway
 """

--- a/tests/functional/adapter/incremental/fixtures.py
+++ b/tests/functional/adapter/incremental/fixtures.py
@@ -163,6 +163,7 @@ append_expected = """id,msg
 """
 
 overwrite_expected = """id,msg
+1,hello
 2,yo
 3,anyway
 """

--- a/tests/functional/adapter/incremental/test_incremental_strategies.py
+++ b/tests/functional/adapter/incremental/test_incremental_strategies.py
@@ -68,6 +68,7 @@ class TestAppendParquetHive(AppendBase):
         }
 
 
+@pytest.mark.skip_profile("databricks_uc_sql_endpoint")
 class InsertOverwriteBase(IncrementalBase):
     @pytest.fixture(scope="class")
     def seeds(self):
@@ -90,10 +91,12 @@ class InsertOverwriteBase(IncrementalBase):
         util.check_relations_equal(project.adapter, ["overwrite_model", "overwrite_expected"])
 
 
+@pytest.mark.skip_profile("databricks_uc_sql_endpoint")
 class TestInsertOverwriteDelta(InsertOverwriteBase):
     pass
 
 
+@pytest.mark.skip_profile("databricks_uc_sql_endpoint")
 class TestInsertOverwriteWithPartitionsDelta(InsertOverwriteBase):
     @pytest.fixture(scope="class")
     def project_config_update(self):
@@ -105,7 +108,7 @@ class TestInsertOverwriteWithPartitionsDelta(InsertOverwriteBase):
         }
 
 
-@pytest.mark.skip_profile("databricks_uc_cluster", "databricks_cluster")
+@pytest.mark.skip_profile("databricks_uc_sql_endpoint", "databricks_cluster")
 class TestInsertOverwriteParquet(InsertOverwriteBase):
     @pytest.fixture(scope="class")
     def project_config_update(self):
@@ -119,7 +122,7 @@ class TestInsertOverwriteParquet(InsertOverwriteBase):
         }
 
 
-@pytest.mark.skip_profile("databricks_uc_cluster", "databricks_cluster")
+@pytest.mark.skip_profile("databricks_uc_sql_endpoint", "databricks_cluster")
 class TestInsertOverwriteWithPartitionsParquet(InsertOverwriteBase):
     @pytest.fixture(scope="class")
     def project_config_update(self):

--- a/tests/functional/adapter/incremental/test_incremental_strategies.py
+++ b/tests/functional/adapter/incremental/test_incremental_strategies.py
@@ -108,7 +108,7 @@ class TestInsertOverwriteWithPartitionsDelta(InsertOverwriteBase):
         }
 
 
-@pytest.mark.skip_profile("databricks_uc_sql_endpoint", "databricks_cluster")
+@pytest.mark.skip("This test is not repeatable due to external location")
 class TestInsertOverwriteParquet(InsertOverwriteBase):
     @pytest.fixture(scope="class")
     def project_config_update(self):
@@ -122,7 +122,7 @@ class TestInsertOverwriteParquet(InsertOverwriteBase):
         }
 
 
-@pytest.mark.skip_profile("databricks_uc_sql_endpoint", "databricks_cluster")
+@pytest.mark.skip("This test is not repeatable due to external location")
 class TestInsertOverwriteWithPartitionsParquet(InsertOverwriteBase):
     @pytest.fixture(scope="class")
     def project_config_update(self):

--- a/tests/functional/adapter/incremental/test_incremental_strategies.py
+++ b/tests/functional/adapter/incremental/test_incremental_strategies.py
@@ -33,7 +33,7 @@ class AppendBase(IncrementalBase):
             "append_model.sql": fixtures.base_model,
         }
 
-    def test_append(self, project):
+    def test_incremental(self, project):
         self.seed_and_run_twice()
         util.check_relations_equal(project.adapter, ["append_model", "append_expected"])
 
@@ -86,7 +86,7 @@ class InsertOverwriteBase(IncrementalBase):
             "overwrite_model.sql": fixtures.base_model,
         }
 
-    def test_append(self, project):
+    def test_incremental(self, project):
         self.seed_and_run_twice()
         util.check_relations_equal(project.adapter, ["overwrite_model", "overwrite_expected"])
 
@@ -106,6 +106,16 @@ class TestInsertOverwriteWithPartitionsDelta(InsertOverwriteBase):
                 "+partition_by": "id",
             }
         }
+
+    @pytest.fixture(scope="class")
+    def seeds(self):
+        return {
+            "upsert_expected.csv": fixtures.upsert_expected,
+        }
+
+    def test_incremental(self, project):
+        self.seed_and_run_twice()
+        util.check_relations_equal(project.adapter, ["overwrite_model", "upsert_expected"])
 
 
 @pytest.mark.skip("This test is not repeatable due to external location")


### PR DESCRIPTION
<!-- Please review our pull request review process in CONTRIBUTING.md before your proceed. -->

Resolves #687

<!---
  Include the number of the issue addressed by this PR above if applicable.

  Example:
    resolves #1234

  Please review our pull request review process in CONTRIBUTING.md before your proceed.
-->

### Description

We had removed the spark setting for insert overwrite so that the strategy could be compatible with SQL Warehouses, but upon further reflection, it's unclear if the strategy is even useful for incremental tables without the setting, as it will just replace the entire table.  The consequence of having removed the spark setting was regressing users that were successfully using the strategy with clusters.

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
