### PR TITLE
Upgrade to PySQL 3.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Under the Hood
 
 - Fix places where we were not properly closing cursors, and other test warnings ([713](https://github.com/databricks/dbt-databricks/pull/713))
+- Upgrade databricks-sql-connector dependency to 3.2.0 ([729](https://github.com/databricks/dbt-databricks/pull/729))
 
 ## dbt-databricks 1.8.4 (TBD)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,7 @@
-databricks-sql-connector>=3.1.0, <3.2.0
+databricks-sql-connector>=3.2.0, <3.3.0
 dbt-spark~=1.8.0
 dbt-core~=1.8.0
 dbt-adapters~=1.2.0
 databricks-sdk==0.17.0
 keyring>=23.13.0
-pandas<2.2.0
 protobuf<5.0.0

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
         "dbt-spark>=1.8.0, <2.0",
         "dbt-core~=1.8.0",
         "dbt-adapters~=1.2.0",
-        "databricks-sql-connector>=3.1.0, <3.2.0",
+        "databricks-sql-connector>=3.2.0, <3.3.0",
         "databricks-sdk==0.17.0",
         "keyring>=23.13.0",
         "pandas<2.2.0",


### PR DESCRIPTION
### Description

Upgrades our dependency to databricks-sql-connector to >=3.2.0,<3.3.0.  Ignore the branch name; I forgot that we need to remove the pin in PySQL before we can remove the pin here.

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
