### PR TITLE
Propose fix for connection testing issues in Cloud.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Fix places where we were not properly closing cursors, and other test warnings ([713](https://github.com/databricks/dbt-databricks/pull/713))
 - Drop support for Python 3.8 ([713](https://github.com/databricks/dbt-databricks/pull/713))
 - Upgrade databricks-sql-connector dependency to 3.5.0 ([833](https://github.com/databricks/dbt-databricks/pull/833))
+- Fix behavior flag use in init of DatabricksAdapter ([836](https://github.com/databricks/dbt-databricks/pull/836/files))
 
 ## dbt-databricks 1.8.7 (October 10, 2024)
 

--- a/dbt/adapters/databricks/impl.py
+++ b/dbt/adapters/databricks/impl.py
@@ -85,6 +85,7 @@ from dbt.adapters.spark.impl import SparkAdapter
 from dbt_common.behavior_flags import BehaviorFlag
 from dbt_common.utils import executor
 from dbt_common.utils.dict import AttrDict
+from dbt_common.exceptions import CompilationError
 from dbt_common.exceptions import DbtConfigError
 from dbt_common.exceptions import DbtInternalError
 from dbt_common.contracts.config.base import BaseConfig

--- a/tests/functional/adapter/columns/test_get_columns.py
+++ b/tests/functional/adapter/columns/test_get_columns.py
@@ -13,6 +13,9 @@ class ColumnsInRelation:
 
     @pytest.fixture(scope="class", autouse=True)
     def setup(self, project):
+        # debug uses different rules for managing project flags than run
+        util.run_dbt(["debug"])
+
         util.run_dbt(["run"])
 
     @pytest.fixture(scope="class")

--- a/tests/functional/adapter/columns/test_get_columns.py
+++ b/tests/functional/adapter/columns/test_get_columns.py
@@ -14,7 +14,7 @@ class ColumnsInRelation:
     @pytest.fixture(scope="class", autouse=True)
     def setup(self, project):
         # debug uses different rules for managing project flags than run
-        util.run_dbt(["debug"])
+        util.run_dbt(["debug", "--connection"])
 
         util.run_dbt(["run"])
 


### PR DESCRIPTION
### Description

dbt cloud has a feature for testing connections. It and other features are currently failing due to adapter behavior flags not being registered for those runs. 

If we look at [these lines](https://github.com/databricks/dbt-databricks/blob/84fc024fb8e881ef5dc59d09a56bfcba99842091/dbt/adapters/databricks/impl.py#L183-L188), we see the use of a flag in the adapter class init.  This was par t of #808 

```
    def __init__(self, config: Any, mp_context: SpawnContext) -> None:
        super().__init__(config, mp_context)
        if self.behavior.use_info_schema_for_columns.no_warn:  # type: ignore[attr-defined]
            self.get_column_behavior = GetColumnsByInformationSchema()
        else:
            self.get_column_behavior = GetColumnsByDescribe()
```

This is not guaranteed to succeed. So we can use exception handling to ensure the control flow for other subtasks where the flags won't be registered are handled gracefully.

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
