### PR TITLE
Fix table comment updates

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
       - id: check-yaml
       - id: check-added-large-files
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 22.12.0
+    rev: 24.3.0
     hooks:
       - id: black
         language_version: python3.11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Alter column statements are now done before the alter table statement (thanks @frankivo!). ([731](https://github.com/databricks/dbt-databricks/pull/731))
 - Always use lower case when gathering metadata (since objects are stored internally as lower case regardless of how we create them) ([742](https://github.com/databricks/dbt-databricks/pull/742))
 - Persist table comments for python models ([743](https://github.com/databricks/dbt-databricks/pull/743))
+- Persist table comments for incremental models, snapshots and dbt clone ([750](https://github.com/databricks/dbt-databricks/pull/750))
 - Stop cursor destructor warnings ([744](https://github.com/databricks/dbt-databricks/pull/744))
 - Race condition on cluster creation. (thanks @jurasan!) ([751](https://github.com/databricks/dbt-databricks/pull/751))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,16 @@
-## dbt-databricks next
+## dbt-databricks 1.8.6 (TBD)
+
+### Fixes
+
+- Persist table comments for incremental models, snapshots and dbt clone (thanks @henlue!) ([750](https://github.com/databricks/dbt-databricks/pull/750))
+
+## dbt-databricks 1.8.5 (August 6, 2024)
 
 ### Fixes
 
 - Alter column statements are now done before the alter table statement (thanks @frankivo!). ([731](https://github.com/databricks/dbt-databricks/pull/731))
 - Always use lower case when gathering metadata (since objects are stored internally as lower case regardless of how we create them) ([742](https://github.com/databricks/dbt-databricks/pull/742))
 - Persist table comments for python models ([743](https://github.com/databricks/dbt-databricks/pull/743))
-- Persist table comments for incremental models, snapshots and dbt clone ([750](https://github.com/databricks/dbt-databricks/pull/750))
 - Stop cursor destructor warnings ([744](https://github.com/databricks/dbt-databricks/pull/744))
 - Race condition on cluster creation. (thanks @jurasan!) ([751](https://github.com/databricks/dbt-databricks/pull/751))
 

--- a/dbt/include/databricks/macros/adapters/persist_docs.sql
+++ b/dbt/include/databricks/macros/adapters/persist_docs.sql
@@ -28,9 +28,8 @@
   {% do return(load_result('get_columns_comments').table) %}
 {% endmacro %}
 
-
 {% macro databricks__persist_docs(relation, model, for_relation, for_columns) -%}
-  {%- if for_relation and model.description and model['language'] == 'python' %}
+  {%- if for_relation and config.persist_relation_docs() and model.description %}
     {% do alter_table_comment(relation, model) %}
   {% endif %}
   {% if for_columns and config.persist_column_docs() and model.columns %}

--- a/dbt/include/databricks/macros/materializations/incremental/incremental.sql
+++ b/dbt/include/databricks/macros/materializations/incremental/incremental.sql
@@ -38,6 +38,7 @@
     {%- endcall -%}
     {% do persist_constraints(target_relation, model) %}
     {% do apply_tags(target_relation, tags) %}
+    {% do persist_docs(target_relation, model, for_relation=language=='python') %}
   {%- elif existing_relation.is_view or existing_relation.is_materialized_view or existing_relation.is_streaming_table or should_full_refresh() -%}
     {#-- Relation must be dropped & recreated --#}
     {% set is_delta = (file_format == 'delta' and existing_relation.is_delta) %}
@@ -52,6 +53,7 @@
       {% do persist_constraints(target_relation, model) %}
     {% endif %}
     {% do apply_tags(target_relation, tags) %}
+    {% do persist_docs(target_relation, model, for_relation=language=='python') %}
   {%- else -%}
     {#-- Set Overwrite Mode to DYNAMIC for subsequent incremental operations --#}
     {%- if incremental_strategy == 'insert_overwrite' and partition_by -%}
@@ -99,12 +101,12 @@
         {% do apply_tags(target_relation, tags.set_tags, tags.unset_tags) %}
       {%- endif -%}
     {%- endif -%}
+    {% do persist_docs(target_relation, model, for_relation=True) %}
   {%- endif -%}
 
   {% set should_revoke = should_revoke(existing_relation, full_refresh_mode) %}
   {% do apply_grants(target_relation, grant_config, should_revoke) %}
   {% do apply_tblproperties_python(target_relation, tblproperties, language) %}
-  {% do persist_docs(target_relation, model) %}
   {% do optimize(target_relation) %}
 
   {{ run_hooks(post_hooks) }}

--- a/dbt/include/databricks/macros/materializations/materialized_view.sql
+++ b/dbt/include/databricks/macros/materializations/materialized_view.sql
@@ -91,7 +91,7 @@
     {% set should_revoke = should_revoke(existing_relation, full_refresh_mode=True) %}
     {% do apply_grants(target_relation, grant_config, should_revoke=should_revoke) %}
 
-    {% do persist_docs(target_relation, model) %}
+    {% do persist_docs(target_relation, model, for_relation=False) %}
 
     {{ run_hooks(post_hooks, inside_transaction=True) }}
 

--- a/dbt/include/databricks/macros/materializations/snapshot.sql
+++ b/dbt/include/databricks/macros/materializations/snapshot.sql
@@ -71,6 +71,8 @@
           {{ final_sql }}
       {% endcall %}
 
+      {% do persist_docs(target_relation, model, for_relation=False) %}
+
   {% else %}
 
       {{ adapter.valid_snapshot_target(target_relation) }}
@@ -117,12 +119,12 @@
           {{ final_sql }}
       {% endcall %}
 
+      {% do persist_docs(target_relation, model, for_relation=True) %}
+
   {% endif %}
 
   {% set should_revoke = should_revoke(target_relation_exists, full_refresh_mode) %}
   {% do apply_grants(target_relation, grant_config, should_revoke) %}
-
-  {% do persist_docs(target_relation, model) %}
 
   {% do persist_constraints(target_relation, model) %}
 

--- a/dbt/include/databricks/macros/materializations/streaming_table.sql
+++ b/dbt/include/databricks/macros/materializations/streaming_table.sql
@@ -90,7 +90,7 @@
     {% set should_revoke = should_revoke(existing_relation, full_refresh_mode=True) %}
     {% do apply_grants(target_relation, grant_config, should_revoke=should_revoke) %}
 
-    {% do persist_docs(target_relation, model) %}
+    {% do persist_docs(target_relation, model, for_relation=False) %}
 
     {{ run_hooks(post_hooks, inside_transaction=True) }}
 

--- a/dbt/include/databricks/macros/materializations/table.sql
+++ b/dbt/include/databricks/macros/materializations/table.sql
@@ -32,8 +32,8 @@
   {% do apply_tblproperties_python(target_relation, tblproperties, language) %}
 
   {%- do apply_tags(target_relation, tags) -%}
-  
-  {% do persist_docs(target_relation, model) %}
+
+  {% do persist_docs(target_relation, model, for_relation=language=='python') %}
 
   {% do persist_constraints(target_relation, model) %}
 

--- a/tests/functional/adapter/dbt_clone/fixtures.py
+++ b/tests/functional/adapter/dbt_clone/fixtures.py
@@ -1,0 +1,20 @@
+comment_schema_yml = """
+version: 2
+models:
+  - name: view_model
+    description: This is a view model
+  - name: table_model
+    description: This is a table model
+"""
+
+view_model_sql = """
+{{ config(materialized = 'view') }}
+
+select 1 as id
+"""
+
+table_model_sql = """
+{{ config(materialized = 'table') }}
+
+select 1 as id
+"""

--- a/tests/functional/adapter/dbt_clone/test_dbt_clone.py
+++ b/tests/functional/adapter/dbt_clone/test_dbt_clone.py
@@ -89,11 +89,19 @@ class TestClonePersistDocs(BaseClone):
         ]
 
         results = run_dbt(clone_args)
+
         results = project.run_sql(
-            f"select comment from {project.database}.information_schema.tables "
-            f"where table_schema = '{other_schema}' "
-            f"order by table_name",
+            f"describe extended {project.database}.{other_schema}.table_model",
             fetch="all",
         )
-        assert results[0][0] == "This is a table model"
-        assert results[1][0] == "This is a view model"
+        for row in results:
+            if row[0] == "comment":
+                assert row[1] == "This is a table model"
+
+        results = project.run_sql(
+            f"describe extended {project.database}.{other_schema}.view_model",
+            fetch="all",
+        )
+        for row in results:
+            if row[0] == "comment":
+                assert row[1] == "This is a view model"

--- a/tests/functional/adapter/incremental/fixtures.py
+++ b/tests/functional/adapter/incremental/fixtures.py
@@ -37,6 +37,7 @@ version: 2
 
 models:
   - name: merge_update_columns_sql
+    description: This is a model description
     columns:
         - name: id
           description: This is the id column

--- a/tests/functional/adapter/incremental/test_incremental_persist_docs.py
+++ b/tests/functional/adapter/incremental/test_incremental_persist_docs.py
@@ -28,7 +28,23 @@ class TestIncrementalPersistDocs:
     def test_adding_comments(self, project):
         util.run_dbt(["run"])
         util.write_file(fixtures.comment_schema, "models", "schema.yml")
-        _, out = util.run_dbt_and_capture(["--debug", "run"])
-        assert "comment 'This is the id column'" in out
-        assert "comment 'This is the msg column'" in out
-        assert "comment ''" not in out
+        util.run_dbt(["run"])
+
+        results = project.run_sql(
+            f"select comment from {project.database}.information_schema.tables "
+            f"where"
+            f"  table_schema = '{project.test_schema}' and"
+            f"  table_name = 'merge_update_columns_sql'",
+            fetch="all",
+        )
+        assert results[0][0] == "This is a model description"
+        results = project.run_sql(
+            f"select comment from {project.database}.information_schema.columns "
+            f"where"
+            f"  table_schema = '{project.test_schema}' and"
+            f"  table_name = 'merge_update_columns_sql'"
+            f"order by ordinal_position",
+            fetch="all",
+        )
+        assert results[0][0] == "This is the id column"
+        assert results[1][0] == "This is the msg column"

--- a/tests/functional/adapter/incremental/test_incremental_persist_docs.py
+++ b/tests/functional/adapter/incremental/test_incremental_persist_docs.py
@@ -31,20 +31,13 @@ class TestIncrementalPersistDocs:
         util.run_dbt(["run"])
 
         results = project.run_sql(
-            f"select comment from {project.database}.information_schema.tables "
-            f"where"
-            f"  table_schema = '{project.test_schema}' and"
-            f"  table_name = 'merge_update_columns_sql'",
+            f"describe detail {project.database}.{project.test_schema}.merge_update_columns_sql",
             fetch="all",
         )
-        assert results[0][0] == "This is a model description"
+        assert results[0][3] == "This is a model description"
         results = project.run_sql(
-            f"select comment from {project.database}.information_schema.columns "
-            f"where"
-            f"  table_schema = '{project.test_schema}' and"
-            f"  table_name = 'merge_update_columns_sql'"
-            f"order by ordinal_position",
+            f"describe table {project.database}.{project.test_schema}.merge_update_columns_sql",
             fetch="all",
         )
-        assert results[0][0] == "This is the id column"
-        assert results[1][0] == "This is the msg column"
+        assert results[0][2] == "This is the id column"
+        assert results[1][2] == "This is the msg column"

--- a/tests/functional/adapter/python_model/test_python_model.py
+++ b/tests/functional/adapter/python_model/test_python_model.py
@@ -1,6 +1,7 @@
 import os
 
 import pytest
+
 from dbt.tests import util
 from dbt.tests.adapter.python_model import test_python_model as fixtures
 from dbt.tests.adapter.python_model.test_python_model import BasePythonIncrementalTests
@@ -83,6 +84,17 @@ class TestComplexConfig:
         return {
             "schema.yml": override_fixtures.complex_schema,
             "complex_config.py": override_fixtures.complex_py,
+        }
+
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {
+            "models": {
+                "+persist_docs": {
+                    "relation": True,
+                    "columns": True,
+                },
+            }
         }
 
     def test_expected_handling_of_complex_config(self, project):

--- a/tests/functional/adapter/simple_snapshot/fixtures.py
+++ b/tests/functional/adapter/simple_snapshot/fixtures.py
@@ -1,0 +1,28 @@
+comment_schema_yml = """
+version: 2
+snapshots:
+  - name: snapshot
+    description: This is a snapshot description
+"""
+
+new_comment_schema_yml = """
+version: 2
+snapshots:
+  - name: snapshot
+    description: This is a new snapshot description
+"""
+
+snapshot_sql = """
+{% snapshot snapshot %}
+    {{
+        config(
+            target_database=database,
+            target_schema=schema,
+            unique_key='id',
+            strategy='check',
+            check_cols=['id'],
+        )
+    }}
+    select 1 as id
+{% endsnapshot %}
+"""

--- a/tests/functional/adapter/simple_snapshot/test_snapshot.py
+++ b/tests/functional/adapter/simple_snapshot/test_snapshot.py
@@ -57,16 +57,11 @@ class TestSnapshotPersistDocs:
 
     def test_persist_docs(self, project):
         results = run_dbt(["snapshot"])
-        comment_query = (
-            f"select comment from {project.database}.information_schema.tables "
-            f"where "
-            f"  table_schema = '{project.test_schema}' and "
-            f"  table_name = 'snapshot'"
-        )
+        comment_query = f"describe detail {project.database}.{project.test_schema}.snapshot"
         results = project.run_sql(comment_query, fetch="all")
-        assert results[0][0] == "This is a snapshot description"
+        assert results[0][3] == "This is a snapshot description"
 
         util.write_file(fixtures.new_comment_schema_yml, "models", "schema.yml")
         results = run_dbt(["snapshot"])
         results = project.run_sql(comment_query, fetch="all")
-        assert results[0][0] == "This is a new snapshot description"
+        assert results[0][3] == "This is a new snapshot description"

--- a/tests/functional/adapter/simple_snapshot/test_snapshot.py
+++ b/tests/functional/adapter/simple_snapshot/test_snapshot.py
@@ -1,8 +1,12 @@
 from typing import Optional
 
+import pytest
+
 from dbt.tests import util
 from dbt.tests.adapter.simple_snapshot.test_snapshot import BaseSimpleSnapshot
 from dbt.tests.adapter.simple_snapshot.test_snapshot import BaseSnapshotCheck
+from dbt.tests.util import run_dbt
+from tests.functional.adapter.simple_snapshot import fixtures
 
 
 class TestSnapshot(BaseSimpleSnapshot):
@@ -27,3 +31,42 @@ class TestSnapshot(BaseSimpleSnapshot):
 
 class TestSnapshotCheck(BaseSnapshotCheck):
     pass
+
+
+class TestSnapshotPersistDocs:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "schema.yml": fixtures.comment_schema_yml,
+        }
+
+    @pytest.fixture(scope="class")
+    def snapshots(self):
+        return {"snapshot.sql": fixtures.snapshot_sql}
+
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {
+            "snapshots": {
+                "+persist_docs": {
+                    "relation": True,
+                    "columns": True,
+                }
+            }
+        }
+
+    def test_persist_docs(self, project):
+        results = run_dbt(["snapshot"])
+        comment_query = (
+            f"select comment from {project.database}.information_schema.tables "
+            f"where "
+            f"  table_schema = '{project.test_schema}' and "
+            f"  table_name = 'snapshot'"
+        )
+        results = project.run_sql(comment_query, fetch="all")
+        assert results[0][0] == "This is a snapshot description"
+
+        util.write_file(fixtures.new_comment_schema_yml, "models", "schema.yml")
+        results = run_dbt(["snapshot"])
+        results = project.run_sql(comment_query, fetch="all")
+        assert results[0][0] == "This is a new snapshot description"


### PR DESCRIPTION
<!-- Please review our pull request review process in CONTRIBUTING.md before your proceed. -->

Resolves #732

<!---
  Include the number of the issue addressed by this PR above if applicable.

  Example:
    resolves #1234

  Please review our pull request review process in CONTRIBUTING.md before your proceed.
-->

### Description

 - Update table comments for incremental models on incremental runs
 - Update table comments for snapshots on incremental runs
 - Create table comments during dbt clone
 - Check for `config.persist_relation_docs()` in `persist_docs`
 - Align black versions in `black.ini` and `.pre-commit-config.yaml` to fix failing `pre-commit` runs

The issue is only about the incremental models. While working on the PR I realized table comments are also not being updated for snapshots and are not created with `dbt clone`.

I think comments are also not being updated in materialized views and streaming tables. Since I don't have a good understanding of those materializations, I kept the original behavior by setting `for_relation=False`. The tests would also run through with `for_relation=True`, but this might lead to unnecessary queries that are being send to databricks on the first run of those relations.

Generally, the code would be simpler if relation comments are only persisted in `persist_docs` (using `comment on ...` queries) and not as part of `create table` statements. I assume they are persisted as part of the `create` statement to improve performance?

I've ran:
`tox -e unit`
`tox -e integration-databricks-uc-sql-endpoint`
`tox -e integration-databricks-uc-cluster`

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
