### PR TITLE
fix dbt-databricks scopes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 
 ### Fixes
 
-- Fix the default scope for `dbt-databricks` to `all-apis` so it can run python models
+- Fix the default scope for `dbt-databricks` to `all-apis` so it can run python models([772](https://github.com/databricks/dbt-databricks/pull/772))
 
 ### Under the Hood
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 - Add support for serverless job clusters on python models ([706](https://github.com/databricks/dbt-databricks/pull/706))
 - Add 'user_folder_for_python' config to switch writing python model notebooks to the user's folder ([706](https://github.com/databricks/dbt-databricks/pull/706))
 
+### Fixes
+
+- Fix the default scope for `dbt-databricks` to `all-apis` so it can run python models
+
 ### Under the Hood
 
 - Fix places where we were not properly closing cursors, and other test warnings ([713](https://github.com/databricks/dbt-databricks/pull/713))

--- a/dbt/adapters/databricks/credentials.py
+++ b/dbt/adapters/databricks/credentials.py
@@ -273,17 +273,8 @@ class DatabricksCredentials(Credentials):
                 return provider
 
             client_id = self.client_id or CLIENT_ID
-
-            if client_id == "dbt-databricks":
-                # This is the temp code to make client id dbt-databricks work with server,
-                # currently the redirect url and scope for client dbt-databricks are fixed
-                # values as below. It can be removed after Databricks extends dbt-databricks
-                # scope to all-apis
-                redirect_url = "http://localhost:8050"
-                scopes = ["sql", "offline_access"]
-            else:
-                redirect_url = self.oauth_redirect_url or REDIRECT_URL
-                scopes = self.oauth_scopes or SCOPES
+            redirect_url = self.oauth_redirect_url or REDIRECT_URL
+            scopes = self.oauth_scopes or SCOPES
 
             oauth_client = OAuthClient(
                 host=host,


### PR DESCRIPTION
<!-- Please review our pull request review process in CONTRIBUTING.md before your proceed. -->


<!---
  Include the number of the issue addressed by this PR above if applicable.

  Example:
    resolves #1234

  Please review our pull request review process in CONTRIBUTING.md before your proceed.
-->

### Description

This change only affect U2M OAuth for dbt-databricks.
The dbt-databricks oauth app has changed its scope to all-apis, offline_access, the redirect url has been changed to http://localhost:8020, http://localhost:8050. This will enable customer being able to use the default dbt-databricks oauth app to run python models.
The scope/redirect_url changes have already landed in all AWS & GCP regions, for Azure the govCloud regions are still pending.
But since for Azure there is another bug that we need to fix to use this dbt-databricks client, it is fine for this PR to land without fully ramped up in Azure.

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
