### PR TITLE
Fix dbt seed command error when seed file is partially defined in the config file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## dbt-databricks next
 
-- Fix `dbt seed` command failing for a seed file when the columns for that seed file were partially defined in the properties file. ([724](https://github.com/databricks/dbt-databricks/pull/724))
+- Fix `dbt seed` command failing for a seed file when the columns for that seed file were partially defined in the properties file.  (thanks @kass-artur!) ([724](https://github.com/databricks/dbt-databricks/pull/724))
 
 ## dbt-databricks 1.8.3 (June 25, 2024)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## dbt-databricks next
 
-- Fix issue that caused `dbt seed` command to fail when seed file columns were partially defined in the properties file.
+- Fix `dbt seed` command failing for a seed file when the columns for that seed file were partially defined in the properties file. ([724](https://github.com/databricks/dbt-databricks/pull/724))
 
 ## dbt-databricks 1.8.3 (June 25, 2024)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## dbt-databricks next
+
+- Fix issue that caused `dbt seed` command to fail when seed file columns were partially defined in the properties file.
+
 ## dbt-databricks 1.8.3 (June 25, 2024)
 
 ### Fixes

--- a/dbt/include/databricks/macros/materializations/seeds/helpers.sql
+++ b/dbt/include/databricks/macros/materializations/seeds/helpers.sql
@@ -77,7 +77,7 @@
             {%- set type = column_override.get(col_name, inferred_type) -%}
             {%- set column_name = (col_name | string) -%}
             {%- set column_comment_clause = "" -%}
-            {%- if column_comment -%}       
+            {%- if column_comment and col_name in model.columns.keys() -%}   
               {%- set comment = model.columns[col_name]['description'] | replace("'", "\\'") -%}
               {%- if comment and comment != "" -%}
                 {%- set column_comment_clause = "comment '" ~ comment ~ "'" -%}


### PR DESCRIPTION
fix: address dbt seed command  error when seed file is partially defined in the config file

<!-- Please review our pull request review process in CONTRIBUTING.md before your proceed. -->

Resolves #723

<!---
  Include the number of the issue addressed by this PR above if applicable.

  Example:
    resolves #1234

  Please review our pull request review process in CONTRIBUTING.md before your proceed.
-->

### Description

<!--- Describe the Pull Request here -->

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
