### PR TITLE
Set unique temp table suffix to allow parallel incremental executions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 ## dbt-databricks 1.8.7 (TBD)
 
+### Features
+
+- Add config for generating unique tmp table names for enabling parralel replace-where (thanks @huangxingyi-git!) ([811](https://github.com/databricks/dbt-databricks/pull/811))
+
 ### Fixes
 
-- Stop setting cluster by to None. If you want to drop liquid clustering, you will need to full-refresh ([806]https://github.com/databricks/dbt-databricks/pull/806)
+- Stop setting cluster by to None. If you want to drop liquid clustering, you will need to full-refresh ([806](https://github.com/databricks/dbt-databricks/pull/806))
 
 ## dbt-databricks 1.8.6 (September 18, 2024)
 

--- a/dbt/adapters/databricks/impl.py
+++ b/dbt/adapters/databricks/impl.py
@@ -23,6 +23,7 @@ from typing import Type
 from typing import TYPE_CHECKING
 from typing import TypeVar
 from typing import Union
+from uuid import uuid4
 
 from dbt.adapters.base import AdapterConfig
 from dbt.adapters.base import PythonJobHelper
@@ -103,6 +104,7 @@ class DatabricksConfig(AdapterConfig):
     databricks_tags: Optional[Dict[str, str]] = None
     tblproperties: Optional[Dict[str, str]] = None
     zorder: Optional[Union[List[str], str]] = None
+    unique_tmp_table_suffix: bool = False
 
 
 def check_not_found_error(errmsg: str) -> bool:
@@ -685,6 +687,9 @@ class DatabricksAdapter(SparkAdapter):
                 f"Materialization {model.config.materialized} is not supported."
             )
 
+    @available
+    def generate_unique_temporary_table_suffix(self, suffix_initial: str = "__dbt_tmp") -> str:
+        return f"{suffix_initial}_{str(uuid4())}"
 
 @dataclass(frozen=True)
 class RelationAPIBase(ABC, Generic[DatabricksRelationConfig]):

--- a/dbt/adapters/databricks/impl.py
+++ b/dbt/adapters/databricks/impl.py
@@ -691,6 +691,7 @@ class DatabricksAdapter(SparkAdapter):
     def generate_unique_temporary_table_suffix(self, suffix_initial: str = "__dbt_tmp") -> str:
         return f"{suffix_initial}_{str(uuid4())}"
 
+
 @dataclass(frozen=True)
 class RelationAPIBase(ABC, Generic[DatabricksRelationConfig]):
     """Base class for the relation API, so as to provide some encapsulation from the adapter.

--- a/dbt/include/databricks/macros/materializations/incremental/incremental.sql
+++ b/dbt/include/databricks/macros/materializations/incremental/incremental.sql
@@ -19,11 +19,11 @@
   {%- set on_schema_change = incremental_validate_on_schema_change(config.get('on_schema_change'), default='ignore') -%}
   {%- set target_relation = this.incorporate(type='table') -%}
   {%- set existing_relation = adapter.get_relation(database=this.database, schema=this.schema, identifier=this.identifier, needs_information=True) -%}
-  {% if unique_tmp_table_suffix == True and raw_strategy == 'replace_where' and raw_file_format == 'delta' %}
-    {% set temp_relation_suffix = adapter.generate_unique_temporary_table_suffix() %}
-  {% else %}
-    {% set temp_relation_suffix = '__dbt_tmp' %}
-  {% endif %}
+  {%- if unique_tmp_table_suffix == True and raw_strategy == 'replace_where' and raw_file_format == 'delta' -%}
+    {%- set temp_relation_suffix = adapter.generate_unique_temporary_table_suffix() -%}
+  {%- else -%}
+    {%- set temp_relation_suffix = '__dbt_tmp' -%}
+  {%- endif -%}
 
   {#-- Set Overwrite Mode to STATIC for initial replace --#}
   {%- if incremental_strategy == 'insert_overwrite' and should_full_refresh() -%}


### PR DESCRIPTION
<!-- Please review our pull request review process in CONTRIBUTING.md before your proceed. -->

Resolves #

<!---
  Include the number of the issue addressed by this PR above if applicable.

  Example:
    resolves #1234

  Please review our pull request review process in CONTRIBUTING.md before your proceed.
-->

### Description
Set unique table suffix to allow parallel incremental execution
For some specific cases (eg. backfill very large amount of data), we need to execute parallel multiple dbt run of specific incremental(replace_where) model in which we pass the date (or country) as var argument.
For example, we have a model we run every day using Airflow for which we pass the a date relative to the Airflow scheduler.
FYI
https://github.com/dbt-labs/dbt-athena/pull/650/files

If we want to process by batch of N days in parallel using Airflow concurrency, we need the tmp table create by each of the dbt run to be unique. Else, you are going to end up with N insert attempting to run with the same __dbt_tmp name, creating conflict and ultimately creating failure.

[issue](https://github.com/databricks/dbt-databricks/issues/810)

### Checklist

- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
