### PR TITLE
Implement microbatch incremental strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Add `include_full_name_in_path` config boolean for external locations. This writes tables to {location_root}/{catalog}/{schema}/{table} ([823](https://github.com/databricks/dbt-databricks/pull/823))
 - Add a new `workflow_job` submission method for python, which creates a long-lived Databricks Workflow instead of a one-time run (thanks @kdazzle!) ([762](https://github.com/databricks/dbt-databricks/pull/762))
 - Allow for additional options to be passed to the Databricks Job API when using other python submission methods. For example, enable email_notifications (thanks @kdazzle!) ([762](https://github.com/databricks/dbt-databricks/pull/762))
+- Support microbatch incremental strategy using replace_where ([825](https://github.com/databricks/dbt-databricks/pull/825))
 
 ### Under the Hood
 

--- a/dbt/adapters/databricks/__version__.py
+++ b/dbt/adapters/databricks/__version__.py
@@ -1,1 +1,1 @@
-version: str = "1.8.7"
+version: str = "1.9.0b1"

--- a/dbt/adapters/databricks/impl.py
+++ b/dbt/adapters/databricks/impl.py
@@ -86,6 +86,7 @@ from dbt_common.behavior_flags import BehaviorFlag
 from dbt_common.utils import executor
 from dbt_common.utils.dict import AttrDict
 from dbt_common.exceptions import DbtConfigError
+from dbt_common.exceptions import DbtInternalError
 from dbt_common.contracts.config.base import BaseConfig
 
 if TYPE_CHECKING:
@@ -703,8 +704,12 @@ class DatabricksAdapter(SparkAdapter):
                 config_column = columns[name]
                 if isinstance(config_column, dict):
                     comment = columns[name].get("description", "")
-                else:
+                elif hasattr(config_column, "description"):
                     comment = config_column.description
+                else:
+                    raise DbtInternalError(
+                        f"Column {name} in model config is not a dictionary or ColumnInfo object."
+                    )
                 if comment != (column.comment or ""):
                     return_columns[name] = columns[name]
 

--- a/dbt/adapters/databricks/impl.py
+++ b/dbt/adapters/databricks/impl.py
@@ -650,7 +650,7 @@ class DatabricksAdapter(SparkAdapter):
             conn.transaction_open = False
 
     def valid_incremental_strategies(self) -> List[str]:
-        return ["append", "merge", "insert_overwrite", "replace_where"]
+        return ["append", "merge", "insert_overwrite", "replace_where", "microbatch"]
 
     @property
     def python_submission_helpers(self) -> Dict[str, Type[PythonJobHelper]]:

--- a/dbt/adapters/databricks/impl.py
+++ b/dbt/adapters/databricks/impl.py
@@ -22,6 +22,7 @@ from typing import Tuple
 from typing import Type
 from typing import TYPE_CHECKING
 from typing import Union
+from uuid import uuid4
 
 from dbt.adapters.base import AdapterConfig
 from dbt.adapters.base import PythonJobHelper
@@ -53,6 +54,9 @@ from dbt.adapters.databricks.python_models.python_submissions import (
 from dbt.adapters.databricks.python_models.python_submissions import JobClusterPythonJobHelper
 from dbt.adapters.databricks.python_models.python_submissions import (
     ServerlessClusterPythonJobHelper,
+)
+from dbt.adapters.databricks.python_models.python_submissions import (
+    WorkflowPythonJobHelper,
 )
 from dbt.adapters.databricks.relation import DatabricksRelation
 from dbt.adapters.databricks.relation import DatabricksRelationType
@@ -122,6 +126,7 @@ class DatabricksConfig(AdapterConfig):
     databricks_tags: Optional[Dict[str, str]] = None
     tblproperties: Optional[Dict[str, str]] = None
     zorder: Optional[Union[List[str], str]] = None
+    unique_tmp_table_suffix: bool = False
     skip_non_matched_step: Optional[bool] = None
     skip_matched_step: Optional[bool] = None
     matched_condition: Optional[str] = None
@@ -653,6 +658,7 @@ class DatabricksAdapter(SparkAdapter):
             "job_cluster": JobClusterPythonJobHelper,
             "all_purpose_cluster": AllPurposeClusterPythonJobHelper,
             "serverless_cluster": ServerlessClusterPythonJobHelper,
+            "workflow_job": WorkflowPythonJobHelper,
         }
 
     @available
@@ -728,6 +734,10 @@ class DatabricksAdapter(SparkAdapter):
             raise NotImplementedError(
                 f"Materialization {model.config.materialized} is not supported."
             )
+
+    @available
+    def generate_unique_temporary_table_suffix(self, suffix_initial: str = "__dbt_tmp") -> str:
+        return f"{suffix_initial}_{str(uuid4())}"
 
 
 @dataclass(frozen=True)

--- a/dbt/adapters/databricks/impl.py
+++ b/dbt/adapters/databricks/impl.py
@@ -701,8 +701,8 @@ class DatabricksAdapter(SparkAdapter):
             name = column.column
             if (
                 name in columns
-                and "description" in columns[name]
-                and columns[name]["description"] != (column.comment or "")
+                and columns[name].description
+                and columns[name].description != (column.comment or "")
             ):
                 return_columns[name] = columns[name]
 

--- a/dbt/include/databricks/macros/materializations/incremental/strategies.sql
+++ b/dbt/include/databricks/macros/materializations/incremental/strategies.sql
@@ -177,10 +177,10 @@ select {{source_cols_csv}} from {{ source_relation }}
   {%- set start_time = config.get("__dbt_internal_microbatch_event_time_start") -%}
   {%- set end_time = config.get("__dbt_internal_microbatch_event_time_end") -%}
   {%- if start_time -%}
-    {%- do incremental_predicates.append(event_time ~ " >= '" ~ start_time ~ "'") -%}
+    {%- do incremental_predicates.append("cast(" ~ event_time ~ " as TIMESTAMP) >= '" ~ start_time ~ "'") -%}
   {%- endif -%}
   {%- if end_time -%}
-    {%- do incremental_predicates.append(event_time ~ " < '" ~ end_time ~ "'") -%}
+    {%- do incremental_predicates.append("cast(" ~ event_time ~ " as TIMESTAMP) < '" ~ end_time ~ "'") -%}
   {%- endif -%}
   {%- do arg_dict.update({'incremental_predicates': incremental_predicates}) -%}
   {{ return(get_replace_where_sql(arg_dict)) }}

--- a/dbt/include/databricks/macros/materializations/incremental/validate.sql
+++ b/dbt/include/databricks/macros/materializations/incremental/validate.sql
@@ -35,13 +35,13 @@
     Use the 'merge' or 'replace_where' strategy instead
   {%- endset %}
 
-  {% if raw_strategy not in ['append', 'merge', 'insert_overwrite', 'replace_where'] %}
+  {% if raw_strategy not in ['append', 'merge', 'insert_overwrite', 'replace_where', 'microbatch'] %}
     {% do exceptions.raise_compiler_error(invalid_strategy_msg) %}
   {%-else %}
     {% if raw_strategy == 'merge' and file_format not in ['delta', 'hudi'] %}
       {% do exceptions.raise_compiler_error(invalid_delta_only_msg) %}
     {% endif %}
-    {% if raw_strategy == 'replace_where' and file_format not in ['delta'] %}
+    {% if raw_strategy in ('replace_where', 'microbatch') and file_format not in ['delta'] %}
       {% do exceptions.raise_compiler_error(invalid_delta_only_msg) %}
     {% endif %}
   {% endif %}

--- a/tests/functional/adapter/microbatch/fixtures.py
+++ b/tests/functional/adapter/microbatch/fixtures.py
@@ -1,0 +1,16 @@
+schema = """version: 2
+models:
+  - name: input_model
+
+  - name: microbatch_model
+    config:
+      persist_docs:
+        relation: True
+        columns: True
+    description: This is a microbatch model
+    columns:
+      - name: id
+        description: "Id of the model"
+      - name: event_time
+        description: "Timestamp of the event"
+"""

--- a/tests/functional/adapter/microbatch/test_microbatch.py
+++ b/tests/functional/adapter/microbatch/test_microbatch.py
@@ -1,0 +1,16 @@
+from dbt.tests.adapter.incremental.test_incremental_microbatch import (
+    BaseMicrobatch,
+)
+import pytest
+
+from tests.functional.adapter.microbatch import fixtures
+
+
+class TestDatabricksMicrobatch(BaseMicrobatch):
+    @pytest.fixture(scope="class")
+    def models(self, microbatch_model_sql, input_model_sql):
+        return {
+            "schema.yml": fixtures.schema,
+            "input_model.sql": input_model_sql,
+            "microbatch_model.sql": microbatch_model_sql,
+        }


### PR DESCRIPTION
<!-- Please review our pull request review process in CONTRIBUTING.md before your proceed. -->

Resolves #824

<!---
  Include the number of the issue addressed by this PR above if applicable.

  Example:
    resolves #1234

  Please review our pull request review process in CONTRIBUTING.md before your proceed.
-->

### Description

Implements the microbatch incremental strategy: https://docs.getdbt.com/docs/build/incremental-microbatch

Core idea is that dbt will determine slices of time to break up an insert into multiple statements; we run a replace-where with those slices so that any old data is replaced by the newest version of that data.  This makes it much easier for users to back fill, and on failure, only rerun the slices that failed.

I have to cast the column to TIMESTAMP, as if your event_time column is a date, Databricks casts the conditions to date and then it looks like
replace where date >= X and date < X

I also hit an issue with column comments that I think was introduced in dbt-core 1.9.0b2 that I have fixed here.

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
