### PR TITLE
Simple Iceberg support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
   - `matched` and `not matched` steps can now be skipped;
 - Allow for the use of custom constraints, using the `custom` constraint type with an `expression` as the constraint (thanks @roydobbe). ([792](https://github.com/databricks/dbt-databricks/pull/792))
 - Add "use_info_schema_for_columns" behavior flag to turn on use of information_schema to get column info where possible. This may have more latency but will not truncate complex data types the way that 'describe' can. ([808](https://github.com/databricks/dbt-databricks/pull/808))
+- Add support for table_format: iceberg. This uses UniForm under the hood to provide iceberg compatibility for tables or incrementals. ([815](https://github.com/databricks/dbt-databricks/pull/815))
 
 ### Under the Hood
 

--- a/dbt/adapters/databricks/connections.py
+++ b/dbt/adapters/databricks/connections.py
@@ -74,6 +74,7 @@ from dbt.adapters.events.types import SQLQueryStatus
 from dbt.adapters.spark.connections import SparkConnectionManager
 from dbt_common.events.contextvars import get_node_info
 from dbt_common.events.functions import fire_event
+from dbt_common.exceptions import DbtDatabaseError
 from dbt_common.exceptions import DbtInternalError
 from dbt_common.exceptions import DbtRuntimeError
 from dbt_common.utils import cast_to_str
@@ -505,7 +506,7 @@ class DatabricksConnectionManager(SparkConnectionManager):
 
         except Error as exc:
             logger.debug(QueryError(log_sql, exc))
-            raise DbtRuntimeError(str(exc)) from exc
+            raise DbtDatabaseError(str(exc)) from exc
 
         except Exception as exc:
             logger.debug(QueryError(log_sql, exc))
@@ -515,9 +516,9 @@ class DatabricksConnectionManager(SparkConnectionManager):
             thrift_resp = exc.args[0]
             if hasattr(thrift_resp, "status"):
                 msg = thrift_resp.status.errorMessage
-                raise DbtRuntimeError(msg) from exc
+                raise DbtDatabaseError(msg) from exc
             else:
-                raise DbtRuntimeError(str(exc)) from exc
+                raise DbtDatabaseError(str(exc)) from exc
 
     # override/overload
     def set_connection_name(

--- a/dbt/adapters/databricks/impl.py
+++ b/dbt/adapters/databricks/impl.py
@@ -66,6 +66,7 @@ from dbt.adapters.databricks.relation_configs.materialized_view import (
 from dbt.adapters.databricks.relation_configs.streaming_table import (
     StreamingTableConfig,
 )
+from dbt.adapters.databricks.relation_configs.table_format import TableFormat
 from dbt.adapters.databricks.relation_configs.tblproperties import TblPropertiesConfig
 from dbt.adapters.databricks.utils import get_first_row, handle_missing_objects
 from dbt.adapters.databricks.utils import redact_credentials
@@ -80,6 +81,7 @@ from dbt.adapters.spark.impl import SparkAdapter
 from dbt_common.behavior_flags import BehaviorFlag
 from dbt_common.utils import executor
 from dbt_common.utils.dict import AttrDict
+from dbt_common.exceptions import DbtConfigError
 
 if TYPE_CHECKING:
     from agate import Row
@@ -106,6 +108,7 @@ USE_INFO_SCHEMA_FOR_COLUMNS = BehaviorFlag(
 @dataclass
 class DatabricksConfig(AdapterConfig):
     file_format: str = "delta"
+    table_format: TableFormat = TableFormat.DEFAULT
     location_root: Optional[str] = None
     partition_by: Optional[Union[List[str], str]] = None
     clustered_by: Optional[Union[List[str], str]] = None
@@ -179,6 +182,20 @@ class DatabricksAdapter(SparkAdapter):
     @property
     def _behavior_flags(self) -> List[BehaviorFlag]:
         return [USE_INFO_SCHEMA_FOR_COLUMNS]
+
+    @available.parse(lambda *a, **k: 0)
+    def check_iceberg(self, table_format: TableFormat, file_format: str, materialized: str) -> bool:
+        if table_format == TableFormat.ICEBERG:
+            if self.compare_dbr_version(14, 3) < 0:
+                raise DbtConfigError("Iceberg support requires Databricks Runtime 14.3 or later.")
+            if file_format and file_format != "delta":
+                raise DbtConfigError("When table_format is 'iceberg', cannot set file_format.")
+            if materialized not in ("incremental", "table"):
+                raise DbtConfigError(
+                    "When table_format is 'iceberg', materialized must be 'incremental' or 'table'."
+                )
+            return True
+        return False
 
     # override/overload
     def acquire_connection(

--- a/dbt/adapters/databricks/relation_configs/table_format.py
+++ b/dbt/adapters/databricks/relation_configs/table_format.py
@@ -1,0 +1,15 @@
+from dbt_common.dataclass_schema import StrEnum
+
+
+class TableFormat(StrEnum):
+    """
+    For now we have table format separate from file format, as Iceberg support in Databricks is via
+    Delta plus a compatibility layer.  We ultimately merge file formats into table format to
+    simplify things for users.
+    """
+
+    DEFAULT = "default"
+    ICEBERG = "iceberg"
+
+    def __str__(self) -> str:
+        return self.value

--- a/dbt/include/databricks/macros/relations/components/tblproperties.sql
+++ b/dbt/include/databricks/macros/relations/components/tblproperties.sql
@@ -1,10 +1,3 @@
 {% macro get_create_sql_tblproperties(tblproperties) %}
-  {%- set _ = adapter.check_iceberg(config.get('table_format'), config.get('file_format'), model.config.materialized) -%}
-  {%- if tblproperties and tblproperties|length>0 -%}
-    TBLPROPERTIES (
-    {%- for prop in tblproperties -%}
-      '{{ prop }}' = '{{ tblproperties[prop] }}'{%- if not loop.last -%}, {% endif -%}
-    {% endfor -%}
-    )
-  {%- endif -%}
+  {{ databricks__tblproperties_clause(tblproperties)}}
 {% endmacro %}

--- a/dbt/include/databricks/macros/relations/components/tblproperties.sql
+++ b/dbt/include/databricks/macros/relations/components/tblproperties.sql
@@ -1,4 +1,5 @@
 {% macro get_create_sql_tblproperties(tblproperties) %}
+  {%- set _ = adapter.check_iceberg(config.get('table_format'), config.get('file_format'), model.config.materialized) -%}
   {%- if tblproperties and tblproperties|length>0 -%}
     TBLPROPERTIES (
     {%- for prop in tblproperties -%}

--- a/dbt/include/databricks/macros/relations/tblproperties.sql
+++ b/dbt/include/databricks/macros/relations/tblproperties.sql
@@ -3,8 +3,12 @@
 {%- endmacro -%}
 
 {% macro databricks__tblproperties_clause() -%}
-  {%- set tblproperties = config.get('tblproperties') -%}
-  {%- if tblproperties is not none %}
+  {%- set tblproperties = config.get('tblproperties', {}) -%}
+  {%- set is_iceberg = adapter.check_iceberg(config.get('table_format'), config.get('file_format'), model.config.materialized) -%}
+  {%- if is_iceberg -%}
+    {%- set _ = tblproperties.update({'delta.enableIcebergCompatV2': 'true', 'delta.universalFormat.enabledFormats': 'iceberg'}) -%}
+  {%- endif -%}
+  {%- if tblproperties != {} %}
     tblproperties (
       {%- for prop in tblproperties -%}
       '{{ prop }}' = '{{ tblproperties[prop] }}' {% if not loop.last %}, {% endif %}
@@ -15,6 +19,10 @@
 
 {% macro apply_tblproperties(relation, tblproperties) -%}
   {% if tblproperties %}
+    {%- set is_iceberg = adapter.check_iceberg(config.get('table_format'), config.get('file_format'), model.config.materialized) -%}
+    {%- if is_iceberg -%}
+      {%- set _ = tblproperties.update({'delta.enableIcebergCompatV2': 'true', 'delta.universalFormat.enabledFormats': 'iceberg'}) -%}
+    {%- endif -%}
     {%- call statement('apply_tblproperties') -%}
       ALTER {{ relation.type }} {{ relation }} SET TBLPROPERTIES (
       {% for tblproperty in tblproperties -%}

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -15,4 +15,4 @@ types-requests
 types-mock
 pre-commit
 
-dbt-tests-adapter>=1.8.0, <2.0
+dbt-tests-adapter>=1.10.2, <2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 databricks-sql-connector>=3.4.0, <3.5.0
 dbt-spark~=1.8.0
-dbt-core>=1.8.7, <2.0
+dbt-core>=1.9.0b1, <2.0
 dbt-common>=1.10.0, <2.0
 dbt-adapters>=1.7.0, <2.0
 databricks-sdk==0.17.0

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "dbt-spark>=1.8.0, <2.0",
-        "dbt-core>=1.8.7, <2.0",
+        "dbt-core>=1.9.0b1, <2.0",
         "dbt-adapters>=1.7.0, <2.0",
         "dbt-common>=1.10.0, <2.0",
         "databricks-sql-connector>=3.4.0, <3.5.0",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ pytest_plugins = ["dbt.tests.fixtures.project"]
 
 
 def pytest_addoption(parser):
-    parser.addoption("--profile", action="store", default="databricks_uc_cluster", type=str)
+    parser.addoption("--profile", action="store", default="databricks_uc_sql_endpoint", type=str)
 
 
 # Using @pytest.mark.skip_profile('databricks_cluster') uses the 'skip_by_adapter_type'

--- a/tests/functional/adapter/constraints/fixtures.py
+++ b/tests/functional/adapter/constraints/fixtures.py
@@ -81,7 +81,7 @@ models:
       - type: foreign_key
         name: fk_example__child_table_1
         columns: ["parent_id"]
-        to: parent_table
+        to: ref('parent_table')
         to_columns: ["id"]
     columns:
       - name: id

--- a/tests/functional/adapter/iceberg/fixtures.py
+++ b/tests/functional/adapter/iceberg/fixtures.py
@@ -48,3 +48,24 @@ basic_incremental_swap = """
 }}
 select 1 as id
 """
+
+invalid_iceberg_view = """
+{{
+  config(
+    materialized = "view",
+    table_format = "iceberg",
+  )
+}}
+select 1 as id
+"""
+
+invalid_iceberg_format = """
+{{
+  config(
+    materialized = "table",
+    table_format = "iceberg",
+    file_format = "parquet",
+  )
+}}
+select 1 as id
+"""

--- a/tests/functional/adapter/iceberg/fixtures.py
+++ b/tests/functional/adapter/iceberg/fixtures.py
@@ -1,0 +1,50 @@
+basic_table = """
+{{
+  config(
+    materialized = "table",
+  )
+}}
+select 1 as id
+"""
+
+basic_iceberg = """
+{{
+  config(
+    materialized = "table",
+    table_format="iceberg",
+  )
+}}
+select * from {{ ref('first_table') }}
+"""
+
+ref_iceberg = """
+{{
+  config(
+    materialized = "table",
+  )
+}}
+select * from {{ ref('iceberg_table') }}
+"""
+
+basic_view = """
+select 1 as id
+"""
+
+basic_iceberg_swap = """
+{{
+  config(
+    materialized = "table",
+    table_format="iceberg",
+  )
+}}
+select 1 as id
+"""
+
+basic_incremental_swap = """
+{{
+  config(
+    materialized = "incremental",
+  )
+}}
+select 1 as id
+"""

--- a/tests/functional/adapter/iceberg/test_iceberg_support.py
+++ b/tests/functional/adapter/iceberg/test_iceberg_support.py
@@ -2,6 +2,7 @@ import pytest
 
 from tests.functional.adapter.iceberg import fixtures
 from dbt.tests import util
+from dbt.artifacts.schemas.results import RunStatus
 
 
 @pytest.mark.skip_profile("databricks_cluster")
@@ -33,3 +34,23 @@ class TestIcebergSwap:
         util.write_file(fixtures.basic_incremental_swap, "models", "first_model.sql")
         run_results = util.run_dbt()
         assert len(run_results) == 1
+
+
+class InvalidIcebergConfig:
+    def test_iceberg_failures(self, project):
+        results = util.run_dbt(expect_pass=False)
+        assert results.results[0].status == RunStatus.Error
+
+
+@pytest.mark.skip_profile("databricks_cluster")
+class TestIcebergView(InvalidIcebergConfig):
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"first_model.sql": fixtures.invalid_iceberg_view}
+
+
+@pytest.mark.skip_profile("databricks_cluster")
+class TestIcebergWithParquet(InvalidIcebergConfig):
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"first_model.sql": fixtures.invalid_iceberg_format}

--- a/tests/functional/adapter/iceberg/test_iceberg_support.py
+++ b/tests/functional/adapter/iceberg/test_iceberg_support.py
@@ -1,0 +1,35 @@
+import pytest
+
+from tests.functional.adapter.iceberg import fixtures
+from dbt.tests import util
+
+
+@pytest.mark.skip_profile("databricks_cluster")
+class TestIcebergTables:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "first_table.sql": fixtures.basic_table,
+            "iceberg_table.sql": fixtures.basic_iceberg,
+            "table_built_on_iceberg_table.sql": fixtures.ref_iceberg,
+        }
+
+    def test_iceberg_refs(self, project):
+        run_results = util.run_dbt()
+        assert len(run_results) == 3
+
+
+@pytest.mark.skip_profile("databricks_cluster")
+class TestIcebergSwap:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"first_model.sql": fixtures.basic_view}
+
+    def test_iceberg_swaps(self, project):
+        util.run_dbt()
+        util.write_file(fixtures.basic_iceberg_swap, "models", "first_model.sql")
+        run_results = util.run_dbt()
+        assert len(run_results) == 1
+        util.write_file(fixtures.basic_incremental_swap, "models", "first_model.sql")
+        run_results = util.run_dbt()
+        assert len(run_results) == 1


### PR DESCRIPTION
<!---
  Include the number of the issue addressed by this PR above if applicable.

  Example:
    resolves #1234

  Please review our pull request review process in CONTRIBUTING.md before your proceed.
-->

### Description

Adds table_format: iceberg, to match support of other dbt-adapters.  This config sets a table or incremental materialization as iceberg compatible via UniForm.  Note: once a table is made iceberg compatible, removing the table_format will not remove the tblproperties, as we currently find doing tblproperty deletes on behalf of the user to be too fragile for most use-cases.

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
