### PR TITLE
#676 pk constraint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 ## dbt-databricks next
 
+- Alter column statements are now done before the alter table statement (thanks @frankivo!). ([676](https://github.com/databricks/dbt-databricks/issues/676))
+
+## dbt-databricks 1.8.4 (July 17, 2024)
+
 - Fix `dbt seed` command failing for a seed file when the columns for that seed file were partially defined in the properties file. (thanks @kass-artur!) ([724](https://github.com/databricks/dbt-databricks/pull/724))
 - Readd the External relation type for compliance with adapter expectations ([728](https://github.com/databricks/dbt-databricks/pull/728))
-- Alter column statements are now done before the alter table statement (thanks @frankivo!). ([676](https://github.com/databricks/dbt-databricks/issues/676))
 
 ## dbt-databricks 1.8.3 (June 25, 2024)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Fix `dbt seed` command failing for a seed file when the columns for that seed file were partially defined in the properties file. (thanks @kass-artur!) ([724](https://github.com/databricks/dbt-databricks/pull/724))
 - Readd the External relation type for compliance with adapter expectations ([728](https://github.com/databricks/dbt-databricks/pull/728))
+- Alter column statements are now done before the alter table statement. ([676](https://github.com/databricks/dbt-databricks/issues/676))
 
 ## dbt-databricks 1.8.3 (June 25, 2024)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - Fix `dbt seed` command failing for a seed file when the columns for that seed file were partially defined in the properties file. (thanks @kass-artur!) ([724](https://github.com/databricks/dbt-databricks/pull/724))
 - Readd the External relation type for compliance with adapter expectations ([728](https://github.com/databricks/dbt-databricks/pull/728))
-- Alter column statements are now done before the alter table statement. ([676](https://github.com/databricks/dbt-databricks/issues/676))
+- Alter column statements are now done before the alter table statement (thanks @frankivo!). ([676](https://github.com/databricks/dbt-databricks/issues/676))
 
 ## dbt-databricks 1.8.3 (June 25, 2024)
 

--- a/dbt/include/databricks/macros/relations/constraints.sql
+++ b/dbt/include/databricks/macros/relations/constraints.sql
@@ -19,8 +19,8 @@
       {# Constraints are not applied for incremental updates. This point in the code should not have been reached #}
       {{ exceptions.raise_compiler_error("Constraints are not applied for incremental updates. Full refresh is required to update constraints.") }}
     {% else %}
-      {% do alter_table_add_constraints(relation, model) %}
       {% do alter_column_set_constraints(relation, model) %}
+      {% do alter_table_add_constraints(relation, model) %}
     {% endif %}
   {% endif %}
 {% endmacro %}

--- a/dbt/include/databricks/macros/relations/constraints.sql
+++ b/dbt/include/databricks/macros/relations/constraints.sql
@@ -79,8 +79,7 @@
 
 {% macro get_constraints_sql(relation, constraints, model, column={}) %}
   {% set statements = [] %}
-  -- Hack so that not null constraints will be applied before primary key constraints
-  {% for constraint in constraints|sort(attribute='type') %}
+  {% for constraint in constraints %}
     {% if constraint %}
       {% set constraint_statements = get_constraint_sql(relation, constraint, model, column) %}
       {% for statement in constraint_statements %}

--- a/dbt/include/databricks/macros/relations/constraints.sql
+++ b/dbt/include/databricks/macros/relations/constraints.sql
@@ -79,7 +79,8 @@
 
 {% macro get_constraints_sql(relation, constraints, model, column={}) %}
   {% set statements = [] %}
-  {% for constraint in constraints %}
+  -- Hack so that not null constraints will be applied before primary key constraints
+  {% for constraint in constraints|sort(attribute='type') %}
     {% if constraint %}
       {% set constraint_statements = get_constraint_sql(relation, constraint, model, column) %}
       {% for statement in constraint_statements %}


### PR DESCRIPTION
Resolves #676 

### Description

This PR makes sure that the column constraints are added before the table constraints.
The order matters for the primary_key constraint, which requires the column to have a not_null constraint. At a later moment, I suppose, the unique constraint should be present too.

I don't think the order matters for other (supported) contraints.

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [X] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.

I am not sure how to build and test this yet. Existing unit tests seem to still work.