### PR TITLE
Update _wait_for_cluster_to_start func to check for libraries statuses

### DIFF
--- a/dbt/adapters/databricks/python_submissions.py
+++ b/dbt/adapters/databricks/python_submissions.py
@@ -379,6 +379,20 @@ class DBContext:
         json_response = response.json()
         return json_response
 
+    def get_cluster_libraries_status(self) -> Dict:
+        # https://docs.databricks.com/api/workspace/libraries/clusterstatus
+
+        response = self.session.get(
+            f"https://{self.host}/api/2.0/libraries/cluster-status",
+            headers=self.extra_headers,
+            json={"cluster_id": self.cluster_id},
+        )
+        if response.status_code != 200:
+            raise DbtRuntimeError(f"Error getting status of libraries of a cluster.\n {response.content!r}")
+
+        json_response = response.json()
+        return json_response
+
     def start_cluster(self) -> None:
         """Send the start command and poll for the cluster status until it shows "Running"
 
@@ -406,6 +420,7 @@ class DBContext:
         logger.info("Waiting for cluster to be ready")
 
         MAX_CLUSTER_START_TIME = 900
+        LIBRARY_VALID_STATUSES = {"INSTALLED", "RESTORED", "SKIPPED"}
         start_time = time.time()
 
         def get_elapsed() -> float:
@@ -414,9 +429,11 @@ class DBContext:
         while get_elapsed() < MAX_CLUSTER_START_TIME:
             status_response = self.get_cluster_status()
             if str(status_response.get("state")).lower() == "running":
-                return
-            else:
-                time.sleep(5)
+                libraries_status_response = self.get_cluster_libraries_status()
+                if all(library["status"] in valid_statuses for library in response["library_statuses"]):
+                    return
+            
+            time.sleep(5)
 
         raise DbtRuntimeError(
             f"Cluster {self.cluster_id} restart timed out after {MAX_CLUSTER_START_TIME} seconds"


### PR DESCRIPTION
Resolves #821 

### Description
Enhance `_wait_for_cluster_to_start` to wait for library installation

Previously, the `_wait_for_cluster_to_start` function only checked if the cluster state was 'running'. This update adds a check to ensure all cluster libraries have been successfully installed (or skipped or restored) before proceeding. This ensures the cluster is fully ready for operations that depend on these libraries.

- Added `get_cluster_libraries_status` to fetch the status of cluster libraries.
- Updated `_wait_for_cluster_to_start` to wait until all libraries are in valid statuses ('INSTALLED', 'RESTORED', 'SKIPPED').
### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
