### PR TITLE
Extend Merge Capabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@
 - Add 'user_folder_for_python' config to switch writing python model notebooks to the user's folder ([706](https://github.com/databricks/dbt-databricks/pull/706))
 - Merge capabilities are extended ([739](https://github.com/databricks/dbt-databricks/pull/739)) to include the support for the follwing features:
   - `with schema evolution` clause (requires Databricks Runtime 15.2 or above);
-  - `when not matched on source` clause, only for `delete` action
-  - `matched`, `not matched` and `not matched on source` condition clauses;
+  - `when not matched by source` clause, only for `delete` action
+  - `matched`, `not matched` and `not matched by source` condition clauses;
   - custom aliases for source and target tables can be specified and used in condition clauses;
   - `matched` and `not matched` steps can now be skipped;
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 - Add support for serverless job clusters on python models ([706](https://github.com/databricks/dbt-databricks/pull/706))
 - Add 'user_folder_for_python' config to switch writing python model notebooks to the user's folder ([706](https://github.com/databricks/dbt-databricks/pull/706))
+- Merge capabilities are extended ([739](https://github.com/databricks/dbt-databricks/pull/739)) to include the support for the follwing features:
+  - `with schema evolution` clause (requires Databricks Runtime 15.2 or above);
+  - `when not matched on source` clause, only for `delete` action
+  - `matched`, `not matched` and `not matched on source` condition clauses;
+  - custom aliases for source and target tables can be specified and used in condition clauses;
+  - `matched` and `not matched` steps can now be skipped;
 
 ### Under the Hood
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Add support for serverless job clusters on python models ([706](https://github.com/databricks/dbt-databricks/pull/706))
 - Add 'user_folder_for_python' config to switch writing python model notebooks to the user's folder ([706](https://github.com/databricks/dbt-databricks/pull/706))
-- Merge capabilities are extended ([739](https://github.com/databricks/dbt-databricks/pull/739)) to include the support for the follwing features:
+- Merge capabilities are extended ([739](https://github.com/databricks/dbt-databricks/pull/739)) to include the support for the following features (thanks @mi-volodin):
   - `with schema evolution` clause (requires Databricks Runtime 15.2 or above);
   - `when not matched by source` clause, only for `delete` action
   - `matched`, `not matched` and `not matched by source` condition clauses;

--- a/dbt/adapters/databricks/impl.py
+++ b/dbt/adapters/databricks/impl.py
@@ -101,9 +101,13 @@ class DatabricksConfig(AdapterConfig):
     buckets: Optional[int] = None
     options: Optional[Dict[str, str]] = None
     merge_update_columns: Optional[str] = None
+    merge_exclude_columns: Optional[str] = None
     databricks_tags: Optional[Dict[str, str]] = None
     tblproperties: Optional[Dict[str, str]] = None
     zorder: Optional[Union[List[str], str]] = None
+    skip_matched_step: Optional[bool] = None
+    skip_non_matched_step: Optional[bool] = None
+    merge_with_schema_evolution: Optional[bool] = None
 
 
 def check_not_found_error(errmsg: str) -> bool:

--- a/dbt/adapters/databricks/impl.py
+++ b/dbt/adapters/databricks/impl.py
@@ -105,8 +105,14 @@ class DatabricksConfig(AdapterConfig):
     databricks_tags: Optional[Dict[str, str]] = None
     tblproperties: Optional[Dict[str, str]] = None
     zorder: Optional[Union[List[str], str]] = None
-    skip_matched_step: Optional[bool] = None
     skip_non_matched_step: Optional[bool] = None
+    skip_matched_step: Optional[bool] = None
+    matched_condition: Optional[str] = None
+    not_matched_condition: Optional[str] = None
+    not_matched_by_source_action: Optional[str] = None
+    not_matched_by_source_condition: Optional[str] = None
+    target_alias: Optional[str] = None
+    source_alias: Optional[str] = None
     merge_with_schema_evolution: Optional[bool] = None
 
 

--- a/dbt/include/databricks/macros/materializations/incremental/strategies.sql
+++ b/dbt/include/databricks/macros/materializations/incremental/strategies.sql
@@ -90,7 +90,7 @@ select {{source_cols_csv}} from {{ source_relation }}
   {%- set not_matched_condition = config.get('not_matched_condition') -%}
 
   {%- set not_matched_by_source_action = config.get('not_matched_by_source_action') -%}
-  {%- set not_matched_by_source_condition = config.get('not_matchednot_matched_by_source_condition_condition') -%}
+  {%- set not_matched_by_source_condition = config.get('not_matched_by_source_condition') -%}
   
 
   {% if unique_key %}

--- a/dbt/include/databricks/macros/materializations/incremental/strategies.sql
+++ b/dbt/include/databricks/macros/materializations/incremental/strategies.sql
@@ -146,7 +146,7 @@ select {{source_cols_csv}} from {{ source_relation }}
     {%- endif %}
 {% endmacro %}
 
-{% macro get_merge_update_set(update_columns, on_schema_change, source_columns, source_alias) %}
+{% macro get_merge_update_set(update_columns, on_schema_change, source_columns, source_alias='src') %}
   {%- if update_columns -%}
     {%- for column_name in update_columns -%}
       {{ column_name }} = {{ source_alias }}.{{ column_name }}{%- if not loop.last %}, {% endif -%}
@@ -160,7 +160,7 @@ select {{source_cols_csv}} from {{ source_relation }}
   {%- endif -%}
 {% endmacro %}
 
-{% macro get_merge_insert(on_schema_change, source_columns, source_alias) %}
+{% macro get_merge_insert(on_schema_change, source_columns, source_alias='src') %}
   {%- if on_schema_change == 'ignore' -%}
     *
   {%- else -%}

--- a/dbt/include/databricks/macros/materializations/incremental/strategies.sql
+++ b/dbt/include/databricks/macros/materializations/incremental/strategies.sql
@@ -76,11 +76,11 @@ select {{source_cols_csv}} from {{ source_relation }}
   {%- set source_columns = (adapter.get_columns_in_relation(source) | map(attribute='quoted') | list)-%}
   {%- set merge_update_columns = config.get('merge_update_columns') -%}
   {%- set merge_exclude_columns = config.get('merge_exclude_columns') -%}
-  {%- set merge_with_schema_evolution = config.get('merge_with_schema_evolution') == 'true' -%}
+  {%- set merge_with_schema_evolution = (config.get('merge_with_schema_evolution') | lower == 'true') -%}
   {%- set on_schema_change = incremental_validate_on_schema_change(config.get('on_schema_change'), default='ignore') -%}
   {%- set update_columns = get_merge_update_columns(merge_update_columns, merge_exclude_columns, dest_columns) -%}
-  {%- set skip_matched_step = config.get('skip_matched_step') == 'true' -%}
-  {%- set skip_not_matched_step = config.get('skip_not_matched_step') == 'true' -%}
+  {%- set skip_matched_step = (config.get('skip_matched_step') | lower == 'true') -%}
+  {%- set skip_not_matched_step = (config.get('skip_not_matched_step') | lower == 'true') -%}
 
   {% if unique_key %}
       {% if unique_key is sequence and unique_key is not mapping and unique_key is not string %}

--- a/docs/databricks-merge.md
+++ b/docs/databricks-merge.md
@@ -17,7 +17,7 @@ From v.1.9 onwards `merge` behavior can be tuned by setting the additional param
 - Merge steps control parameters that tweak the default behaviour:
   - `skip_matched_step`: if set to `true`, dbt will completely skip the `matched` clause of the merge statement.
   - `skip_not_matched_step`: similarly if `true` the `not matched` clause will be skipped.
-  - `not_matched_on_source_action`: if set to `delete` the corresponding `when not matched on source ... then delete` clause will be added to the merge statement.
+  - `not_matched_by_source_action`: if set to `delete` the corresponding `when not matched by source ... then delete` clause will be added to the merge statement.
   - `merge_with_schema_evolution`: when set to `true` dbt generates the merge statement with `WITH SCHEMA EVOLUTION` clause. 
 
 - Step conditions that are expressed with an explicit SQL predicates allow to execute corresponding action only in case the conditions are met in addition to matching by the `unique_key`. 

--- a/docs/databricks-merge.md
+++ b/docs/databricks-merge.md
@@ -1,0 +1,96 @@
+## The merge strategy
+
+The merge incremental strategy requires:
+
+- `file_format`: delta or hudi
+- Databricks Runtime 5.1 and above for delta file format
+- Apache Spark for hudi file format
+
+dbt will run an [atomic `merge` statement](https://docs.databricks.com/en/sql/language-manual/delta-merge-into.html) which looks nearly identical to the default merge behavior on Snowflake and BigQuery. 
+If a `unique_key` is specified (recommended), dbt will update old records with values from new records that match on the key column. 
+If a `unique_key` is not specified, dbt will forgo match criteria and simply insert all new records (similar to `append` strategy).
+
+Specifying `merge` as the incremental strategy is optional since it's the default strategy used when none is specified.
+
+From v.1.9 onwards `merge` behavior can be tuned by setting the additional parameters.
+
+- Merge steps control parameters that tweak the default behaviour:
+  - `skip_matched_step`: if set to `true`, dbt will completely skip the `matched` clause of the merge statement.
+  - `skip_not_matched_step`: similarly if `true` the `not matched` clause will be skipped.
+  - `not_matched_on_source_action`: if set to `delete` the corresponding `when not matched on source ... then delete` clause will be added to the merge statement.
+  - `merge_with_schema_evolution`: when set to `true` dbt generates the merge statement with `WITH SCHEMA EVOLUTION` clause. 
+
+- Step conditions that are expressed with an explicit SQL predicates allow to execute corresponding action only in case the conditions are met in addition to matching by the `unique_key`. 
+  - `matched_condition`:  applies to `when matched` step. 
+    In order to define such conditions one may use `tgt` and `src` as aliases for the target and source tables respectively, e.g. `tgt.col1 = hash(src.col2, src.col3)`.
+  - `not_matched_condition`: applies to `when not matched` step.
+  - `not_matched_by_source_condition`: applies to `when not matched by source` step.
+  - `target_alias`, `source_alias`: string values that will be used instead of `tgt` and `src` to distinguish between source and target tables in the merge statement.
+
+Example below illustrates how these parameters affect the merge statement generation:
+
+```sql
+{{ config(
+    materialized = 'incremental',
+    unique_key = 'id',
+    incremental_strategy='merge',
+    target_alias='t',
+    source_alias='s',
+    matched_condition='t.tech_change_ts < s.tech_change_ts',
+    not_matched_condition='s.attr1 IS NOT NULL',
+    not_matched_by_source_condition='t.tech_change_ts < current_timestamp()',
+    not_matched_by_source_action='delete',
+    merge_with_schema_evolution=true
+) }}
+
+select
+    id,
+    attr1,
+    attr2,
+    tech_change_ts
+from
+    {{ ref('source_table') }} as s
+```
+
+```sql
+merge 
+    with schema evolution
+into
+    target_table as t
+using (
+    select
+        id,
+        attr1,
+        attr2,
+        tech_change_ts
+    from
+        source_table as s
+)
+on
+    t.id <=> s.id
+when matched
+    and t.tech_change_ts < s.tech_change_ts
+    then update set
+        id = s.id,
+        attr1 = s.attr1,
+        attr2 = s.attr2,
+        tech_change_ts = s.tech_change_ts
+
+when not matched
+    and s.attr1 IS NOT NULL
+    then insert (
+        id,
+        attr1,
+        attr2,
+        tech_change_ts
+    ) values (
+        s.id,
+        s.attr1,
+        s.attr2,
+        s.tech_change_ts
+    )
+    
+when not matched by source
+    and t.tech_change_ts < current_timestamp()
+    then delete
+```

--- a/tests/functional/adapter/incremental/fixtures.py
+++ b/tests/functional/adapter/incremental/fixtures.py
@@ -221,6 +221,11 @@ skip_matched_expected = """id,msg,color
 3,anyway,purple
 """
 
+skip_not_matched_expected = """id,msg,color
+1,hey,cyan
+2,yo,green
+"""
+
 base_model = """
 {{ config(
     materialized = 'incremental'
@@ -314,6 +319,9 @@ select 3 as id, 'anyway' as msg, 'purple' as color
 {% endif %}
 """
 
+skip_not_matched_model = skip_matched_model.replace(
+    "skip_matched_step = true", "skip_not_matched_step = true"
+)
 
 simple_python_model = """
 import pandas

--- a/tests/functional/adapter/incremental/fixtures.py
+++ b/tests/functional/adapter/incremental/fixtures.py
@@ -226,6 +226,13 @@ skip_not_matched_expected = """id,msg,color
 2,yo,green
 """
 
+matching_conditions_expected = """id,first,second,V
+1,Jessica,Atreides,2
+2,Paul,Atreides,1
+3,Dunkan,Aidaho,1
+4,Baron,Harkonnen,1
+"""
+
 base_model = """
 {{ config(
     materialized = 'incremental'
@@ -322,6 +329,43 @@ select 3 as id, 'anyway' as msg, 'purple' as color
 skip_not_matched_model = skip_matched_model.replace(
     "skip_matched_step = true", "skip_not_matched_step = true"
 )
+
+matching_conditions_model = """
+{{ config(
+    materialized = 'incremental',
+    unique_key = 'id',
+    incremental_strategy='merge',
+    target_alias='t',
+    matched_conditions='src.V > t.V and hash(src.first, src.second) <> hash(t.first, t.second)',
+    not_matched_conditions='src.V > 0',
+) }}
+
+{% if not is_incremental() %}
+
+-- data for first invocation of model
+
+select 1 as id, 'Vasya' as first, 'Pupkin' as second, 1 as V
+union all
+select 2 as id, 'Paul' as first, 'Atreides' as second, 1 as V
+union all
+select 3 as id, 'Dunkan' as first, 'Aidaho' as second, 1 as V
+
+{% else %}
+
+-- data for subsequent incremental update
+
+select 1 as id, 'Jessica' as first, 'Atreides' as second, 2 as V -- should merge
+union all
+select 2 as id, 'Paul' as first, 'Whiskas' as second, 1 as V -- V is same, no merge
+union all
+select 3 as id, 'Dunkan' as first, 'Aidaho' as second, 2 as V -- Hash is same, no merge
+union all
+select 4 as id, 'Baron' as first, 'Harkonnen' as second, 1 as V -- should append
+union all
+select 5 as id, 'Raban' as first, '' as second, 0 as V -- no append
+
+{% endif %}
+"""
 
 simple_python_model = """
 import pandas

--- a/tests/functional/adapter/incremental/fixtures.py
+++ b/tests/functional/adapter/incremental/fixtures.py
@@ -215,6 +215,12 @@ replace_where_expected = """id,msg,color
 3,anyway,purple
 """
 
+skip_matched_expected = """id,msg,color
+1,hello,blue
+2,goodbye,red
+3,anyway,purple
+"""
+
 base_model = """
 {{ config(
     materialized = 'incremental'
@@ -275,6 +281,35 @@ select cast(2 as bigint) as id, 'goodbye' as msg, 'red' as color
 {% else %}
 
 select cast(3 as bigint) as id, 'anyway' as msg, 'purple' as color
+
+{% endif %}
+"""
+
+skip_matched_model = """
+{{ config(
+    materialized = 'incremental',
+    unique_key = 'id',
+    incremental_strategy='merge',
+    skip_matched_step = true,
+) }}
+
+{% if not is_incremental() %}
+
+-- data for first invocation of model
+
+select 1 as id, 'hello' as msg, 'blue' as color
+union all
+select 2 as id, 'goodbye' as msg, 'red' as color
+
+{% else %}
+
+-- data for subsequent incremental update
+
+select 1 as id, 'hey' as msg, 'cyan' as color
+union all
+select 2 as id, 'yo' as msg, 'green' as color
+union all
+select 3 as id, 'anyway' as msg, 'purple' as color
 
 {% endif %}
 """

--- a/tests/functional/adapter/incremental/fixtures.py
+++ b/tests/functional/adapter/incremental/fixtures.py
@@ -226,7 +226,7 @@ skip_not_matched_expected = """id,msg,color
 2,yo,green
 """
 
-matching_conditions_expected = """id,first,second,V
+matching_condition_expected = """id,first,second,V
 1,Jessica,Atreides,2
 2,Paul,Atreides,1
 3,Dunkan,Aidaho,1
@@ -330,14 +330,14 @@ skip_not_matched_model = skip_matched_model.replace(
     "skip_matched_step = true", "skip_not_matched_step = true"
 )
 
-matching_conditions_model = """
+matching_condition_model = """
 {{ config(
     materialized = 'incremental',
     unique_key = 'id',
     incremental_strategy='merge',
     target_alias='t',
-    matched_conditions='src.V > t.V and hash(src.first, src.second) <> hash(t.first, t.second)',
-    not_matched_conditions='src.V > 0',
+    matched_condition='src.V > t.V and hash(src.first, src.second) <> hash(t.first, t.second)',
+    not_matched_condition='src.V > 0',
 ) }}
 
 {% if not is_incremental() %}

--- a/tests/functional/adapter/incremental/test_incremental_predicates.py
+++ b/tests/functional/adapter/incremental/test_incremental_predicates.py
@@ -9,7 +9,12 @@ from tests.functional.adapter.incremental import fixtures
 class TestIncrementalPredicatesMergeDatabricks(BaseIncrementalPredicates):
     @pytest.fixture(scope="class")
     def project_config_update(self):
-        return {"models": {"+incremental_predicates": ["dbt_internal_dest.id != 2"]}}
+        return {
+            "models": {
+                "+incremental_predicates": ["dbt_internal_dest.id != 2"],
+                "+target_alias": "dbt_internal_dest",
+            }
+        }
 
     @pytest.fixture(scope="class")
     def models(self):
@@ -23,7 +28,12 @@ class TestIncrementalPredicatesMergeDatabricks(BaseIncrementalPredicates):
 class TestPredicatesMergeDatabricks(BaseIncrementalPredicates):
     @pytest.fixture(scope="class")
     def project_config_update(self):
-        return {"models": {"+predicates": ["dbt_internal_dest.id != 2"]}}
+        return {
+            "models": {
+                "+predicates": ["dbt_internal_dest.id != 2"],
+                "+target_alias": "dbt_internal_dest",
+            }
+        }
 
     @pytest.fixture(scope="class")
     def models(self):

--- a/tests/functional/adapter/incremental/test_incremental_strategies.py
+++ b/tests/functional/adapter/incremental/test_incremental_strategies.py
@@ -239,3 +239,23 @@ class TestSkipMatched(IncrementalBase):
     def test_merge(self, project):
         self.seed_and_run_twice()
         util.check_relations_equal(project.adapter, ["skip_matched", "skip_matched_expected"])
+
+
+class TestSkipNotMatched(IncrementalBase):
+    @pytest.fixture(scope="class")
+    def seeds(self):
+        return {
+            "skip_not_matched_expected.csv": fixtures.skip_not_matched_expected,
+        }
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "skip_not_matched.sql": fixtures.skip_not_matched_model,
+        }
+
+    def test_merge(self, project):
+        self.seed_and_run_twice()
+        util.check_relations_equal(
+            project.adapter, ["skip_not_matched", "skip_not_matched_expected"]
+        )

--- a/tests/functional/adapter/incremental/test_incremental_strategies.py
+++ b/tests/functional/adapter/incremental/test_incremental_strategies.py
@@ -280,3 +280,45 @@ class TestMatchedAndNotMatchedCondition(IncrementalBase):
             project.adapter,
             ["matching_condition", "matching_condition_expected"],
         )
+
+
+class TestNotMatchedBySourceAndCondition(IncrementalBase):
+    @pytest.fixture(scope="class")
+    def seeds(self):
+        return {
+            "not_matched_by_source_expected.csv": fixtures.not_matched_by_source_expected,
+        }
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "not_matched_by_source.sql": fixtures.not_matched_by_source_model,
+        }
+
+    def test_merge(self, project):
+        self.seed_and_run_twice()
+        util.check_relations_equal(
+            project.adapter,
+            ["not_matched_by_source", "not_matched_by_source_expected"],
+        )
+
+
+class TestMergeSchemaEvolution(IncrementalBase):
+    @pytest.fixture(scope="class")
+    def seeds(self):
+        return {
+            "merge_schema_evolution_expected.csv": fixtures.merge_schema_evolution_expected,
+        }
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "merge_schema_evolution.sql": fixtures.merge_schema_evolution_model,
+        }
+
+    def test_merge(self, project):
+        self.seed_and_run_twice()
+        util.check_relations_equal(
+            project.adapter,
+            ["merge_schema_evolution", "merge_schema_evolution_expected"],
+        )

--- a/tests/functional/adapter/incremental/test_incremental_strategies.py
+++ b/tests/functional/adapter/incremental/test_incremental_strategies.py
@@ -259,3 +259,24 @@ class TestSkipNotMatched(IncrementalBase):
         util.check_relations_equal(
             project.adapter, ["skip_not_matched", "skip_not_matched_expected"]
         )
+
+
+class TestMatchedAndNotMatchedConditions(IncrementalBase):
+    @pytest.fixture(scope="class")
+    def seeds(self):
+        return {
+            "matching_conditions_expected.csv": fixtures.matching_conditions_expected,
+        }
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "matching_conditions.sql": fixtures.matching_conditions_model,
+        }
+
+    def test_merge(self, project):
+        self.seed_and_run_twice()
+        util.check_relations_equal(
+            project.adapter,
+            ["matching_conditions", "matching_conditions_expected"],
+        )

--- a/tests/functional/adapter/incremental/test_incremental_strategies.py
+++ b/tests/functional/adapter/incremental/test_incremental_strategies.py
@@ -261,22 +261,22 @@ class TestSkipNotMatched(IncrementalBase):
         )
 
 
-class TestMatchedAndNotMatchedConditions(IncrementalBase):
+class TestMatchedAndNotMatchedCondition(IncrementalBase):
     @pytest.fixture(scope="class")
     def seeds(self):
         return {
-            "matching_conditions_expected.csv": fixtures.matching_conditions_expected,
+            "matching_condition_expected.csv": fixtures.matching_condition_expected,
         }
 
     @pytest.fixture(scope="class")
     def models(self):
         return {
-            "matching_conditions.sql": fixtures.matching_conditions_model,
+            "matching_condition.sql": fixtures.matching_condition_model,
         }
 
     def test_merge(self, project):
         self.seed_and_run_twice()
         util.check_relations_equal(
             project.adapter,
-            ["matching_conditions", "matching_conditions_expected"],
+            ["matching_condition", "matching_condition_expected"],
         )

--- a/tests/functional/adapter/incremental/test_incremental_strategies.py
+++ b/tests/functional/adapter/incremental/test_incremental_strategies.py
@@ -221,3 +221,21 @@ class TestReplaceWhere(IncrementalBase):
     def test_replace_where(self, project):
         self.seed_and_run_twice()
         util.check_relations_equal(project.adapter, ["replace_where", "replace_where_expected"])
+
+
+class TestSkipMatched(IncrementalBase):
+    @pytest.fixture(scope="class")
+    def seeds(self):
+        return {
+            "skip_matched_expected.csv": fixtures.skip_matched_expected,
+        }
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "skip_matched.sql": fixtures.skip_matched_model,
+        }
+
+    def test_merge(self, project):
+        self.seed_and_run_twice()
+        util.check_relations_equal(project.adapter, ["skip_matched", "skip_matched_expected"])


### PR DESCRIPTION
<!-- Please review our pull request review process in CONTRIBUTING.md before your proceed. -->

Resolves #245 
Resolves #707 

<!---
  Include the number of the issue addressed by this PR above if applicable.

  Example:
    resolves #1234

  Please review our pull request review process in CONTRIBUTING.md before your proceed.
-->

### Motivation

The current MERGE INTO capabilities available in dbt (data build tool) significantly differ from what can be achieved through a pure SQL interface. While it is sometimes possible to circumvent these limitations using complex SQL techniques, this approach often increases code complexity. Additionally, because Spark does not execute some operations identically when comparing direct merges with workaround solutions, this can lead to performance issues.

### Description

<!--- Describe the Pull Request here -->
This PR aims to add the following capabilities:

- Add flag `skip_matched_step` to be able to skip matched step in merge statement. This and other mentioned flags are considered active only if they equal to a `true` string (case-insensitive).
- Add flag `skip_not_matched_step` to be able to skip not matched step in merge statement.
- Add flag `merge_with_schema_evolution` to allow new capability of MERGE to evolve schema.
- Add `matched_conditions` and `not_matched_conditions`:
    - The default conditions can be expressed as a string only, as it looks more convenient for complex conditions (mix of `and` and `or`, functions)
    - Default aliases for source and target are `src` and `tgt` respectively, but...
    - it is possible to set aliases using `target_alias` or `source_alias` parameters.
    - Rationale and background:  see [discussion](https://github.com/databricks/dbt-databricks/issues/245#issuecomment-2168416491)
- Add `delete` option for merge. This will be triggered by two parameters: `not_matched_by_source_action` which should be set to `delete`. Also it is possible to add `not_matched_by_source_condition` which defines additional predicates that should resolve to `true` for delete to happen.

### DOD checklist

#### Tests

- [x] Model that has updates with `skip_matched_step == true` updates nothing.
- [x] Model that has new records with `skip_not_matched_step == true` inserts nothing.
- [x] Model with extended schema adds the new attribute when used in the input model. When attribute is not provided in the old records - it remains `null`.
- [x] Test for `matched_conditions` and `not_matched_conditions` that covers all cases of logic (matched / not + conditions met / not) + also cover custom alias testing.
- [x] Test for `not_matched_by_source` removes the record that is not on source, keeps the record which is not on source but the `not_matched_by_source_condition` is not met.

#### Open questions

- [x] Do I need to implement exceptions for compile time for the case I have some inconsistent flag states (e.g. all steps in merge are requested to be skipped)?
  - Decision is NO, as Databricks should cover syntax errors reporting.


#### Docs

- [x] Update documentation with the new capabilities (see added `docs/databricks-merge.md`
- [x] Changelog

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
