### PR TITLE
Add custom constraint option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
   - `matched`, `not matched` and `not matched by source` condition clauses;
   - custom aliases for source and target tables can be specified and used in condition clauses;
   - `matched` and `not matched` steps can now be skipped;
-- Allow for the use of custom constraints, using the `custom` constraint type with an `expression` as the constraint. ([792](https://github.com/databricks/dbt-databricks/pull/792))
+- Allow for the use of custom constraints, using the `custom` constraint type with an `expression` as the constraint (thanks @roydobbe). ([792](https://github.com/databricks/dbt-databricks/pull/792))
 
 
 ### Under the Hood

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@
 - Update tblproperties on incremental runs. Note: only adds/edits. Deletes are too risky/complex for now ([765](https://github.com/databricks/dbt-databricks/pull/765))
 - Update default scope/redirect Url for OAuth U2M, so with default OAuth app user can run python models ([776](https://github.com/databricks/dbt-databricks/pull/776))
 
+### Features
+
+- Allow for the use of custom constraints, using the `custom` constraint type with an `expression`. ([785](https://github.com/databricks/dbt-databricks/pull/785))
+
 ## dbt-databricks 1.8.5 (August 6, 2024)
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@
 
 ### Features
 
-- Allow for the use of custom constraints, using the `custom` constraint type with an `expression`. ([785](https://github.com/databricks/dbt-databricks/pull/785))
+- Allow for the use of custom constraints, using the `custom` constraint type with an `expression`. ([786](https://github.com/databricks/dbt-databricks/pull/786))
 
 ## dbt-databricks 1.8.5 (August 6, 2024)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
   - `matched`, `not matched` and `not matched by source` condition clauses;
   - custom aliases for source and target tables can be specified and used in condition clauses;
   - `matched` and `not matched` steps can now be skipped;
+- Allow for the use of custom constraints, using the `custom` constraint type with an `expression` as the constraint. ([792](https://github.com/databricks/dbt-databricks/pull/792))
+
 
 ### Under the Hood
 
@@ -24,10 +26,6 @@
 - Add relation identifier (i.e. table name) in auto generated constraint names, also adding the statement of table list for foreign keys (thanks @elca-anh!) ([774](https://github.com/databricks/dbt-databricks/pull/774))
 - Update tblproperties on incremental runs. Note: only adds/edits. Deletes are too risky/complex for now ([765](https://github.com/databricks/dbt-databricks/pull/765))
 - Update default scope/redirect Url for OAuth U2M, so with default OAuth app user can run python models ([776](https://github.com/databricks/dbt-databricks/pull/776))
-
-### Features
-
-- Allow for the use of custom constraints, using the `custom` constraint type with an `expression`. ([786](https://github.com/databricks/dbt-databricks/pull/786))
 
 ## dbt-databricks 1.8.5 (August 6, 2024)
 

--- a/dbt/include/databricks/macros/relations/constraints.sql
+++ b/dbt/include/databricks/macros/relations/constraints.sql
@@ -238,7 +238,7 @@
   {% elif type == 'custom' %}
     {% set expression = constraint.get("expression", "") %}
     {% if not expression %}
-      {{ exceptions.raise_compiler_error('Invalid check constraint expression') }}
+      {{ exceptions.raise_compiler_error('Missing custom constraint expression') }}
     {% endif %}
 
     {% set name = constraint.get("name") %}

--- a/dbt/include/databricks/macros/relations/constraints.sql
+++ b/dbt/include/databricks/macros/relations/constraints.sql
@@ -19,8 +19,8 @@
       {# Constraints are not applied for incremental updates. This point in the code should not have been reached #}
       {{ exceptions.raise_compiler_error("Constraints are not applied for incremental updates. Full refresh is required to update constraints.") }}
     {% else %}
-      {% do alter_column_set_constraints(relation, model) %}
       {% do alter_table_add_constraints(relation, model) %}
+      {% do alter_column_set_constraints(relation, model) %}
     {% endif %}
   {% endif %}
 {% endmacro %}
@@ -79,8 +79,18 @@
 
 {% macro get_constraints_sql(relation, constraints, model, column={}) %}
   {% set statements = [] %}
-  -- Hack so that not null constraints will be applied before primary key constraints
-  {% for constraint in constraints|sort(attribute='type') %}
+  -- Hack so that not null constraints will be applied before other constraints
+  {% for constraint in constraints|selectattr('type', 'eq', 'not_null') %}
+    {% if constraint %}
+      {% set constraint_statements = get_constraint_sql(relation, constraint, model, column) %}
+      {% for statement in constraint_statements %}
+        {% if statement %}
+          {% do statements.append(statement) %}
+        {% endif %}
+      {% endfor %}
+    {% endif %}
+  {% endfor %}
+  {% for constraint in constraints|rejectattr('type', 'eq', 'not_null') %}
     {% if constraint %}
       {% set constraint_statements = get_constraint_sql(relation, constraint, model, column) %}
       {% for statement in constraint_statements %}
@@ -105,13 +115,9 @@
     {% endif %}
 
     {% set name = constraint.get("name") %}
-    {% if not name %}
-      {% if local_md5 %}
-        {{ exceptions.warn("Constraint of type " ~ type ~ " with no `name` provided. Generating hash instead for relation " ~ relation.identifier) }}
-        {%- set name = local_md5 (relation.identifier ~ ";" ~ column.get("name", "") ~ ";" ~ expression ~ ";") -%}
-      {% else %}
-        {{ exceptions.raise_compiler_error("Constraint of type " ~ type ~ " with no `name` provided, and no md5 utility.") }}
-      {% endif %}
+    {% if not name and local_md5 %}
+      {{ exceptions.warn("Constraint of type " ~ type ~ " with no `name` provided. Generating hash instead.") }}
+      {%- set name = local_md5 (column.get("name", "") ~ ";" ~ expression ~ ";") -%}
     {% endif %}
     {% set stmt = "alter table " ~ relation ~ " add constraint " ~ name ~ " check (" ~ expression ~ ");" %}
     {% do statements.append(stmt) %}
@@ -152,13 +158,9 @@
     {% set joined_names = quoted_names|join(", ") %}
 
     {% set name = constraint.get("name") %}
-    {% if not name %}
-      {% if local_md5 %}
-        {{ exceptions.warn("Constraint of type " ~ type ~ " with no `name` provided. Generating hash instead for relation " ~ relation.identifier) }}
-        {%- set name = local_md5("primary_key;" ~ relation.identifier ~ ";" ~ column_names ~ ";") -%}
-      {% else %}
-        {{ exceptions.raise_compiler_error("Constraint of type " ~ type ~ " with no `name` provided, and no md5 utility.") }}
-      {% endif %}
+    {% if not name and local_md5 %}
+      {{ exceptions.warn("Constraint of type " ~ type ~ " with no `name` provided. Generating hash instead.") }}
+      {%- set name = local_md5("primary_key;" ~ column_names ~ ";") -%}
     {% endif %}
     {% set stmt = "alter table " ~ relation ~ " add constraint " ~ name ~ " primary key(" ~ joined_names ~ ");" %}
     {% do statements.append(stmt) %}
@@ -169,18 +171,12 @@
     {% endif %}
 
     {% set name = constraint.get("name") %}
-    
+    {% if not name and local_md5 %}
+      {{ exceptions.warn("Constraint of type " ~ type ~ " with no `name` provided. Generating hash instead.") }}
+      {%- set name = local_md5("primary_key;" ~ column_names ~ ";") -%}
+    {% endif %}
+
     {% if constraint.get('expression') %}
-
-      {% if not name %}
-        {% if local_md5 %}
-          {{ exceptions.warn("Constraint of type " ~ type ~ " with no `name` provided. Generating hash instead for relation " ~ relation.identifier) }}
-          {%- set name = local_md5("foreign_key;" ~ relation.identifier ~ ";" ~ constraint.get('expression') ~ ";") -%}
-        {% else %}
-          {{ exceptions.raise_compiler_error("Constraint of type " ~ type ~ " with no `name` provided, and no md5 utility.") }}
-        {% endif %}    
-      {% endif %}
-
       {% set stmt = "alter table " ~ relation ~ " add constraint " ~ name ~ " foreign key" ~ constraint.get('expression') %}
     {% else %}
       {% set column_names = constraint.get("columns", []) %}
@@ -207,16 +203,6 @@
       {% if not "." in parent %}
         {% set parent = relation.schema ~ "." ~ parent%}
       {% endif %}
-
-      {% if not name %}
-        {% if local_md5 %}
-          {{ exceptions.warn("Constraint of type " ~ type ~ " with no `name` provided. Generating hash instead for relation " ~ relation.identifier) }}
-          {%- set name = local_md5("foreign_key;" ~ relation.identifier ~ ";" ~ column_names ~ ";" ~ parent ~ ";") -%}
-        {% else %}
-          {{ exceptions.raise_compiler_error("Constraint of type " ~ type ~ " with no `name` provided, and no md5 utility.") }}
-        {% endif %}    
-      {% endif %}
-
       {% set stmt = "alter table " ~ relation ~ " add constraint " ~ name ~ " foreign key(" ~ joined_names ~ ") references " ~ parent %}
       {% set parent_columns = constraint.get("parent_columns") %}
       {% if parent_columns %}
@@ -224,6 +210,20 @@
       {% endif %}
     {% endif %}
     {% set stmt = stmt ~ ";" %}
+    {% do statements.append(stmt) %}
+  {% elif type == 'custom' %}
+    {% set expression = constraint.get("expression", "") %}
+    {% if not expression %}
+      {{ exceptions.raise_compiler_error('Invalid check constraint expression') }}
+    {% endif %}
+
+    {% set name = constraint.get("name") %}
+    {% set expression = constraint.get("expression") %}
+    {% if not name and local_md5 %}
+      {{ exceptions.warn("Constraint of type " ~ type ~ " with no `name` provided. Generating hash instead.") }}
+      {%- set name = local_md5(expression ~ ";") -%}
+    {% endif %}
+    {% set stmt = "alter table " ~ relation ~ " add constraint " ~ name ~ " " ~ expression ~ ";" %}
     {% do statements.append(stmt) %}
   {% elif constraint.get('warn_unsupported') %}
     {{ exceptions.warn("unsupported constraint type: " ~ constraint.type)}}

--- a/tests/unit/macros/relations/test_constraint_macros.py
+++ b/tests/unit/macros/relations/test_constraint_macros.py
@@ -414,27 +414,27 @@ class TestConstraintMacros(MacroTestBase):
         constraint = {
             "type": "custom",
             "name": "myconstraint",
-            "expression": "PRIMARY KEY(valid_at, TIMESERIES)",
+            "expression": "PRIMARY KEY(valid_at TIMESERIES)",
         }
         r = self.render_constraint_sql(template_bundle, constraint, model)
 
         expected = (
             "['alter table `some_database`.`some_schema`.`some_table` add constraint "
-            "myconstraint PRIMARY KEY(valid_at, TIMESERIES);']"
+            "myconstraint PRIMARY KEY(valid_at TIMESERIES);']"
         )
         assert expected in r
 
     def test_macros_get_constraint_sql_custom_noname_constraint(self, template_bundle, model):
         constraint = {
             "type": "custom",
-            "expression": "PRIMARY KEY(valid_at, TIMESERIES)",
+            "expression": "PRIMARY KEY(valid_at TIMESERIES)",
         }
         r = self.render_constraint_sql(template_bundle, constraint, model)
 
         expected = (
             "['alter table `some_database`.`some_schema`.`some_table` "
-            "add constraint hash(some_table;PRIMARY KEY(valid_at, TIMESERIES);) "
-            "PRIMARY KEY(valid_at, TIMESERIES);']"
+            "add constraint hash(some_table;PRIMARY KEY(valid_at TIMESERIES);) "
+            "PRIMARY KEY(valid_at TIMESERIES);']"
         )  # noqa: E501
         assert expected in r
 

--- a/tests/unit/macros/relations/test_constraint_macros.py
+++ b/tests/unit/macros/relations/test_constraint_macros.py
@@ -409,3 +409,40 @@ class TestConstraintMacros(MacroTestBase):
             "some_schema.parent_table(parent_name);']"
         )
         assert expected in r
+
+    def test_macros_get_constraint_sql_custom(self, template_bundle, model):
+        constraint = {
+            "type": "custom",
+            "name": "myconstraint",
+            "expression": "PRIMARY KEY(valid_at, TIMESERIES)",
+        }
+        r = self.render_constraint_sql(template_bundle, constraint, model)
+
+        expected = (
+            "['alter table `some_database`.`some_schema`.`some_table` add constraint "
+            "myconstraint PRIMARY KEY(valid_at, TIMESERIES);']"
+        )
+        assert expected in r
+
+    def test_macros_get_constraint_sql_custom_noname_constraint(self, template_bundle, model):
+        constraint = {
+            "type": "custom",
+            "expression": "PRIMARY KEY(valid_at, TIMESERIES)",
+        }
+        r = self.render_constraint_sql(template_bundle, constraint, model)
+
+        expected = (
+            "['alter table `some_database`.`some_schema`.`some_table` "
+            "add constraint hash(PRIMARY KEY(valid_at, TIMESERIES);) "
+            "PRIMARY KEY(valid_at, TIMESERIES);']"
+        )  # noqa: E501
+        assert expected in r
+
+    def test_macros_get_constraint_sql_custom_missing_expression(self, template_bundle, model):
+        constraint = {
+            "type": "check",
+            "expression": "",
+            "name": "myconstraint",
+        }
+        r = self.render_constraint_sql(template_bundle, constraint, model)
+        assert "raise_compiler_error" in r

--- a/tests/unit/macros/relations/test_constraint_macros.py
+++ b/tests/unit/macros/relations/test_constraint_macros.py
@@ -433,7 +433,7 @@ class TestConstraintMacros(MacroTestBase):
 
         expected = (
             "['alter table `some_database`.`some_schema`.`some_table` "
-            "add constraint hash(PRIMARY KEY(valid_at, TIMESERIES);) "
+            "add constraint hash(some_table;PRIMARY KEY(valid_at, TIMESERIES);) "
             "PRIMARY KEY(valid_at, TIMESERIES);']"
         )  # noqa: E501
         assert expected in r


### PR DESCRIPTION
### Description

Added an option to create custom constraints. A usecase could be creating TIMESERIES primary keys.

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
