### PR TITLE
Stop setting cluster by to None

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-## dbt-databricks TBD (TBD)
+## dbt-databricks 1.8.7 (TBD)
+
+### Fixes
+
+- Stop setting cluster by to None. If you want to drop liquid clustering, you will need to full-refresh ([806]https://github.com/databricks/dbt-databricks/pull/806)
 
 ## dbt-databricks 1.8.6 (September 18, 2024)
 

--- a/dbt/include/databricks/macros/relations/liquid_clustering.sql
+++ b/dbt/include/databricks/macros/relations/liquid_clustering.sql
@@ -9,19 +9,13 @@
 {%- endmacro -%}
 
 {% macro apply_liquid_clustered_cols(target_relation) -%}
-  {%- set file_format = config.get('file_format', default='delta') -%}
-  {%- set partition_by = config.get('partition_by', validator=validation.any[list, basestring], default=None) -%}
   {%- set cols = config.get('liquid_clustered_by', validator=validation.any[list, basestring]) -%}
   {%- if cols is not none %}
     {%- if cols is string -%}
       {%- set cols = [cols] -%}
-    {%- endif -%}      
+    {%- endif -%}
     {%- call statement('set_cluster_by_columns') -%}
         ALTER {{ target_relation.type }} {{ target_relation }} CLUSTER BY ({{ cols | join(', ') }})
-    {%- endcall -%}
-  {%- elif not target_relation.is_hive_metastore() and file_format == "delta" and not partition_by -%}
-    {%- call statement('unset_cluster_by_columns') -%}
-        ALTER {{ target_relation.type }} {{ target_relation }} CLUSTER BY NONE
     {%- endcall -%}
   {%- endif %}
 {%- endmacro -%}


### PR DESCRIPTION
<!-- Please review our pull request review process in CONTRIBUTING.md before your proceed. -->

Resolves #805

### Description

This fixes 805, though 805 raises a bigger question about whether its reasonable for users to materialize things outside of dbt, and expect dbt to handle that gracefully if you don't add matching config to the project.  Setting that aside, actually getting rid of this clause because I think it's more reasonable for someone to do a full refresh if they want to get rid of liquid clustering than it is to run cluster by none on every Delta incremental run.

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
