### PR TITLE
Issue 747 primary key autoname

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### Fixes
 
 - Persist table comments for incremental models, snapshots and dbt clone (thanks @henlue!) ([750](https://github.com/databricks/dbt-databricks/pull/750))
-- Add relation identifier (i.e. table name) in auto generated constraint names, also adding the statement of table list for foreign keys
+- Add relation identifier (i.e. table name) in auto generated constraint names, also adding the statement of table list for foreign keys  ([774](https://github.com/databricks/dbt-databricks/pull/774))
 
 ## dbt-databricks 1.8.5 (August 6, 2024)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### Fixes
 
 - Persist table comments for incremental models, snapshots and dbt clone (thanks @henlue!) ([750](https://github.com/databricks/dbt-databricks/pull/750))
-- Add relation identifier (i.e. table name) in auto generated constraint names, also adding the statement of table list for foreign keys  ([774](https://github.com/databricks/dbt-databricks/pull/774))
+- Add relation identifier (i.e. table name) in auto generated constraint names, also adding the statement of table list for foreign keys (thanks @elca-anh!) ([774](https://github.com/databricks/dbt-databricks/pull/774))
 - Update tblproperties on incremental runs. Note: only adds/edits. Deletes are too risky/complex for now ([765](https://github.com/databricks/dbt-databricks/pull/765))
 
 ## dbt-databricks 1.8.5 (August 6, 2024)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -460,6 +460,7 @@ Throw an error if a model has an enforced contract. ([#322](https://github.com/d
 - Implement testing for a test for various Python models ([#189](https://github.com/databricks/dbt-databricks/pull/189))
 - Implement testing for `type_boolean` in Databricks ([dbt-labs/dbt-spark#471](https://github.com/dbt-labs/dbt-spark/pull/471), [#188](https://github.com/databricks/dbt-databricks/pull/188))
 - Add a macro to support [COPY INTO](https://docs.databricks.com/spark/latest/spark-sql/language-manual/delta-copy-into.html) ([#190](https://github.com/databricks/dbt-databricks/pull/190))
+- Add relation identifier (i.e. table name) in auto generated constraint names, also adding the statement of table list for foreign keys
 
 ### Under the hood
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Fixes
 
 - Persist table comments for incremental models, snapshots and dbt clone (thanks @henlue!) ([750](https://github.com/databricks/dbt-databricks/pull/750))
+- Add relation identifier (i.e. table name) in auto generated constraint names, also adding the statement of table list for foreign keys
 
 ## dbt-databricks 1.8.5 (August 6, 2024)
 
@@ -460,7 +461,6 @@ Throw an error if a model has an enforced contract. ([#322](https://github.com/d
 - Implement testing for a test for various Python models ([#189](https://github.com/databricks/dbt-databricks/pull/189))
 - Implement testing for `type_boolean` in Databricks ([dbt-labs/dbt-spark#471](https://github.com/dbt-labs/dbt-spark/pull/471), [#188](https://github.com/databricks/dbt-databricks/pull/188))
 - Add a macro to support [COPY INTO](https://docs.databricks.com/spark/latest/spark-sql/language-manual/delta-copy-into.html) ([#190](https://github.com/databricks/dbt-databricks/pull/190))
-- Add relation identifier (i.e. table name) in auto generated constraint names, also adding the statement of table list for foreign keys
 
 ### Under the hood
 

--- a/dbt/include/databricks/macros/relations/constraints.sql
+++ b/dbt/include/databricks/macros/relations/constraints.sql
@@ -148,9 +148,13 @@
     {% set joined_names = quoted_names|join(", ") %}
 
     {% set name = constraint.get("name") %}
-    {% if not name and local_md5 %}
-      {{ exceptions.warn("Constraint of type " ~ type ~ " with no `name` provided. Generating hash instead.") }}
-      {%- set name = local_md5("primary_key;" ~ column_names ~ ";") -%}
+    {% if not name %}
+      {% if local_md5 %}
+        {{ exceptions.warn("Constraint of type " ~ type ~ " with no `name` provided. Generating hash instead.") }}
+        {%- set name = local_md5("primary_key;" ~ column_names ~ ";") -%}
+      {% else %}
+        {{ exceptions.raise_compiler_error("Constraint of type " ~ type ~ " with no `name` provided, and no md5 utility.") }}
+      {% endif %}
     {% endif %}
     {% set stmt = "alter table " ~ relation ~ " add constraint " ~ name ~ " primary key(" ~ joined_names ~ ");" %}
     {% do statements.append(stmt) %}

--- a/tests/unit/macros/relations/test_constraint_macros.py
+++ b/tests/unit/macros/relations/test_constraint_macros.py
@@ -253,7 +253,8 @@ class TestConstraintMacros(MacroTestBase):
         r = self.render_constraint_sql(template_bundle, constraint, model)
 
         expected = (
-            "['alter table `some_database`.`some_schema`.`some_table` add constraint hash(some_table;;id != name;) "
+            "['alter table `some_database`.`some_schema`.`some_table` "
+            "add constraint hash(some_table;;id != name;) "
             "check (id != name);']"
         )  # noqa: E501
         assert expected in r
@@ -351,8 +352,8 @@ class TestConstraintMacros(MacroTestBase):
 
         expected = (
             '["alter table `some_database`.`some_schema`.`some_table` add '
-            "constraint hash(foreign_key;some_table;['name'];some_schema.parent_table;) foreign key(name) references "
-            'some_schema.parent_table;"]'
+            "constraint hash(foreign_key;some_table;['name'];some_schema.parent_table;) "
+            'foreign key(name) references some_schema.parent_table;"]'
         )
         assert expected in r
 

--- a/tests/unit/macros/relations/test_constraint_macros.py
+++ b/tests/unit/macros/relations/test_constraint_macros.py
@@ -1,7 +1,6 @@
 import pytest
 
 from tests.unit.macros.base import MacroTestBase
-from dbt import utils
 
 
 class TestConstraintMacros(MacroTestBase):

--- a/tests/unit/macros/relations/test_constraint_macros.py
+++ b/tests/unit/macros/relations/test_constraint_macros.py
@@ -254,7 +254,7 @@ class TestConstraintMacros(MacroTestBase):
         r = self.render_constraint_sql(template_bundle, constraint, model)
 
         expected = (
-            "['alter table `some_database`.`some_schema`.`some_table` add constraint hash(;id != name;) "
+            "['alter table `some_database`.`some_schema`.`some_table` add constraint hash(some_table;;id != name;) "
             "check (id != name);']"
         )  # noqa: E501
         assert expected in r
@@ -313,7 +313,7 @@ class TestConstraintMacros(MacroTestBase):
         )
         assert expected in r
 
-    def test_macros_get_constraint_sql_primary_key_without_name(self, template_bundle, model):
+    def test_macros_get_constraint_sql_primary_key_noname(self, template_bundle, model):
         constraint = {
             "type": "primary_key"
         }
@@ -323,7 +323,7 @@ class TestConstraintMacros(MacroTestBase):
 
         expected = (
             '["alter table `some_database`.`some_schema`.`some_table` add constraint '
-            'hash(primary_key;[\'id\'];) '
+            'hash(primary_key;some_table;[\'id\'];) '
             'primary key(id);"]'
         )
         assert expected in r
@@ -341,6 +341,21 @@ class TestConstraintMacros(MacroTestBase):
             "['alter table `some_database`.`some_schema`.`some_table` add "
             "constraint myconstraint foreign key(name) references "
             "some_schema.parent_table;']"
+        )
+        assert expected in r
+
+    def test_macros_get_constraint_sql_foreign_key_noname(self, template_bundle, model):
+        constraint = {
+            "type": "foreign_key",
+            "columns": ["name"],
+            "parent": "parent_table",
+        }
+        r = self.render_constraint_sql(template_bundle, constraint, model)
+
+        expected = (
+            '["alter table `some_database`.`some_schema`.`some_table` add '
+            'constraint hash(foreign_key;some_table;[\'name\'];some_schema.parent_table;) foreign key(name) references '
+            'some_schema.parent_table;"]'
         )
         assert expected in r
 

--- a/tests/unit/macros/relations/test_constraint_macros.py
+++ b/tests/unit/macros/relations/test_constraint_macros.py
@@ -14,8 +14,8 @@ class TestConstraintMacros(MacroTestBase):
 
     @pytest.fixture(scope="class", autouse=True)
     def modify_context(self, default_context) -> None:
-         # Mock local_md5
-         default_context["local_md5"] = lambda s: f"hash({s})"
+        # Mock local_md5
+        default_context["local_md5"] = lambda s: f"hash({s})"
 
     def render_constraints(self, template, *args):
         return self.run_macro(template, "databricks_constraints_to_dbt", *args)
@@ -313,16 +313,14 @@ class TestConstraintMacros(MacroTestBase):
         assert expected in r
 
     def test_macros_get_constraint_sql_primary_key_noname(self, template_bundle, model):
-        constraint = {
-            "type": "primary_key"
-        }
+        constraint = {"type": "primary_key"}
         column = {"name": "id"}
 
         r = self.render_constraint_sql(template_bundle, constraint, model, column)
 
         expected = (
             '["alter table `some_database`.`some_schema`.`some_table` add constraint '
-            'hash(primary_key;some_table;[\'id\'];) '
+            "hash(primary_key;some_table;['id'];) "
             'primary key(id);"]'
         )
         assert expected in r
@@ -353,7 +351,7 @@ class TestConstraintMacros(MacroTestBase):
 
         expected = (
             '["alter table `some_database`.`some_schema`.`some_table` add '
-            'constraint hash(foreign_key;some_table;[\'name\'];some_schema.parent_table;) foreign key(name) references '
+            "constraint hash(foreign_key;some_table;['name'];some_schema.parent_table;) foreign key(name) references "
             'some_schema.parent_table;"]'
         )
         assert expected in r


### PR DESCRIPTION
Resolves #747 

### Description

- Add the relation identifier (i.e. table name) to the auto generated name of constraints
- For foreign-key constraints, add either the statement of the list of columns including the parent column

### Checklist

- [X] I have run this code in development and it appears to resolve the stated issue
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [X] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
