### PR TITLE
When we persist doc, for python lets remember to add a comment

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ pytest_plugins = ["dbt.tests.fixtures.project"]
 
 
 def pytest_addoption(parser):
-    parser.addoption("--profile", action="store", default="databricks_uc_sql_endpoint", type=str)
+    parser.addoption("--profile", action="store", default="databricks_uc_cluster", type=str)
 
 
 # Using @pytest.mark.skip_profile('databricks_cluster') uses the 'skip_by_adapter_type'

--- a/tests/functional/adapter/python_model/fixtures.py
+++ b/tests/functional/adapter/python_model/fixtures.py
@@ -71,6 +71,7 @@ sources:
 complex_schema = """version: 2
 models:
   - name: complex_config
+    description: This is a python table
     config:
       marterialized: table
       tags: ["python"]

--- a/tests/functional/adapter/python_model/test_python_model.py
+++ b/tests/functional/adapter/python_model/test_python_model.py
@@ -96,3 +96,9 @@ class TestComplexConfig:
         result_dict = {result[0]: result[1] for result in results}
         assert result_dict["a"] == "b"
         assert result_dict["c"] == "d"
+        results = project.run_sql(
+            "select comment from {database}.information_schema"
+            ".tables where table_name = 'complex_config'",
+            fetch="all",
+        )
+        assert results[0][0] == "This is a python table"


### PR DESCRIPTION
<!-- Please review our pull request review process in CONTRIBUTING.md before your proceed. -->

Resolves #740

<!---
  Include the number of the issue addressed by this PR above if applicable.

  Example:
    resolves #1234

  Please review our pull request review process in CONTRIBUTING.md before your proceed.
-->

### Description

Since python models don't have the capability to write the description with the table writer, when we persist docs, ensure that we persist table-level comments for python.

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
