### PR TITLE
Fix #712: missing catalog in one place

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-## dbt-databricks Next (TBD)
+## dbt-databricks 1.8.3 (June 25, 2024)
+
+### Fixes
+
+- Fix missing catalog name in one of the metadata gathering calls ([714](https://github.com/databricks/dbt-databricks/pull/714))
 
 ## dbt-databricks 1.8.2 (June 24, 2024)
 

--- a/dbt/include/databricks/macros/adapters/metadata.sql
+++ b/dbt/include/databricks/macros/adapters/metadata.sql
@@ -95,7 +95,8 @@
       lower(data_source_format) as file_format,
       table_owner
     from `system`.`information_schema`.`tables`
-    where table_schema = '{{ relation.schema }}'
+    where table_catalog = '{{ relation.database }}'
+      and table_schema = '{{ relation.schema }}'
     {% if relation.identifier %}
       and table_name = '{{ relation.identifier }}'
     {% endif %}


### PR DESCRIPTION
<!-- Please review our pull request review process in CONTRIBUTING.md before your proceed. -->

Resolves #712 

<!---
  Include the number of the issue addressed by this PR above if applicable.

  Example:
    resolves #1234

  Please review our pull request review process in CONTRIBUTING.md before your proceed.
-->

### Description

Core issue is that I missed one of the places that I needed to add a clause to specify the catalog when I switched over to using system information_schema

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
