### PR TITLE
Fix for describe column types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Update default scope/redirect Url for OAuth U2M, so with default OAuth app user can run python models ([776](https://github.com/databricks/dbt-databricks/pull/776))
 - Fix foreign key constraints by switching from `parent` to `to` and `parent_columns` to `to_columns` ([789](https://github.com/databricks/dbt-databricks/pull/789))
 - Now handles external shallow clones without blowing up ([795](https://github.com/databricks/dbt-databricks/pull/795))
+- Use information_schema to get column types when possible, since describe extended truncates complex types ([796](https://github.com/databricks/dbt-databricks/pull/796))
 
 ## dbt-databricks 1.8.5 (August 6, 2024)
 

--- a/dbt/adapters/databricks/impl.py
+++ b/dbt/adapters/databricks/impl.py
@@ -49,7 +49,7 @@ from dbt.adapters.databricks.python_submissions import (
 from dbt.adapters.databricks.python_submissions import (
     DbtDatabricksJobClusterPythonJobHelper,
 )
-from dbt.adapters.databricks.relation import DatabricksRelation, is_hive_metastore
+from dbt.adapters.databricks.relation import DatabricksRelation
 from dbt.adapters.databricks.relation import DatabricksRelationType
 from dbt.adapters.databricks.relation import KEY_TABLE_PROVIDER
 from dbt.adapters.databricks.relation_configs.base import DatabricksRelationConfig

--- a/dbt/adapters/databricks/impl.py
+++ b/dbt/adapters/databricks/impl.py
@@ -170,7 +170,7 @@ class DatabricksAdapter(SparkAdapter):
     # For now does nothing
     @property
     def _behavior_flags(self) -> List[BehaviorFlag]:
-        return [{"name": "column_types_from_information_schema", "default": False}]
+        return [{"name": "column_types_from_information_schema", "default": False}]  # type: ignore
 
     # override/overload
     def acquire_connection(

--- a/dbt/adapters/databricks/impl.py
+++ b/dbt/adapters/databricks/impl.py
@@ -166,6 +166,8 @@ class DatabricksAdapter(SparkAdapter):
         }
     )
 
+    # This will begin working once we have 1.9 of dbt-core.
+    # For now does nothing
     @property
     def _behavior_flags(self) -> List[BehaviorFlag]:
         return [{"name": "column_types_from_information_schema", "default": False}]
@@ -384,8 +386,9 @@ class DatabricksAdapter(SparkAdapter):
         self, relation: DatabricksRelation
     ) -> List[DatabricksColumn]:
         if (
-            self.behavior.column_types_from_information_schema  # type: ignore
-            and not relation.is_hive_metastore()
+            # We can uncomment this once behavior flags are available to adapters
+            # self.behavior.column_types_from_information_schema and # type: ignore
+            not relation.is_hive_metastore()
         ):
             return self._get_columns_in_relation_by_information_schema(relation)
         else:
@@ -405,11 +408,7 @@ class DatabricksAdapter(SparkAdapter):
 
         columns = []
         for row in rows:
-            columns.append(
-                DatabricksColumn(
-                    column=row["columm_name"], dtype=row["full_data_type"], comment=row["comment"]
-                )
-            )
+            columns.append(DatabricksColumn(column=row[0], dtype=row[1], comment=row[2]))
 
         return columns
 

--- a/dbt/include/databricks/macros/adapters/persist_docs.sql
+++ b/dbt/include/databricks/macros/adapters/persist_docs.sql
@@ -29,7 +29,7 @@
 {% endmacro %}
 
 {% macro get_columns_comments_via_information_schema(relation) -%}
-  {% call statement('get_columns_comments', fetch_result=True) -%}
+  {% call statement('get_columns_comments_via_information_schema', fetch_result=True) -%}
     select
       column_name,
       full_data_type,

--- a/dbt/include/databricks/macros/adapters/persist_docs.sql
+++ b/dbt/include/databricks/macros/adapters/persist_docs.sql
@@ -28,6 +28,22 @@
   {% do return(load_result('get_columns_comments').table) %}
 {% endmacro %}
 
+{% macro get_columns_comments_via_information_schema(relation) -%}
+  {% call statement('get_columns_comments', fetch_result=True) -%}
+    select
+      column_name,
+      full_data_type,
+      comment
+    from `system`.`information_schema`.`columns`
+    where
+      table_catalog = '{{ relation.database|lower }}' and
+      table_schema = '{{ relation.schema|lower }}' and 
+      table_name = '{{ relation.identifier|lower }}'
+  {% endcall %}
+
+  {% do return(load_result('get_columns_comments_via_information_schema').table) %}
+{% endmacro %}
+
 {% macro databricks__persist_docs(relation, model, for_relation, for_columns) -%}
   {%- if for_relation and config.persist_relation_docs() and model.description %}
     {% do alter_table_comment(relation, model) %}

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -15,4 +15,4 @@ types-requests
 types-mock
 pre-commit
 
-dbt-tests-adapter~=1.8.0
+dbt-tests-adapter~=1.9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 databricks-sql-connector>=3.1.0, <3.2.0
 dbt-spark~=1.8.0
 dbt-core>=1.8.0, <2.0
-dbt-adapters>=1.3.0, <2.0
+dbt-adapters>=1.6.0, <2.0
 databricks-sdk==0.17.0
 keyring>=23.13.0
 pandas<2.2.0

--- a/tests/functional/adapter/columns/fixtures.py
+++ b/tests/functional/adapter/columns/fixtures.py
@@ -9,7 +9,5 @@ models:
   - name: base_model
     columns:
       - name: struct_col
-        description: 'A struct column'
       - name: str_col
-        description: 'A string column'
 """

--- a/tests/functional/adapter/columns/fixtures.py
+++ b/tests/functional/adapter/columns/fixtures.py
@@ -1,0 +1,15 @@
+base_model = """
+select struct('a', 1, 'b', 'b', 'c', ARRAY(1,2,3)) as struct_col, 'hello' as str_col
+"""
+
+schema = """
+version: 2
+
+models:
+  - name: base_model
+    columns:
+      - name: struct_col
+        description: 'A struct column'
+      - name: str_col
+        description: 'A string column'
+"""

--- a/tests/functional/adapter/columns/test_get_columns.py
+++ b/tests/functional/adapter/columns/test_get_columns.py
@@ -1,0 +1,48 @@
+import pytest
+
+from dbt.adapters.databricks.column import DatabricksColumn
+from dbt.adapters.databricks.relation import DatabricksRelation
+from tests.functional.adapter.columns import fixtures
+from dbt.tests import util
+
+
+class ColumnsInRelation:
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"base_model.sql": fixtures.base_model, "schema.yml": fixtures.schema}
+
+    @pytest.fixture(scope="class", autouse=True)
+    def setup(self, project):
+        util.run_dbt(["run"])
+
+    @pytest.fixture(scope="class")
+    def expected_columns(self):
+        return [
+            DatabricksColumn(column="struct_col", dtype="struct", comment="A struct column"),
+            DatabricksColumn(column="str_col", dtype="string", comment="A string column"),
+        ]
+
+    def test_columns_in_relation(self, project, expected_columns):
+        my_relation = DatabricksRelation.create(
+            database=project.database,
+            schema=project.test_schema,
+            identifier="base_model",
+            type=DatabricksRelation.Table,
+        )
+
+        with project.adapter.connection_named("_test"):
+            actual_columns = project.adapter.get_columns_in_relation(my_relation)
+        assert actual_columns == expected_columns
+
+
+class TestColumnsInRelationBehaviorFlagOff(ColumnsInRelation):
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {"flags": {}}
+
+
+class TestColumnsInRelationBehaviorFlagOn(ColumnsInRelation):
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {"flags": {"column_types_from_information_schema": True}}

--- a/tests/functional/adapter/columns/test_get_columns.py
+++ b/tests/functional/adapter/columns/test_get_columns.py
@@ -18,9 +18,16 @@ class ColumnsInRelation:
 
     @pytest.fixture(scope="class")
     def expected_columns(self):
+
         return [
-            DatabricksColumn(column="struct_col", dtype="struct", comment="A struct column"),
-            DatabricksColumn(column="str_col", dtype="string", comment="A string column"),
+            DatabricksColumn(
+                column="struct_col",
+                dtype=(
+                    "struct<col1:string,col2:int,col3:string,"
+                    "col4:string,col5:string,col6:array<int>>"
+                ),
+            ),
+            DatabricksColumn(column="str_col", dtype="string"),
         ]
 
     def test_columns_in_relation(self, project, expected_columns):


### PR DESCRIPTION
<!-- Please review our pull request review process in CONTRIBUTING.md before your proceed. -->

Resolves #779 (for UC)

<!---
  Include the number of the issue addressed by this PR above if applicable.

  Example:
    resolves #1234

  Please review our pull request review process in CONTRIBUTING.md before your proceed.
-->

### Description

`DESCRIBE EXTENDED` truncates column types.  For generating doc site, this is ok, but for running a dbt project, it can cause issues.  Where information_schema is available, we can use it to get an un-truncated column type.  Initially I was going to hide this behind a behavior flag, since both methods can have performance issues; however, during implementation I discovered that behavior flags aren't available to adapters yet, due to the current dbt-core not having flags on the RuntimeConfig object.  So, plan is to use information_schema where available, as it is more correct.  Once behavior flags are available, we can allow users to choose, so that if one way is less performant, they can switch.

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
