### PR TITLE
Update split part to use safe operation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@
 - Allow for additional options to be passed to the Databricks Job API when using other python submission methods. For example, enable email_notifications (thanks @kdazzle!) ([762](https://github.com/databricks/dbt-databricks/pull/762))
 - Support microbatch incremental strategy using replace_where ([825](https://github.com/databricks/dbt-databricks/pull/825))
 
+### Fixes
+
+- Replace array indexing with 'get' in split_part so as not to raise exception when indexing beyond bounds ([839](https://github.com/databricks/dbt-databricks/pull/839))
+
 ### Under the Hood
 
 - Significant refactoring and increased testing of python_submissions ([830](https://github.com/databricks/dbt-databricks/pull/830))

--- a/dbt/include/databricks/macros/utils/split_part.sql
+++ b/dbt/include/databricks/macros/utils/split_part.sql
@@ -1,0 +1,43 @@
+{% macro databricks__split_part(string_text, delimiter_text, part_number) %}
+
+    {% set delimiter_expr %}
+
+        -- escape if starts with a special character
+        case when regexp_extract({{ delimiter_text }}, '([^A-Za-z0-9])(.*)', 1) != '_'
+            then concat('\\', {{ delimiter_text }})
+            else {{ delimiter_text }} end
+
+    {% endset %}
+
+    {% if part_number >= 0 %}
+
+        {% set split_part_expr %}
+
+        get(split(
+            {{ string_text }},
+            {{ delimiter_expr }}
+            ), {{ part_number - 1 if part_number > 0 else part_number }})
+
+        {% endset %}
+
+    {% else %}
+
+        {% set split_part_expr %}
+
+        get(split(
+            {{ string_text }},
+            {{ delimiter_expr }}
+            ), 
+                length({{ string_text }})
+                - length(
+                    replace({{ string_text }},  {{ delimiter_text }}, '')
+                ) + 1 + {{ part_number }}
+            )
+
+        {% endset %}
+
+    {% endif %}
+
+    {{ return(split_part_expr) }}
+
+{% endmacro %}


### PR DESCRIPTION
### Description

Hit issue with internal testing; turns out that the split_part macro in dbt-spark uses unsafe indexing (which is a totally reasonable choice), but the adapter tests expect it to be safe to index beyond the number of matched parts.  Switching to 'get' fixes the issue.

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
