### PR TITLE
Behavior for external path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Allow for the use of custom constraints, using the `custom` constraint type with an `expression` as the constraint (thanks @roydobbe). ([792](https://github.com/databricks/dbt-databricks/pull/792))
 - Add "use_info_schema_for_columns" behavior flag to turn on use of information_schema to get column info where possible. This may have more latency but will not truncate complex data types the way that 'describe' can. ([808](https://github.com/databricks/dbt-databricks/pull/808))
 - Add support for table_format: iceberg. This uses UniForm under the hood to provide iceberg compatibility for tables or incrementals. ([815](https://github.com/databricks/dbt-databricks/pull/815))
+- Add `include_full_name_in_path` config boolean for external locations. This writes tables to {location_root}/{catalog}/{schema}/{table} ([823](https://github.com/databricks/dbt-databricks/pull/823))
 
 ### Under the Hood
 

--- a/dbt/include/databricks/macros/adapters/python.sql
+++ b/dbt/include/databricks/macros/adapters/python.sql
@@ -53,7 +53,6 @@ writer.saveAsTable("{{ target_relation }}")
 
 {%- macro py_get_writer_options() -%}
 {%- set location_root = config.get('location_root', validator=validation.any[basestring]) -%}
-{%- set include_catalog_schema = config.get('include_full_name_in_path', False) -%}
 {%- set file_format = config.get('file_format', validator=validation.any[basestring])|default('delta', true) -%}
 {%- set partition_by = config.get('partition_by', validator=validation.any[list, basestring]) -%}
 {%- set liquid_clustered_by = config.get('liquid_clustered_by', validator=validation.any[list, basestring]) -%}

--- a/dbt/include/databricks/macros/adapters/python.sql
+++ b/dbt/include/databricks/macros/adapters/python.sql
@@ -53,6 +53,7 @@ writer.saveAsTable("{{ target_relation }}")
 
 {%- macro py_get_writer_options() -%}
 {%- set location_root = config.get('location_root', validator=validation.any[basestring]) -%}
+{%- set include_catalog_schema = config.get('include_full_name_in_path', False) -%}
 {%- set file_format = config.get('file_format', validator=validation.any[basestring])|default('delta', true) -%}
 {%- set partition_by = config.get('partition_by', validator=validation.any[list, basestring]) -%}
 {%- set liquid_clustered_by = config.get('liquid_clustered_by', validator=validation.any[list, basestring]) -%}
@@ -60,11 +61,8 @@ writer.saveAsTable("{{ target_relation }}")
 {%- set buckets = config.get('buckets', validator=validation.any[int]) -%}
 .format("{{ file_format }}")
 {%- if location_root is not none %}
-{%- set identifier = model['alias'] %}
-{%- if is_incremental() %}
-{%- set identifier = identifier + '__dbt_tmp' %}
-{%- endif %}
-.option("path", "{{ location_root }}/{{ identifier }}")
+{%- set model_path = adapter.compute_external_path(config, model, is_incremental()) %}
+.option("path", "{{ model_path }}")
 {%- endif -%}
 {%- if partition_by is not none -%}
     {%- if partition_by is string -%}

--- a/dbt/include/databricks/macros/relations/location.sql
+++ b/dbt/include/databricks/macros/relations/location.sql
@@ -3,7 +3,8 @@
   {%- set file_format = config.get('file_format', default='delta') -%}
   {%- set identifier = model['alias'] -%}
   {%- if location_root is not none %}
-    location '{{ location_root }}/{{ identifier }}'
+  {%- set model_path = adapter.compute_external_path(config, model, is_incremental()) %}
+    location '{{ model_path }}'
   {%- elif (not relation.is_hive_metastore()) and file_format != 'delta' -%}
     {{ exceptions.raise_compiler_error(
         'Incompatible configuration: `location_root` must be set when using a non-delta file format with Unity Catalog'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ pytest_plugins = ["dbt.tests.fixtures.project"]
 
 
 def pytest_addoption(parser):
-    parser.addoption("--profile", action="store", default="databricks_uc_cluster", type=str)
+    parser.addoption("--profile", action="store", default="databricks_uc_sql_endpoint", type=str)
 
 
 # Using @pytest.mark.skip_profile('databricks_cluster') uses the 'skip_by_adapter_type'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ pytest_plugins = ["dbt.tests.fixtures.project"]
 
 
 def pytest_addoption(parser):
-    parser.addoption("--profile", action="store", default="databricks_uc_sql_endpoint", type=str)
+    parser.addoption("--profile", action="store", default="databricks_uc_cluster", type=str)
 
 
 # Using @pytest.mark.skip_profile('databricks_cluster') uses the 'skip_by_adapter_type'

--- a/tests/functional/adapter/basic/test_incremental.py
+++ b/tests/functional/adapter/basic/test_incremental.py
@@ -34,6 +34,7 @@ class TestIncrementalParquet(BaseIncremental):
             "models": {
                 "+file_format": "parquet",
                 "+location_root": f"{location_root}/parquet",
+                "+include_full_name_in_path": "true",
                 "+incremental_strategy": "append",
             },
         }
@@ -61,6 +62,7 @@ class TestIncrementalCSV(BaseIncremental):
             "models": {
                 "+file_format": "csv",
                 "+location_root": f"{location_root}/csv",
+                "+include_full_name_in_path": "true",
                 "+incremental_strategy": "append",
             },
         }

--- a/tests/functional/adapter/incremental/test_incremental_strategies.py
+++ b/tests/functional/adapter/incremental/test_incremental_strategies.py
@@ -52,6 +52,7 @@ class TestAppendParquet(AppendBase):
             "models": {
                 "+file_format": "parquet",
                 "+location_root": f"{location_root}/parquet_append",
+                "+include_full_name_in_path": "true",
                 "+incremental_strategy": "append",
             },
         }
@@ -129,6 +130,7 @@ class TestInsertOverwriteParquet(InsertOverwriteBase):
             "models": {
                 "+file_format": "parquet",
                 "+location_root": f"{location_root}/parquet_insert_overwrite",
+                "+include_full_name_in_path": "true",
                 "+incremental_strategy": "insert_overwrite",
             },
         }
@@ -144,6 +146,7 @@ class TestInsertOverwriteWithPartitionsParquet(InsertOverwriteBase):
             "models": {
                 "+file_format": "parquet",
                 "+location_root": f"{location_root}/parquet_insert_overwrite_partitions",
+                "+include_full_name_in_path": "true",
                 "+incremental_strategy": "insert_overwrite",
                 "+partition_by": "id",
             },

--- a/tests/functional/adapter/persist_docs/fixtures.py
+++ b/tests/functional/adapter/persist_docs/fixtures.py
@@ -5,6 +5,7 @@ seeds:
     description: 'A seed description'
     config:
       location_root: '{{ env_var("DBT_DATABRICKS_LOCATION_ROOT") }}'
+      include_full_name_in_path: true
       persist_docs:
         relation: True
         columns: True
@@ -22,6 +23,7 @@ seeds:
     description: 'A seed description'
     config:
       location_root: '/mnt/dbt_databricks/seeds'
+      include_full_name_in_path: true
       persist_docs:
         relation: True
         columns: True

--- a/tests/functional/adapter/python_model/fixtures.py
+++ b/tests/functional/adapter/python_model/fixtures.py
@@ -102,7 +102,8 @@ models:
       marterialized: table
       tags: ["python"]
       create_notebook: true
-      location_root: "{root}/{schema}"
+      include_full_name_in_path: true
+      location_root: "{{ env_var('DBT_DATABRICKS_LOCATION_ROOT') }}"
     columns:
       - name: date
         tests:

--- a/tests/functional/adapter/python_model/test_python_model.py
+++ b/tests/functional/adapter/python_model/test_python_model.py
@@ -119,15 +119,6 @@ class TestComplexConfig:
         }
 
     def test_expected_handling_of_complex_config(self, project):
-        unformatted_schema_yml = util.read_file("models", "schema.yml")
-        util.write_file(
-            unformatted_schema_yml.replace(
-                "root", os.environ["DBT_DATABRICKS_LOCATION_ROOT"]
-            ).replace("{schema}", project.test_schema),
-            "models",
-            "schema.yml",
-        )
-
         util.run_dbt(["seed"])
         util.run_dbt(["build", "-s", "complex_config"])
         util.run_dbt(["build", "-s", "complex_config"])

--- a/tests/unit/macros/adapters/test_python_macros.py
+++ b/tests/unit/macros/adapters/test_python_macros.py
@@ -33,19 +33,10 @@ class TestPythonMacros(MacroTestBase):
 
     def test_py_get_writer__specified_location_root(self, config, template, context):
         config["location_root"] = "s3://fake_location"
+        template.globals["adapter"].compute_external_path.return_value = "s3://fake_location/schema"
         result = self.run_macro_raw(template, "py_get_writer_options")
 
         expected = '.format("delta")\n.option("path", "s3://fake_location/schema")'
-        assert result == expected
-
-    def test_py_get_writer__specified_location_root_on_incremental(
-        self, config, template: Template, context
-    ):
-        config["location_root"] = "s3://fake_location"
-        context["is_incremental"].return_value = True
-        result = self.run_macro_raw(template, "py_get_writer_options")
-
-        expected = '.format("delta")\n.option("path", "s3://fake_location/schema__dbt_tmp")'
         assert result == expected
 
     def test_py_get_writer__partition_by_single_column(self, config, template):

--- a/tests/unit/macros/adapters/test_python_macros.py
+++ b/tests/unit/macros/adapters/test_python_macros.py
@@ -1,5 +1,4 @@
 import pytest
-from jinja2 import Template
 from mock import MagicMock
 
 from tests.unit.macros.base import MacroTestBase

--- a/tests/unit/macros/relations/test_table_macros.py
+++ b/tests/unit/macros/relations/test_table_macros.py
@@ -28,6 +28,10 @@ class TestCreateTableAs(MacroTestBase):
         return template.globals
 
     def render_create_table_as(self, template_bundle, temporary=False, sql="select 1"):
+        external_path = f"/mnt/root/{template_bundle.relation.identifier}"
+        template_bundle.template.globals["adapter"].compute_external_path.return_value = (
+            external_path
+        )
         return self.run_macro(
             template_bundle.template,
             "databricks__create_table_as",


### PR DESCRIPTION
<!-- Please review our pull request review process in CONTRIBUTING.md before your proceed. -->

Resolves #812 

<!---
  Include the number of the issue addressed by this PR above if applicable.

  Example:
    resolves #1234

  Please review our pull request review process in CONTRIBUTING.md before your proceed.
-->

### Description

Adding config to have dbt-databricks add catalog and schema information to the path of external tables, to reduce the likelihood of conflicts arising from tables with the same name.  This is a huge pain in testing, but not sure if others hit this in the wild, hence why default is to not do this behavior.  We probably should have always been doing this, but it could potentially break existing workflows, another reason to default to False.

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
