### PR TITLE
Delegate for location_clause

### DIFF
--- a/dbt/include/databricks/macros/relations/location.sql
+++ b/dbt/include/databricks/macros/relations/location.sql
@@ -1,4 +1,4 @@
-{% macro location_clause(relation) %}
+{% macro databricks__location_clause(relation) %}
   {%- set location_root = config.get('location_root', validator=validation.any[basestring]) -%}
   {%- set file_format = config.get('file_format', default='delta') -%}
   {%- set identifier = model['alias'] -%}


### PR DESCRIPTION
<!---
  Include the number of the issue addressed by this PR above if applicable.

  Example:
    resolves #1234

  Please review our pull request review process in CONTRIBUTING.md before your proceed.
-->

### Description

I believe when I added our version of the location clause that dbt-spark was not set up for delegation.  Now they are, so we should respect the delegating by prefixing with our adapter name.

### Checklist

- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
