### PR TITLE
Attempt changing over to system for metadata gathering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Fixes
 
 - Undo the removal of spark.sql.sources.partitionOverwriteMode = DYNAMIC ([688](https://github.com/databricks/dbt-databricks/pull/688))
+- Migrate to using system.information_schema to fix issue with catalog renames ([692](https://github.com/databricks/dbt-databricks/pull/692))
 
 ## dbt-databricks 1.8.1 (May 29, 2024)
 

--- a/dbt/adapters/databricks/impl.py
+++ b/dbt/adapters/databricks/impl.py
@@ -749,10 +749,7 @@ class MaterializedViewAPI(DeltaLiveTableAPIBase[MaterializedViewConfig]):
 
     @staticmethod
     def _get_information_schema_views(adapter: DatabricksAdapter, kwargs: Dict[str, Any]) -> "Row":
-        row = get_first_row(adapter.execute_macro("get_view_description", kwargs=kwargs))
-        if "view_definition" in row.keys() and row["view_definition"] is not None:
-            return row
-        return get_first_row(adapter.execute_macro("get_view_description_alt", kwargs=kwargs))
+        return get_first_row(adapter.execute_macro("get_view_description", kwargs=kwargs))
 
 
 class StreamingTableAPI(DeltaLiveTableAPIBase[StreamingTableConfig]):

--- a/dbt/include/databricks/macros/adapters/catalog.sql
+++ b/dbt/include/databricks/macros/adapters/catalog.sql
@@ -3,11 +3,11 @@
     {% set query %}
         with tables as (
             {{ databricks__get_catalog_tables_sql(information_schema) }}
-            {{ databricks__get_catalog_schemas_where_clause_sql(schemas) }}
+            {{ databricks__get_catalog_schemas_where_clause_sql(information_schema.database, schemas) }}
         ),
         columns as (
             {{ databricks__get_catalog_columns_sql(information_schema) }}
-            {{ databricks__get_catalog_schemas_where_clause_sql(schemas) }}
+            {{ databricks__get_catalog_schemas_where_clause_sql(information_schema.database, schemas) }}
         )
         {{ databricks__get_catalog_results_sql() }}
     {%- endset -%}
@@ -68,15 +68,15 @@
     order by column_index
 {%- endmacro %}
 
-{% macro databricks__get_catalog_schemas_where_clause_sql(schemas) -%}
-    where ({%- for relation in schemas -%}
+{% macro databricks__get_catalog_schemas_where_clause_sql(catalog, schemas) -%}
+    where table_catalog = '{{ catalog }}' and ({%- for relation in schemas -%}
         table_schema = lower('{{ relation[1] }}'){%- if not loop.last %} or {% endif -%}
     {%- endfor -%})
 {%- endmacro %}
 
 
-{% macro databricks__get_catalog_relations_where_clause_sql(relations) -%}
-    where (
+{% macro databricks__get_catalog_relations_where_clause_sql(catalog, relations) -%}
+    where table_catalog = '{{ catalog }}' and (
         {%- for relation in relations -%}
             {% if relation.schema and relation.identifier %}
                 (

--- a/dbt/include/databricks/macros/adapters/catalog.sql
+++ b/dbt/include/databricks/macros/adapters/catalog.sql
@@ -44,7 +44,8 @@
         last_altered as `stats:last_modified:value`,
         'The timestamp for last update/change' as `stats:last_modified:description`,
         (last_altered is not null and table_type not ilike '%VIEW%') as `stats:last_modified:include`
-    from {{ information_schema }}.tables
+    from `system`.`information_schema`.`tables`
+    where table_catalog = '{{ information_schema.database }}'
 {%- endmacro %}
 
 {% macro databricks__get_catalog_columns_sql(information_schema) -%}
@@ -56,7 +57,8 @@
         ordinal_position as column_index,
         lower(data_type) as column_type,
         comment as column_comment
-    from {{ information_schema }}.columns
+    from `system`.`information_schema`.`columns`
+    where table_catalog = '{{ information_schema.database }}'
 {%- endmacro %}
 
 {% macro databricks__get_catalog_results_sql() -%}

--- a/dbt/include/databricks/macros/relations/tags.sql
+++ b/dbt/include/databricks/macros/relations/tags.sql
@@ -10,8 +10,10 @@
 
 {% macro fetch_tags_sql(relation) -%}
   SELECT tag_name, tag_value
-  FROM `{{ relation.database }}`.`information_schema`.`table_tags`
-  WHERE schema_name = '{{ relation.schema }}' AND table_name = '{{ relation.identifier }}'
+  FROM `system`.`information_schema`.`table_tags`
+  WHERE catalog_name = '{{ relation.database }}' 
+    AND schema_name = '{{ relation.schema }}'
+    AND table_name = '{{ relation.identifier }}'
 {%- endmacro -%}
 
 {% macro apply_tags(relation, set_tags, unset_tags=[]) -%}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ pytest_plugins = ["dbt.tests.fixtures.project"]
 
 
 def pytest_addoption(parser):
-    parser.addoption("--profile", action="store", default="databricks_uc_cluster", type=str)
+    parser.addoption("--profile", action="store", default="databricks_uc_sql_endpoint", type=str)
 
 
 # Using @pytest.mark.skip_profile('databricks_cluster') uses the 'skip_by_adapter_type'

--- a/tests/functional/adapter/incremental/test_incremental_tags.py
+++ b/tests/functional/adapter/incremental/test_incremental_tags.py
@@ -17,8 +17,9 @@ class TestIncrementalTags:
         util.write_file(fixtures.tags_b, "models", "schema.yml")
         util.run_dbt(["run"])
         results = project.run_sql(
-            "select tag_name, tag_value from {database}.information_schema.table_tags "
-            "where schema_name = '{schema}' and table_name='merge_update_columns_sql'",
+            "select tag_name, tag_value from `system`.`information_schema`.`table_tags` "
+            "where catalog_name = '{database}' and schema_name = '{schema}' and "
+            "table_name='merge_update_columns_sql'",
             fetch="all",
         )
         assert len(results) == 2
@@ -42,8 +43,9 @@ class TestIncrementalPythonTags:
         util.write_file(fixtures.python_schema2, "models", "schema.yml")
         util.run_dbt(["run"])
         results = project.run_sql(
-            "select tag_name, tag_value from {database}.information_schema.table_tags "
-            "where schema_name = '{schema}' and table_name='tags'",
+            "select tag_name, tag_value from `system`.`information_schema`.`table_tags` "
+            "where catalog_name = '{database}' and schema_name = '{schema}' and "
+            "table_name='tags'",
             fetch="all",
         )
         assert len(results) == 2

--- a/tests/functional/adapter/incremental/test_incremental_tags.py
+++ b/tests/functional/adapter/incremental/test_incremental_tags.py
@@ -18,8 +18,7 @@ class TestIncrementalTags:
         util.run_dbt(["run"])
         results = project.run_sql(
             "select tag_name, tag_value from `system`.`information_schema`.`table_tags` "
-            "where catalog_name = '{database}' and schema_name = '{schema}' and "
-            "table_name='merge_update_columns_sql'",
+            "where schema_name = '{schema}' and table_name='merge_update_columns_sql'",
             fetch="all",
         )
         assert len(results) == 2
@@ -44,8 +43,7 @@ class TestIncrementalPythonTags:
         util.run_dbt(["run"])
         results = project.run_sql(
             "select tag_name, tag_value from `system`.`information_schema`.`table_tags` "
-            "where catalog_name = '{database}' and schema_name = '{schema}' and "
-            "table_name='tags'",
+            "where schema_name = '{schema}' and table_name='tags'",
             fetch="all",
         )
         assert len(results) == 2

--- a/tests/functional/adapter/materialized_view_tests/fixtures.py
+++ b/tests/functional/adapter/materialized_view_tests/fixtures.py
@@ -6,8 +6,9 @@ from dbt.adapters.databricks.relation import DatabricksRelationType
 
 def query_relation_type(project, relation: BaseRelation) -> Optional[str]:
     table_type = project.run_sql(
-        f"select table_type from {relation.information_schema_only()}."
-        f"`tables` where table_schema = '{relation.schema}'"
+        "select table_type from `system`.`information_schema`.`tables`"
+        f" where table_catalog = '{relation.database}'"
+        f" and table_schema = '{relation.schema}'"
         f" and table_name = '{relation.identifier}'",
         fetch="one",
     )[0]
@@ -17,8 +18,10 @@ def query_relation_type(project, relation: BaseRelation) -> Optional[str]:
         return DatabricksRelationType.Table.value
     else:
         is_materialized = project.run_sql(
-            f"select is_materialized from {relation.information_schema_only()}."
-            f"`views` where table_name = '{relation.identifier}'",
+            "select is_materialized from `system`.`information_schema`.`views`"
+            f" where table_catalog = '{relation.database}'"
+            f" and table_schema = '{relation.schema}'"
+            f" and table_name = '{relation.identifier}'",
             fetch="one",
         )[0]
         if is_materialized == "TRUE":

--- a/tests/functional/adapter/streaming_tables/fixtures.py
+++ b/tests/functional/adapter/streaming_tables/fixtures.py
@@ -6,8 +6,9 @@ from dbt.adapters.databricks.relation import DatabricksRelationType
 
 def query_relation_type(project, relation: BaseRelation) -> Optional[str]:
     table_type = project.run_sql(
-        f"select table_type from {relation.information_schema_only()}."
-        f"`tables` where table_schema = '{relation.schema}'"
+        "select table_type from `system`.`information_schema`.`tables`"
+        f" where table_catalog = '{relation.database}'"
+        f" and table_schema = '{relation.schema}'"
         f" and table_name = '{relation.identifier}'",
         fetch="one",
     )[0]
@@ -17,8 +18,10 @@ def query_relation_type(project, relation: BaseRelation) -> Optional[str]:
         return DatabricksRelationType.Table.value
     else:
         is_materialized = project.run_sql(
-            f"select is_materialized from {relation.information_schema_only()}."
-            f"`views` where table_name = '{relation.identifier}'",
+            "select is_materialized from `system`.`information_schema`.`views`"
+            f" where table_catalog = '{relation.database}'"
+            f" and table_schema = '{relation.schema}'"
+            f" and table_name = '{relation.identifier}'",
             fetch="one",
         )[0]
         if is_materialized == "TRUE":

--- a/tests/functional/adapter/tags/test_databricks_tags.py
+++ b/tests/functional/adapter/tags/test_databricks_tags.py
@@ -16,8 +16,7 @@ class TestTags:
         _ = util.run_dbt(["run"])
         results = project.run_sql(
             "select tag_name, tag_value from `system`.`information_schema`.`table_tags`"
-            " where catalog_name = '{database}' and"
-            " schema_name = '{schema}' and table_name='tags'",
+            " where schema_name = '{schema}' and table_name='tags'",
             fetch="all",
         )
         assert len(results) == 2

--- a/tests/functional/adapter/tags/test_databricks_tags.py
+++ b/tests/functional/adapter/tags/test_databricks_tags.py
@@ -15,8 +15,9 @@ class TestTags:
         _ = util.run_dbt(["run"])
         _ = util.run_dbt(["run"])
         results = project.run_sql(
-            "select tag_name, tag_value from {database}.information_schema.table_tags "
-            "where schema_name = '{schema}' and table_name='tags'",
+            "select tag_name, tag_value from `system`.`information_schema`.`table_tags`"
+            " where catalog_name = '{database}' and"
+            " schema_name = '{schema}' and table_name='tags'",
             fetch="all",
         )
         assert len(results) == 2

--- a/tests/unit/macros/relations/test_tags_macros.py
+++ b/tests/unit/macros/relations/test_tags_macros.py
@@ -15,8 +15,9 @@ class TestTagsMacros(MacroTestBase):
         sql = self.render_bundle(template_bundle, "fetch_tags_sql")
         expected = (
             "SELECT tag_name, tag_value "
-            "FROM `some_database`.`information_schema`.`table_tags` "
-            "WHERE schema_name = 'some_schema' AND table_name = 'some_table'"
+            "FROM `system`.`information_schema`.`table_tags` "
+            "WHERE catalog_name = 'some_database'"
+            " AND schema_name = 'some_schema' AND table_name = 'some_table'"
         )
         assert sql == expected
 


### PR DESCRIPTION
<!-- Please review our pull request review process in CONTRIBUTING.md before your proceed. -->

Resolves #691 

<!---
  Include the number of the issue addressed by this PR above if applicable.

  Example:
    resolves #1234

  Please review our pull request review process in CONTRIBUTING.md before your proceed.
-->

### Description

Today, information_schema does not work as expected when the name of a catalog is changed, as the catalog-specific views are written at create time and not updated.  While I'm pursuing that fix internally, switching over to system for all information_schema queries will fix this.  Unclear yet whether this will have any performance or governance implications (testing currently), though since all of the catalog-specific views reference system under the hood, I wouldn't expect any.

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
