### PR TITLE
Sync metadata before asking for column definitions

### DIFF
--- a/dbt/adapters/databricks/impl.py
+++ b/dbt/adapters/databricks/impl.py
@@ -73,10 +73,12 @@ from dbt.adapters.spark.impl import KEY_TABLE_STATISTICS
 from dbt.adapters.spark.impl import LIST_SCHEMAS_MACRO_NAME
 from dbt.adapters.spark.impl import SparkAdapter
 from dbt.adapters.spark.impl import TABLE_OR_VIEW_NOT_FOUND_MESSAGES
-from dbt_common.behavior_flags import BehaviorFlag
+
+# from dbt_common.behavior_flags import BehaviorFlag
 from dbt_common.exceptions import DbtRuntimeError
 from dbt_common.utils import executor
 from dbt_common.utils.dict import AttrDict
+
 
 if TYPE_CHECKING:
     from agate import Row
@@ -167,10 +169,9 @@ class DatabricksAdapter(SparkAdapter):
     )
 
     # This will begin working once we have 1.9 of dbt-core.
-    # For now does nothing
-    @property
-    def _behavior_flags(self) -> List[BehaviorFlag]:
-        return [{"name": "column_types_from_information_schema", "default": False}]  # type: ignore
+    # @property
+    # def _behavior_flags(self) -> List[BehaviorFlag]:
+    #     return [{"name": "column_types_from_information_schema", "default": False}]
 
     # override/overload
     def acquire_connection(

--- a/dbt/include/databricks/macros/adapters/persist_docs.sql
+++ b/dbt/include/databricks/macros/adapters/persist_docs.sql
@@ -29,6 +29,9 @@
 {% endmacro %}
 
 {% macro get_columns_comments_via_information_schema(relation) -%}
+  {% call statement('repair_table', fetch_result=False) -%}
+    MSCK REPAIR TABLE {{ relation|lower }} SYNC METADATA
+  {% endcall %}
   {% call statement('get_columns_comments_via_information_schema', fetch_result=True) -%}
     select
       column_name,


### PR DESCRIPTION
<!---
  Include the number of the issue addressed by this PR above if applicable.

  Example:
    resolves #1234

  Please review our pull request review process in CONTRIBUTING.md before your proceed.
-->

### Description

After switching to using information_schema where possible to get column types to address the issue of describe truncation them, I discovered that information_schema is off out of sync when this call is made.  I discovered this by running an incremental job twice.  On the second run, the columns for some tables from the first run were available in information_schema.  This PR forces metadata sync before getting column information to ensure the information_schema is up to date.  We should probably use this technique more pervasively, but I do want to hold off on that until we have behavior flags, since it could have a performance impact.

Also, commenting out behavior flags for now, because support doesn't exist yet in dbt-core 1.8

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
