### PR TITLE
change oauth default scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Persist table comments for incremental models, snapshots and dbt clone (thanks @henlue!) ([750](https://github.com/databricks/dbt-databricks/pull/750))
 - Update tblproperties on incremental runs. Note: only adds/edits. Deletes are too risky/complex for now ([765](https://github.com/databricks/dbt-databricks/pull/765))
+- Update default scope/redirect Url for OAuth U2M, so with default OAuth app user can run python models ([776](https://github.com/databricks/dbt-databricks/pull/776))
 
 ## dbt-databricks 1.8.5 (August 6, 2024)
 

--- a/dbt/adapters/databricks/credentials.py
+++ b/dbt/adapters/databricks/credentials.py
@@ -273,17 +273,8 @@ class DatabricksCredentials(Credentials):
                 return provider
 
             client_id = self.client_id or CLIENT_ID
-
-            if client_id == "dbt-databricks":
-                # This is the temp code to make client id dbt-databricks work with server,
-                # currently the redirect url and scope for client dbt-databricks are fixed
-                # values as below. It can be removed after Databricks extends dbt-databricks
-                # scope to all-apis
-                redirect_url = "http://localhost:8050"
-                scopes = ["sql", "offline_access"]
-            else:
-                redirect_url = self.oauth_redirect_url or REDIRECT_URL
-                scopes = self.oauth_scopes or SCOPES
+            redirect_url = self.oauth_redirect_url or REDIRECT_URL
+            scopes = self.oauth_scopes or SCOPES
 
             oauth_client = OAuthClient(
                 host=host,


### PR DESCRIPTION
<!-- Please review our pull request review process in CONTRIBUTING.md before your proceed. -->

Resolves #

We have change the default scope for the dbt-databricks app to all-apis, offline_access, we also change the redirect url to https://localhost:8020, https://localhost:8050 in all AWS and GCP and Azure public regions. For Azure GovCloud regions it is still pending.
For Azure in the current python sdk(0.17.0) we will always redirect to [Azure endpoint](https://github.com/databricks/databricks-sdk-py/blob/v0.17.0/databricks/sdk/core.py#L841) so it does not affect how OAuth U2M works on Azure workspace at all.
This PR remove the hardcoded override for scopes and redirectUrls.

### Description

<!--- Describe the Pull Request here -->

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
