### PR TITLE
Debug logging for expired SPA and store refresh token

### DIFF
--- a/dbt/adapters/databricks/credentials.py
+++ b/dbt/adapters/databricks/credentials.py
@@ -298,7 +298,7 @@ class DatabricksCredentials(Credentials):
                                 )
                             return provider
                     except Exception as e:
-                        # SPA token are suppose to expire after 24h, no need to warn
+                        # SPA token are supposed to expire after 24h, no need to warn
                         if SPA_CLIENT_FIXED_TIME_LIMIT_ERROR in str(e):
                             logger.debug(CredentialLoadError(e))
                         else:

--- a/dbt/adapters/databricks/credentials.py
+++ b/dbt/adapters/databricks/credentials.py
@@ -289,10 +289,10 @@ class DatabricksCredentials(Credentials):
                     # if refresh token is expired, this will throw
                     try:
                         if provider.token().valid:
+                            self._credentials_provider = provider.as_dict()
                             if json.loads(credsdict) != provider.as_dict():
                                 # if the provider dict has changed, most likely because of a token
                                 # refresh, save it for further use
-                                self._credentials_provider = provider.as_dict()
                                 self.set_sharded_password(
                                     "dbt-databricks", host, json.dumps(self._credentials_provider)
                                 )

--- a/dbt/adapters/databricks/credentials.py
+++ b/dbt/adapters/databricks/credentials.py
@@ -38,6 +38,10 @@ CLIENT_ID = "dbt-databricks"
 SCOPES = ["all-apis", "offline_access"]
 MAX_NT_PASSWORD_SIZE = 1280
 
+# When using an Azure App Registration with the SPA platform, the refresh token will
+# also expire after 24h. Silently accept this in this case.
+SPA_CLIENT_FIXED_TIME_LIMIT_ERROR = 'AADSTS700084'
+
 TCredentialProvider = Union[CredentialsProvider, SessionCredentials]
 
 
@@ -285,9 +289,19 @@ class DatabricksCredentials(Credentials):
                     # if refresh token is expired, this will throw
                     try:
                         if provider.token().valid:
+                            # if the token was expired, it is now refreshed. Save it to prevent 
+                            # further refresh calls during before it expires.
+                            self._credentials_provider = provider.as_dict()
+                            self.set_sharded_password(
+                                "dbt-databricks", host, json.dumps(self._credentials_provider)
+                            )                            
                             return provider
                     except Exception as e:
-                        logger.warning(CredentialLoadError(e))
+                        # SPA token are suppose to expire after 24h, no need to warn
+                        if SPA_CLIENT_FIXED_TIME_LIMIT_ERROR in str(e):
+                            logger.debug(CredentialLoadError(e))
+                        else:
+                            logger.warning(CredentialLoadError(e))
                         # whatever it is, get rid of the cache
                         self.delete_sharded_password("dbt-databricks", host)
 

--- a/dbt/adapters/databricks/credentials.py
+++ b/dbt/adapters/databricks/credentials.py
@@ -40,7 +40,7 @@ MAX_NT_PASSWORD_SIZE = 1280
 
 # When using an Azure App Registration with the SPA platform, the refresh token will
 # also expire after 24h. Silently accept this in this case.
-SPA_CLIENT_FIXED_TIME_LIMIT_ERROR = 'AADSTS700084'
+SPA_CLIENT_FIXED_TIME_LIMIT_ERROR = "AADSTS700084"
 
 TCredentialProvider = Union[CredentialsProvider, SessionCredentials]
 
@@ -289,12 +289,13 @@ class DatabricksCredentials(Credentials):
                     # if refresh token is expired, this will throw
                     try:
                         if provider.token().valid:
-                            # if the token was expired, it is now refreshed. Save it to prevent 
-                            # further refresh calls during before it expires.
-                            self._credentials_provider = provider.as_dict()
-                            self.set_sharded_password(
-                                "dbt-databricks", host, json.dumps(self._credentials_provider)
-                            )                            
+                            if json.loads(credsdict) != provider.as_dict():
+                                # if the provider dict has changed, most likely because of a token
+                                # refresh, save it for further use
+                                self._credentials_provider = provider.as_dict()
+                                self.set_sharded_password(
+                                    "dbt-databricks", host, json.dumps(self._credentials_provider)
+                                )
                             return provider
                     except Exception as e:
                         # SPA token are suppose to expire after 24h, no need to warn


### PR DESCRIPTION
Resolves #640 

### Description
When using an Azure App Registration with a 'Single-page Application' authentication platform as the oAuth endpoint, the token will always expire after 24h. It is not possible to fetch a new token after this and a new consent (and external browser login) is required. This is 'by design' and should therefore not yield warning in the terminal hinting on a possible problem. Instead, writing to the debugger should suffice.
The second issue this PR tackles is that, after a token expires and a new refresh token is requested from the endpoint, that new token is never stored. This causes the authentication logic to request a new refresh token for every dbt command after initial token has expired (valid for 1h) where it is only needed after it is expired.

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
