### PR TITLE
Fixing failing tests from newer dbt versions

### DIFF
--- a/dbt/adapters/databricks/connections.py
+++ b/dbt/adapters/databricks/connections.py
@@ -75,6 +75,7 @@ from dbt_common.events.contextvars import get_node_info
 from dbt_common.events.functions import fire_event
 from dbt_common.exceptions import DbtInternalError
 from dbt_common.exceptions import DbtRuntimeError
+from dbt_common.exceptions import DbtDatabaseError
 from dbt_common.utils import cast_to_str
 from requests import Session
 
@@ -508,7 +509,7 @@ class DatabricksConnectionManager(SparkConnectionManager):
 
         except Error as exc:
             logger.debug(QueryError(log_sql, exc))
-            raise DbtRuntimeError(str(exc)) from exc
+            raise DbtDatabaseError(str(exc)) from exc
 
         except Exception as exc:
             logger.debug(QueryError(log_sql, exc))
@@ -518,9 +519,9 @@ class DatabricksConnectionManager(SparkConnectionManager):
             thrift_resp = exc.args[0]
             if hasattr(thrift_resp, "status"):
                 msg = thrift_resp.status.errorMessage
-                raise DbtRuntimeError(msg) from exc
+                raise DbtDatabaseError(msg) from exc
             else:
-                raise DbtRuntimeError(str(exc)) from exc
+                raise DbtDatabaseError(str(exc)) from exc
 
     # override/overload
     def set_connection_name(

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -15,4 +15,4 @@ types-requests
 types-mock
 pre-commit
 
-dbt-tests-adapter~=1.8.0
+dbt-tests-adapter>=1.10.0, <2.0

--- a/tests/functional/adapter/constraints/fixtures.py
+++ b/tests/functional/adapter/constraints/fixtures.py
@@ -81,7 +81,7 @@ models:
       - type: foreign_key
         name: fk_example__child_table_1
         columns: ["parent_id"]
-        to: parent_table
+        to: ref('parent_table')
         to_columns: ["id"]
     columns:
       - name: id


### PR DESCRIPTION
<!---
  Include the number of the issue addressed by this PR above if applicable.

  Example:
    resolves #1234

  Please review our pull request review process in CONTRIBUTING.md before your proceed.
-->

### Description

This is the minimal PR required to get 1.8.x tests to stop failing due to dbt-core 1.9.0-b1 and friends.

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
