### PR TITLE
Fix insert_overwrite replacement edge case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Fixes
 
 - Undo the removal of spark.sql.sources.partitionOverwriteMode = DYNAMIC ([688](https://github.com/databricks/dbt-databricks/pull/688))
+- Set spark.sql.sources.partitionOverwriteMode = STATIC on --full-refresh to ensure existing rows are removed ([697](https://github.com/databricks/dbt-databricks/pull/697))
 - Migrate to using system.information_schema to fix issue with catalog renames ([692](https://github.com/databricks/dbt-databricks/pull/692))
 - Cancel python jobs when dbt operation is canceled (thanks @gaoshihang for kicking this off!) ([693](https://github.com/databricks/dbt-databricks/pull/693))
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ pytest_plugins = ["dbt.tests.fixtures.project"]
 
 
 def pytest_addoption(parser):
-    parser.addoption("--profile", action="store", default="databricks_uc_sql_endpoint", type=str)
+    parser.addoption("--profile", action="store", default="databricks_uc_cluster", type=str)
 
 
 # Using @pytest.mark.skip_profile('databricks_cluster') uses the 'skip_by_adapter_type'

--- a/tests/functional/adapter/incremental/fixtures.py
+++ b/tests/functional/adapter/incremental/fixtures.py
@@ -328,3 +328,30 @@ models:
       liquid_clustered_by: test2
       http_path: "{{ env_var('DBT_DATABRICKS_UC_CLUSTER_HTTP_PATH') }}"
 """
+
+replace_table = """
+{{ config(
+    materialized = 'table'
+) }}
+
+select cast(1 as bigint) as id, 'hello' as msg, 'blue' as color
+union all
+select cast(2 as bigint) as id, 'goodbye' as msg, 'red' as color
+"""
+
+replace_incremental = """
+{{ config(
+    materialized = 'incremental',
+    incremental_strategy = 'insert_overwrite',
+    partition_by = 'id'
+) }}
+
+select cast(1 as bigint) as id, 'hello' as msg, 'blue' as color
+union all
+select cast(2 as bigint) as id, 'goodbye' as msg, 'red' as color
+"""
+
+replace_expected = """id,msg,color
+1,hello,blue
+2,goodbye,red
+"""

--- a/tests/functional/adapter/incremental/test_incremental_replace_table.py
+++ b/tests/functional/adapter/incremental/test_incremental_replace_table.py
@@ -1,0 +1,21 @@
+import pytest
+from dbt.tests import util
+from tests.functional.adapter.incremental import fixtures
+
+
+@pytest.mark.skip_profile("databricks_cluster", "databricks_uc_sql_endpoint")
+class TestIncrementalReplaceTable:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"model.sql": fixtures.replace_table}
+
+    @pytest.fixture(scope="class")
+    def seeds(self):
+        return {"seed.csv": fixtures.replace_expected}
+
+    # Validate that when we replace an existing table, no extra partitions are left behind
+    def test_replace(self, project):
+        util.run_dbt(["build"])
+        util.write_file(fixtures.replace_incremental, "models", "model.sql")
+        util.run_dbt(["run", "--full-refresh"])
+        util.check_relations_equal(project.adapter, ["model", "seed"])


### PR DESCRIPTION
<!-- Please review our pull request review process in CONTRIBUTING.md before your proceed. -->

Resolves #696

<!---
  Include the number of the issue addressed by this PR above if applicable.

  Example:
    resolves #1234

  Please review our pull request review process in CONTRIBUTING.md before your proceed.
-->

### Description

The setting that enables insert_overwrite to selectively overwrite partitions also causes it to leave behind partitions when used with `create or replace`.  Hence, ensure the setting is static on 'full-refresh', and dynamic on subsequent runs.

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
