### PR TITLE
fix: race condition on cluster creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Always use lower case when gathering metadata (since objects are stored internally as lower case regardless of how we create them) ([742](https://github.com/databricks/dbt-databricks/pull/742))
 - Persist table comments for python models ([743](https://github.com/databricks/dbt-databricks/pull/743))
 - Stop cursor destructor warnings ([744](https://github.com/databricks/dbt-databricks/pull/744))
-- Race condition on cluster creation([751](https://github.com/databricks/dbt-databricks/pull/751))
+- Race condition on cluster creation. (thanks @jurasan!) ([751](https://github.com/databricks/dbt-databricks/pull/751))
 
 ## dbt-databricks 1.8.4 (July 17, 2024)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Always use lower case when gathering metadata (since objects are stored internally as lower case regardless of how we create them) ([742](https://github.com/databricks/dbt-databricks/pull/742))
 - Persist table comments for python models ([743](https://github.com/databricks/dbt-databricks/pull/743))
 - Stop cursor destructor warnings ([744](https://github.com/databricks/dbt-databricks/pull/744))
+- Race condition on cluster creation([751](https://github.com/databricks/dbt-databricks/pull/751))
 
 ## dbt-databricks 1.8.4 (July 17, 2024)
 

--- a/dbt/adapters/databricks/python_submissions.py
+++ b/dbt/adapters/databricks/python_submissions.py
@@ -395,7 +395,9 @@ class DBContext:
             json={"cluster_id": self.cluster_id},
         )
         if response.status_code != 200:
-            raise DbtRuntimeError(f"Error starting terminated cluster.\n {response.content!r}")
+            current_status = self.get_cluster_status().get("state", "").upper()
+            if current_status not in ["RUNNING", "PENDING"]:
+                raise DbtRuntimeError(f"Error starting terminated cluster.\n {response.content!r}")
 
         self._wait_for_cluster_to_start()
 


### PR DESCRIPTION
Resolves #347

### Description

When multiple threads attempt to start a cluster, it's possible that the check [here](https://github.com/databricks/dbt-databricks/blob/37e16a5b5238f0d8cb7b99777db9fb6e8efeb7f3/dbt/adapters/databricks/python_submissions.py#L334) is True, but by the time it tries to trigger cluster start [here](https://github.com/databricks/dbt-databricks/blob/37e16a5b5238f0d8cb7b99777db9fb6e8efeb7f3/dbt/adapters/databricks/python_submissions.py#L392), the cluster has already been started by another thread and is in "RUNNING" or "PENDING" status. 

In such cases API returns an error "Cluster [cluster_id] is in unexpected state Pending." or "Cluster [cluster_id] is in unexpected state Running."
Current logic throws exceptions in this case. This fix allows it to continue and wait for cluster start if needed. 

This could probably be also backported to versions 1.6 and 1.7

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.

