### PR TITLE
Adding more tblproperties to ignore list for streaming tables

### DIFF
--- a/dbt/adapters/databricks/relation_configs/tblproperties.py
+++ b/dbt/adapters/databricks/relation_configs/tblproperties.py
@@ -29,6 +29,16 @@ class TblPropertiesConfig(DatabricksComponentConfig):
         "pipelines.metastore.tableName",
         "pipeline_internal.enzymeMode",
         "clusteringColumns",
+        "delta.enableRowTracking",
+        "delta.feature.appendOnly",
+        "delta.feature.changeDataFeed",
+        "delta.feature.checkConstraints",
+        "delta.feature.domainMetadata",
+        "delta.feature.generatedColumns",
+        "delta.feature.invariants",
+        "delta.feature.rowTracking",
+        "delta.rowTracking.materializedRowCommitVersionColumnName",
+        "delta.rowTracking.materializedRowIdColumnName",
     ]
 
     def __eq__(self, __value: Any) -> bool:


### PR DESCRIPTION
<!---
  Include the number of the issue addressed by this PR above if applicable.

  Example:
    resolves #1234

  Please review our pull request review process in CONTRIBUTING.md before your proceed.
-->

### Description

Adds more tblproperties that are added by default when creating a streaming table to the ignore list

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
