### PR TITLE
Change default redirect_url and scopes of client dbt-databricks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Set spark.sql.sources.partitionOverwriteMode = STATIC on --full-refresh to ensure existing rows are removed ([697](https://github.com/databricks/dbt-databricks/pull/697))
 - Migrate to using system.information_schema to fix issue with catalog renames ([692](https://github.com/databricks/dbt-databricks/pull/692))
 - Cancel python jobs when dbt operation is canceled (thanks @gaoshihang for kicking this off!) ([693](https://github.com/databricks/dbt-databricks/pull/693))
+- Fix the default redirect_url and scopes of the client `dbt-databricks` ([704](https://github.com/databricks/dbt-databricks/pull/704))
 
 ### Under the Hood
 

--- a/dbt/adapters/databricks/credentials.py
+++ b/dbt/adapters/databricks/credentials.py
@@ -272,12 +272,25 @@ class DatabricksCredentials(Credentials):
                 self._credentials_provider = provider.as_dict()
                 return provider
 
+            client_id = self.client_id or CLIENT_ID
+
+            if client_id == "dbt-databricks":
+                # This is the temp code to make client id dbt-databricks work with server,
+                # currently the redirect url and scope for client dbt-databricks are fixed
+                # values as below. It can be removed after Databricks extends dbt-databricks
+                # scope to all-apis
+                redirect_url = "http://localhost:8050"
+                scopes = ["sql", "offline_access"]
+            else:
+                redirect_url = self.oauth_redirect_url or REDIRECT_URL
+                scopes = self.oauth_scopes or SCOPES
+
             oauth_client = OAuthClient(
                 host=host,
-                client_id=self.client_id or CLIENT_ID,
+                client_id=client_id,
                 client_secret="",
-                redirect_url=self.oauth_redirect_url or REDIRECT_URL,
-                scopes=self.oauth_scopes or SCOPES,
+                redirect_url=redirect_url,
+                scopes=scopes,
             )
             # optional branch. Try and keep going if it does not work
             try:


### PR DESCRIPTION
<!-- Please review our pull request review process in CONTRIBUTING.md before your proceed. -->

<!---
  Include the number of the issue addressed by this PR above if applicable.

  Example:
    resolves #1234

  Please review our pull request review process in CONTRIBUTING.md before your proceed.
-->

### Issue
The default redirect_url `http://localhost:8020` and scope `all-apis` is not configured in the OAuth client `dbt-databricks`, which leads to the failure in OAuth U2M flow with the default OAuth configuration in the dbt profile.

### Description

Change the default `redirect_url` and scopes of OAuth client `dbt-databricks` to align its configuration in Databricks
 - redirect_url: http://localhost:8050
 - scope: `[sql, offline_access]`
 
<img width="563" alt="image" src="https://github.com/databricks/dbt-databricks/assets/115733007/74fea8a3-b886-4f58-a560-7c83fef64e48">




### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
