### PR TITLE
Behavior: Get column info from information_schema Part I

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
   - custom aliases for source and target tables can be specified and used in condition clauses;
   - `matched` and `not matched` steps can now be skipped;
 - Allow for the use of custom constraints, using the `custom` constraint type with an `expression` as the constraint (thanks @roydobbe). ([792](https://github.com/databricks/dbt-databricks/pull/792))
+- Add "use_info_schema_for_columns" behavior flag to turn on use of information_schema to get column info where possible. This may have more latency but will not truncate complex data types the way that 'describe' can. ([808](https://github.com/databricks/dbt-databricks/pull/808))
 
 ### Under the Hood
 

--- a/dbt/adapters/databricks/behaviors/columns.py
+++ b/dbt/adapters/databricks/behaviors/columns.py
@@ -1,0 +1,70 @@
+from abc import ABC, abstractmethod
+from typing import List
+from dbt.adapters.sql import SQLAdapter
+from dbt.adapters.databricks.column import DatabricksColumn
+from dbt.adapters.databricks.relation import DatabricksRelation
+from dbt.adapters.databricks.utils import handle_missing_objects
+from dbt_common.utils.dict import AttrDict
+
+GET_COLUMNS_COMMENTS_MACRO_NAME = "get_columns_comments"
+
+
+class GetColumnsBehavior(ABC):
+    @classmethod
+    @abstractmethod
+    def get_columns_in_relation(
+        cls, adapter: SQLAdapter, relation: DatabricksRelation
+    ) -> List[DatabricksColumn]: ...
+
+    @staticmethod
+    def _get_columns_with_comments(
+        adapter: SQLAdapter, relation: DatabricksRelation, macro_name: str
+    ) -> List[AttrDict]:
+        return list(
+            handle_missing_objects(
+                lambda: adapter.execute_macro(macro_name, kwargs={"relation": relation}),
+                AttrDict(),
+            )
+        )
+
+
+class GetColumnsByDescribe(GetColumnsBehavior):
+    @classmethod
+    def get_columns_in_relation(
+        cls, adapter: SQLAdapter, relation: DatabricksRelation
+    ) -> List[DatabricksColumn]:
+        rows = cls._get_columns_with_comments(adapter, relation, "get_columns_comments")
+        return cls._parse_columns(rows)
+
+    @classmethod
+    def _parse_columns(cls, rows: List[AttrDict]) -> List[DatabricksColumn]:
+        columns = []
+
+        for row in rows:
+            if row["col_name"].startswith("#"):
+                break
+            columns.append(
+                DatabricksColumn(
+                    column=row["col_name"], dtype=row["data_type"], comment=row["comment"]
+                )
+            )
+
+        return columns
+
+
+class GetColumnsByInformationSchema(GetColumnsByDescribe):
+    @classmethod
+    def get_columns_in_relation(
+        cls, adapter: SQLAdapter, relation: DatabricksRelation
+    ) -> List[DatabricksColumn]:
+        if relation.is_hive_metastore() or relation.type == DatabricksRelation.View:
+            return super().get_columns_in_relation(adapter, relation)
+
+        rows = cls._get_columns_with_comments(
+            adapter, relation, "get_columns_comments_via_information_schema"
+        )
+        return cls._parse_columns(rows)
+
+    @classmethod
+    def _parse_columns(cls, rows: List[AttrDict]) -> List[DatabricksColumn]:
+        return [DatabricksColumn(column=row[0], dtype=row[1], comment=row[2]) for row in rows]

--- a/dbt/adapters/databricks/behaviors/columns.py
+++ b/dbt/adapters/databricks/behaviors/columns.py
@@ -14,7 +14,8 @@ class GetColumnsBehavior(ABC):
     @abstractmethod
     def get_columns_in_relation(
         cls, adapter: SQLAdapter, relation: DatabricksRelation
-    ) -> List[DatabricksColumn]: ...
+    ) -> List[DatabricksColumn]:
+        pass
 
     @staticmethod
     def _get_columns_with_comments(

--- a/dbt/adapters/databricks/impl.py
+++ b/dbt/adapters/databricks/impl.py
@@ -93,6 +93,15 @@ SHOW_TABLES_MACRO_NAME = "show_tables"
 SHOW_VIEWS_MACRO_NAME = "show_views"
 GET_COLUMNS_COMMENTS_MACRO_NAME = "get_columns_comments"
 
+USE_INFO_SCHEMA_FOR_COLUMNS = BehaviorFlag(
+    name="use_info_schema_for_columns",
+    default=False,
+    description=(
+        "Use info schema to gather column information to ensure complex types are not truncated."
+        "  Incurs some overhead, so disabled by default."
+    ),
+)
+
 
 @dataclass
 class DatabricksConfig(AdapterConfig):
@@ -169,7 +178,7 @@ class DatabricksAdapter(SparkAdapter):
 
     @property
     def _behavior_flags(self) -> List[BehaviorFlag]:
-        return [BehaviorFlag(name="use_info_schema_for_columns", default=False)]
+        return [USE_INFO_SCHEMA_FOR_COLUMNS]
 
     # override/overload
     def acquire_connection(

--- a/dbt/adapters/databricks/impl.py
+++ b/dbt/adapters/databricks/impl.py
@@ -100,7 +100,7 @@ USE_INFO_SCHEMA_FOR_COLUMNS = BehaviorFlag(
         "Use info schema to gather column information to ensure complex types are not truncated."
         "  Incurs some overhead, so disabled by default."
     ),
-)
+)  # type: ignore[typeddict-item]
 
 
 @dataclass

--- a/dbt/adapters/databricks/impl.py
+++ b/dbt/adapters/databricks/impl.py
@@ -171,7 +171,7 @@ class DatabricksAdapter(SparkAdapter):
 
     def __init__(self, config: Any, mp_context: SpawnContext) -> None:
         super().__init__(config, mp_context)
-        if self.behavior.use_info_schema_for_columns:  # type: ignore[attr-defined]
+        if self.behavior.use_info_schema_for_columns.no_warn:  # type: ignore[attr-defined]
             self.get_column_behavior = GetColumnsByInformationSchema()
         else:
             self.get_column_behavior = GetColumnsByDescribe()

--- a/dbt/include/databricks/macros/adapters/persist_docs.sql
+++ b/dbt/include/databricks/macros/adapters/persist_docs.sql
@@ -28,6 +28,25 @@
   {% do return(load_result('get_columns_comments').table) %}
 {% endmacro %}
 
+{% macro get_columns_comments_via_information_schema(relation) -%}
+  {% call statement('repair_table', fetch_result=False) -%}
+    REPAIR TABLE {{ relation|lower }} SYNC METADATA
+  {% endcall %}
+  {% call statement('get_columns_comments_via_information_schema', fetch_result=True) -%}
+    select
+      column_name,
+      full_data_type,
+      comment
+    from `system`.`information_schema`.`columns`
+    where
+      table_catalog = '{{ relation.database|lower }}' and
+      table_schema = '{{ relation.schema|lower }}' and 
+      table_name = '{{ relation.identifier|lower }}'
+  {% endcall %}
+
+  {% do return(load_result('get_columns_comments_via_information_schema').table) %}
+{% endmacro %}
+
 {% macro databricks__persist_docs(relation, model, for_relation, for_columns) -%}
   {%- if for_relation and config.persist_relation_docs() and model.description %}
     {% do alter_table_comment(relation, model) %}

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -15,4 +15,4 @@ types-requests
 types-mock
 pre-commit
 
-dbt-tests-adapter~=1.8.0
+dbt-tests-adapter>=1.8.0, <2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ databricks-sql-connector>=3.4.0, <3.5.0
 dbt-spark~=1.8.0
 dbt-core>=1.8.7, <2.0
 dbt-common>=1.10.0, <2.0
-dbt-adapters>=1.3.0, <2.0
+dbt-adapters>=1.7.0, <2.0
 databricks-sdk==0.17.0
 keyring>=23.13.0
 protobuf<5.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 databricks-sql-connector>=3.4.0, <3.5.0
 dbt-spark~=1.8.0
-dbt-core>=1.8.0, <2.0
+dbt-core>=1.8.7, <2.0
 dbt-adapters>=1.3.0, <2.0
 databricks-sdk==0.17.0
 keyring>=23.13.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 databricks-sql-connector>=3.4.0, <3.5.0
 dbt-spark~=1.8.0
 dbt-core>=1.8.7, <2.0
+dbt-common>=1.10.0, <2.0
 dbt-adapters>=1.3.0, <2.0
 databricks-sdk==0.17.0
 keyring>=23.13.0

--- a/setup.py
+++ b/setup.py
@@ -55,9 +55,10 @@ setup(
     include_package_data=True,
     install_requires=[
         "dbt-spark>=1.8.0, <2.0",
-        "dbt-core>=1.8.0, <2.0",
-        "dbt-adapters>=1.3.0, <2.0",
-        "databricks-sql-connector>=3.2.0, <3.3.0",
+        "dbt-core>=1.8.7, <2.0",
+        "dbt-adapters>=1.7.0, <2.0",
+        "dbt-common>=1.10.0, <2.0",
+        "databricks-sql-connector>=3.4.0, <3.5.0",
         "databricks-sdk==0.17.0",
         "keyring>=23.13.0",
         "pandas<2.2.0",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ pytest_plugins = ["dbt.tests.fixtures.project"]
 
 
 def pytest_addoption(parser):
-    parser.addoption("--profile", action="store", default="databricks_uc_sql_endpoint", type=str)
+    parser.addoption("--profile", action="store", default="databricks_uc_cluster", type=str)
 
 
 # Using @pytest.mark.skip_profile('databricks_cluster') uses the 'skip_by_adapter_type'

--- a/tests/functional/adapter/columns/fixtures.py
+++ b/tests/functional/adapter/columns/fixtures.py
@@ -1,0 +1,25 @@
+base_model = """
+select struct('a', 1, 'b', 'b', 'c', ARRAY(1,2,3)) as struct_col, 'hello' as str_col
+"""
+
+schema = """
+version: 2
+models:
+  - name: base_model
+    config:
+        materialized: table
+    columns:
+      - name: struct_col
+      - name: str_col
+"""
+
+view_schema = """
+version: 2
+models:
+  - name: base_model
+    config:
+        materialized: view
+    columns:
+      - name: struct_col
+      - name: str_col
+"""

--- a/tests/functional/adapter/columns/test_get_columns.py
+++ b/tests/functional/adapter/columns/test_get_columns.py
@@ -1,0 +1,76 @@
+import pytest
+
+from dbt.adapters.databricks.column import DatabricksColumn
+from dbt.adapters.databricks.relation import DatabricksRelation
+from tests.functional.adapter.columns import fixtures
+from dbt.tests import util
+
+
+class ColumnsInRelation:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"base_model.sql": fixtures.base_model, "schema.yml": fixtures.schema}
+
+    @pytest.fixture(scope="class", autouse=True)
+    def setup(self, project):
+        util.run_dbt(["run"])
+
+    @pytest.fixture(scope="class")
+    def expected_columns(self):
+
+        return [
+            DatabricksColumn(
+                column="struct_col",
+                dtype=(
+                    "struct<col1:string,col2:int,col3:string,"
+                    "col4:string,col5:string,col6:array<int>>"
+                ),
+            ),
+            DatabricksColumn(column="str_col", dtype="string"),
+        ]
+
+    def test_columns_in_relation(self, project, expected_columns):
+        my_relation = DatabricksRelation.create(
+            database=project.database,
+            schema=project.test_schema,
+            identifier="base_model",
+            type=DatabricksRelation.Table,
+        )
+
+        with project.adapter.connection_named("_test"):
+            actual_columns = project.adapter.get_columns_in_relation(my_relation)
+        assert actual_columns == expected_columns
+
+
+class TestColumnsInRelationBehaviorFlagOff(ColumnsInRelation):
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {"flags": {}}
+
+
+class TestColumnsInRelationBehaviorFlagOn(ColumnsInRelation):
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {"flags": {"use_info_schema_for_columns": True}}
+
+
+class TestColumnsInRelationBehaviorFlagOnView(ColumnsInRelation):
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"base_model.sql": fixtures.base_model, "schema.yml": fixtures.view_schema}
+
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {"flags": {"use_info_schema_for_columns": True}}
+
+    def test_columns_in_relation(self, project, expected_columns):
+        my_relation = DatabricksRelation.create(
+            database=project.database,
+            schema=project.test_schema,
+            identifier="base_model",
+            type=DatabricksRelation.View,
+        )
+
+        with project.adapter.connection_named("_test"):
+            actual_columns = project.adapter.get_columns_in_relation(my_relation)
+        assert actual_columns == expected_columns

--- a/tests/functional/adapter/python_model/fixtures.py
+++ b/tests/functional/adapter/python_model/fixtures.py
@@ -101,7 +101,8 @@ models:
     config:
       marterialized: table
       tags: ["python"]
-      location_root: '{{ env_var("DBT_DATABRICKS_LOCATION_ROOT") }}'
+      create_notebook: true
+      location_root: "{root}/{schema}"
     columns:
       - name: date
         tests:

--- a/tests/functional/adapter/python_model/fixtures.py
+++ b/tests/functional/adapter/python_model/fixtures.py
@@ -101,7 +101,7 @@ models:
     config:
       marterialized: table
       tags: ["python"]
-      location_root: '{{ env_var("DBT_DATABRICKS_LOCATION_ROOT") }}/{schema}'
+      location_root: '{{ env_var("DBT_DATABRICKS_LOCATION_ROOT") }}'
     columns:
       - name: date
         tests:

--- a/tests/functional/adapter/python_model/fixtures.py
+++ b/tests/functional/adapter/python_model/fixtures.py
@@ -101,7 +101,7 @@ models:
     config:
       marterialized: table
       tags: ["python"]
-      location_root: '{{ env_var("DBT_DATABRICKS_LOCATION_ROOT") }}'
+      location_root: '{{ env_var("DBT_DATABRICKS_LOCATION_ROOT") }}/{schema}'
     columns:
       - name: date
         tests:

--- a/tests/functional/adapter/python_model/test_python_model.py
+++ b/tests/functional/adapter/python_model/test_python_model.py
@@ -119,13 +119,6 @@ class TestComplexConfig:
         }
 
     def test_expected_handling_of_complex_config(self, project):
-        unformatted_schema_yml = util.read_file("models", "schema.yml")
-        util.write_file(
-            unformatted_schema_yml.format(schema=project.test_schema),
-            "models",
-            "schema.yml",
-        )
-
         util.run_dbt(["seed"])
         util.run_dbt(["build", "-s", "complex_config"])
         util.run_dbt(["build", "-s", "complex_config"])

--- a/tests/functional/adapter/python_model/test_python_model.py
+++ b/tests/functional/adapter/python_model/test_python_model.py
@@ -119,6 +119,15 @@ class TestComplexConfig:
         }
 
     def test_expected_handling_of_complex_config(self, project):
+        unformatted_schema_yml = util.read_file("models", "schema.yml")
+        util.write_file(
+            unformatted_schema_yml.replace(
+                "root", os.environ["DBT_DATABRICKS_LOCATION_ROOT"]
+            ).replace("{schema}", project.test_schema),
+            "models",
+            "schema.yml",
+        )
+
         util.run_dbt(["seed"])
         util.run_dbt(["build", "-s", "complex_config"])
         util.run_dbt(["build", "-s", "complex_config"])

--- a/tests/functional/adapter/python_model/test_python_model.py
+++ b/tests/functional/adapter/python_model/test_python_model.py
@@ -119,6 +119,13 @@ class TestComplexConfig:
         }
 
     def test_expected_handling_of_complex_config(self, project):
+        unformatted_schema_yml = util.read_file("models", "schema.yml")
+        util.write_file(
+            unformatted_schema_yml.format(schema=project.test_schema),
+            "models",
+            "schema.yml",
+        )
+
         util.run_dbt(["seed"])
         util.run_dbt(["build", "-s", "complex_config"])
         util.run_dbt(["build", "-s", "complex_config"])

--- a/tests/unit/test_adapter.py
+++ b/tests/unit/test_adapter.py
@@ -346,13 +346,13 @@ class TestDatabricksAdapter(DatabricksAdapterBase):
     def test_list_relations_without_caching__no_relations(self):
         with mock.patch.object(DatabricksAdapter, "get_relations_without_caching") as mocked:
             mocked.return_value = []
-            adapter = DatabricksAdapter(Mock(), get_context("spawn"))
+            adapter = DatabricksAdapter(Mock(flags={}), get_context("spawn"))
             assert adapter.list_relations("database", "schema") == []
 
     def test_list_relations_without_caching__some_relations(self):
         with mock.patch.object(DatabricksAdapter, "get_relations_without_caching") as mocked:
             mocked.return_value = [("name", "table", "hudi", "owner")]
-            adapter = DatabricksAdapter(Mock(), get_context("spawn"))
+            adapter = DatabricksAdapter(Mock(flags={}), get_context("spawn"))
             relations = adapter.list_relations("database", "schema")
             assert len(relations) == 1
             relation = relations[0]
@@ -366,7 +366,7 @@ class TestDatabricksAdapter(DatabricksAdapterBase):
     def test_list_relations_without_caching__hive_relation(self):
         with mock.patch.object(DatabricksAdapter, "get_relations_without_caching") as mocked:
             mocked.return_value = [("name", "table", None, None)]
-            adapter = DatabricksAdapter(Mock(), get_context("spawn"))
+            adapter = DatabricksAdapter(Mock(flags={}), get_context("spawn"))
             relations = adapter.list_relations("database", "schema")
             assert len(relations) == 1
             relation = relations[0]
@@ -381,7 +381,7 @@ class TestDatabricksAdapter(DatabricksAdapterBase):
             list_info.return_value = [(Mock(), "info")]
             with mock.patch.object(DatabricksAdapter, "_get_columns_for_catalog") as get_columns:
                 get_columns.return_value = []
-                adapter = DatabricksAdapter(Mock(), get_context("spawn"))
+                adapter = DatabricksAdapter(Mock(flags={}), get_context("spawn"))
                 table = adapter._get_schema_for_catalog("database", "schema", "name")
                 assert len(table.rows) == 0
 
@@ -393,7 +393,7 @@ class TestDatabricksAdapter(DatabricksAdapterBase):
                     {"name": "col1", "type": "string", "comment": "comment"},
                     {"name": "col2", "type": "string", "comment": "comment"},
                 ]
-                adapter = DatabricksAdapter(Mock(), get_context("spawn"))
+                adapter = DatabricksAdapter(Mock(flags={}), get_context("spawn"))
                 table = adapter._get_schema_for_catalog("database", "schema", "name")
                 assert len(table.rows) == 2
                 assert table.column_names == ("name", "type", "comment")

--- a/tests/unit/test_adapter.py
+++ b/tests/unit/test_adapter.py
@@ -14,7 +14,7 @@ from dbt.adapters.databricks.column import DatabricksColumn
 from dbt.adapters.databricks.credentials import CATALOG_KEY_IN_SESSION_PROPERTIES
 from dbt.adapters.databricks.credentials import DBT_DATABRICKS_HTTP_SESSION_HEADERS
 from dbt.adapters.databricks.credentials import DBT_DATABRICKS_INVOCATION_ENV
-from dbt.adapters.databricks.impl import check_not_found_error
+from dbt.adapters.databricks.utils import check_not_found_error
 from dbt.adapters.databricks.impl import get_identifier_list_string
 from dbt.adapters.databricks.relation import DatabricksRelationType
 from dbt.config import RuntimeConfig


### PR DESCRIPTION
Partial fix for #779

<!---
  Include the number of the issue addressed by this PR above if applicable.

  Example:
    resolves #1234

  Please review our pull request review process in CONTRIBUTING.md before your proceed.
-->

### Description

This is my second attempt at addressing the issue that describe extended can truncate complex types.  With the release of dbt-core 1.8.7, we can now process behavior flags; this PR introduces the choice of using information_schema for grabbing column information in get_columns_for_relation.  I'm hiding behind a behavior flag because given the current state of UC information_schema, we have to run repair to trust that columns of recently created or altered table will be present in the information_schema, which adds overhead.  Furthermore, this trick only works for Delta tables at this time.  It is hoped that in time the sync issue with information_schema will be solved, but in the mean time, users can use this flag when they have complex types that describe extended truncates.

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
