### PR TITLE
Backport close cursor code to 1.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## dbt-databricks 1.7.17 (July 25, 2024)
+
+### Fixes
+
+- Backport warning prevention from 1.9
+
 ## dbt-databricks 1.7.16 (May 21, 2024)
 
 ### Fixes

--- a/dbt/adapters/databricks/__version__.py
+++ b/dbt/adapters/databricks/__version__.py
@@ -1,1 +1,1 @@
-version: str = "1.7.16"
+version: str = "1.7.17"

--- a/dbt/adapters/databricks/column.py
+++ b/dbt/adapters/databricks/column.py
@@ -17,6 +17,11 @@ class DatabricksColumn(SparkColumn):
     def translate_type(cls, dtype: str) -> str:
         return super(SparkColumn, cls).translate_type(dtype).lower()
 
+    @classmethod
+    def create(cls, name: str, label_or_dtype: str) -> "DatabricksColumn":
+        column_type = cls.translate_type(label_or_dtype)
+        return cls(name, column_type)
+
     @property
     def data_type(self) -> str:
         return self.translate_type(self.dtype)


### PR DESCRIPTION
### Description

Backports close cursor code to 1.7

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
