### PR TITLE
Downgrade dbt-core dependency to concrete required version (i.e. first one with behavior flags)

### DIFF
--- a/dbt/adapters/databricks/impl.py
+++ b/dbt/adapters/databricks/impl.py
@@ -665,6 +665,7 @@ class DatabricksAdapter(SparkAdapter):
             cursor.close()
             conn.transaction_open = False
 
+    @available
     def valid_incremental_strategies(self) -> list[str]:
         valid_strategies = ["append", "merge", "insert_overwrite", "replace_where"]
         if SUPPORT_MICROBATCH:

--- a/dbt/adapters/databricks/impl.py
+++ b/dbt/adapters/databricks/impl.py
@@ -84,14 +84,14 @@ from dbt_common.exceptions import DbtConfigError
 from dbt_common.exceptions import DbtInternalError
 from dbt_common.contracts.config.base import BaseConfig
 
-import pkg_resources
+from importlib import metadata
 from packaging import version
 
 if TYPE_CHECKING:
     from agate import Row
     from agate import Table
 
-dbt_version = pkg_resources.get_distribution("dbt-core").version
+dbt_version = metadata.version("dbt-core")
 SUPPORT_MICROBATCH = version.parse(dbt_version) >= version.parse("1.9.0b1")
 
 CURRENT_CATALOG_MACRO_NAME = "current_catalog"

--- a/dbt/adapters/databricks/impl.py
+++ b/dbt/adapters/databricks/impl.py
@@ -84,9 +84,15 @@ from dbt_common.exceptions import DbtConfigError
 from dbt_common.exceptions import DbtInternalError
 from dbt_common.contracts.config.base import BaseConfig
 
+import pkg_resources
+from packaging import version
+
 if TYPE_CHECKING:
     from agate import Row
     from agate import Table
+
+dbt_version = pkg_resources.get_distribution("dbt-core").version
+SUPPORT_MICROBATCH = version.parse(dbt_version) >= version.parse("1.9.0b1")
 
 CURRENT_CATALOG_MACRO_NAME = "current_catalog"
 USE_CATALOG_MACRO_NAME = "use_catalog"
@@ -660,7 +666,11 @@ class DatabricksAdapter(SparkAdapter):
             conn.transaction_open = False
 
     def valid_incremental_strategies(self) -> list[str]:
-        return ["append", "merge", "insert_overwrite", "replace_where", "microbatch"]
+        valid_strategies = ["append", "merge", "insert_overwrite", "replace_where"]
+        if SUPPORT_MICROBATCH:
+            valid_strategies.append("microbatch")
+
+        return valid_strategies
 
     @property
     def python_submission_helpers(self) -> dict[str, type[PythonJobHelper]]:

--- a/dbt/include/databricks/macros/materializations/incremental/validate.sql
+++ b/dbt/include/databricks/macros/materializations/incremental/validate.sql
@@ -35,7 +35,7 @@
     Use the 'merge' or 'replace_where' strategy instead
   {%- endset %}
 
-  {% if raw_strategy not in adapter.valid_incremental_strategies %}
+  {% if raw_strategy not in adapter.valid_incremental_strategies() %}
     {% do exceptions.raise_compiler_error(invalid_strategy_msg) %}
   {%-else %}
     {% if raw_strategy == 'merge' and file_format not in ['delta', 'hudi'] %}

--- a/dbt/include/databricks/macros/materializations/incremental/validate.sql
+++ b/dbt/include/databricks/macros/materializations/incremental/validate.sql
@@ -35,7 +35,7 @@
     Use the 'merge' or 'replace_where' strategy instead
   {%- endset %}
 
-  {% if raw_strategy not in ['append', 'merge', 'insert_overwrite', 'replace_where', 'microbatch'] %}
+  {% if raw_strategy not in adapter.valid_strategies %}
     {% do exceptions.raise_compiler_error(invalid_strategy_msg) %}
   {%-else %}
     {% if raw_strategy == 'merge' and file_format not in ['delta', 'hudi'] %}

--- a/dbt/include/databricks/macros/materializations/incremental/validate.sql
+++ b/dbt/include/databricks/macros/materializations/incremental/validate.sql
@@ -35,7 +35,7 @@
     Use the 'merge' or 'replace_where' strategy instead
   {%- endset %}
 
-  {% if raw_strategy not in adapter.valid_strategies %}
+  {% if raw_strategy not in adapter.valid_incremental_strategies %}
     {% do exceptions.raise_compiler_error(invalid_strategy_msg) %}
   {%-else %}
     {% if raw_strategy == 'merge' and file_format not in ['delta', 'hudi'] %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 databricks-sql-connector>=3.5.0, <4.0
-dbt-spark>=1.9.0b1, <2.0
-dbt-core>=1.9.0b1, <2.0
+dbt-spark>=1.8.0, <2.0
+dbt-core>=1.8.7, <2.0
 dbt-common>=1.10.0, <2.0
 dbt-adapters>=1.7.0, <2.0
 databricks-sdk==0.17.0

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 import os
 import sys
 
-# require python 3.8 or newer
+# require python 3.9 or newer
 if sys.version_info < (3, 9):
     print("Error: dbt does not support this version of Python.")
     print("Please upgrade to Python 3.9 or higher.")
@@ -54,8 +54,8 @@ setup(
     packages=find_namespace_packages(include=["dbt", "dbt.*"]),
     include_package_data=True,
     install_requires=[
-        "dbt-spark>=1.9.0b1, <2.0",
-        "dbt-core>=1.9.0b1, <2.0",
+        "dbt-spark>=1.8.0, <2.0",
+        "dbt-core>=1.8.7, <2.0",
         "dbt-adapters>=1.7.0, <2.0",
         "dbt-common>=1.10.0, <2.0",
         "databricks-sql-connector>=3.5.0, <4.0.0",

--- a/tests/functional/adapter/microbatch/test_microbatch.py
+++ b/tests/functional/adapter/microbatch/test_microbatch.py
@@ -2,10 +2,18 @@ from dbt.tests.adapter.incremental.test_incremental_microbatch import (
     BaseMicrobatch,
 )
 import pytest
+from packaging import version
+import pkg_resources
 
 from tests.functional.adapter.microbatch import fixtures
 
+dbt_version = pkg_resources.get_distribution("dbt-core").version
 
+
+@pytest.mark.skipif(
+    version.parse(dbt_version) < version.parse("1.9.0b1"),
+    reason="Microbatch is not supported with this version of core",
+)
 class TestDatabricksMicrobatch(BaseMicrobatch):
     @pytest.fixture(scope="class")
     def models(self, microbatch_model_sql, input_model_sql):

--- a/tests/functional/adapter/microbatch/test_microbatch.py
+++ b/tests/functional/adapter/microbatch/test_microbatch.py
@@ -3,11 +3,11 @@ from dbt.tests.adapter.incremental.test_incremental_microbatch import (
 )
 import pytest
 from packaging import version
-import pkg_resources
+from importlib import metadata
 
 from tests.functional.adapter.microbatch import fixtures
 
-dbt_version = pkg_resources.get_distribution("dbt-core").version
+dbt_version = metadata.version("dbt-core")
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
<!---
  Include the number of the issue addressed by this PR above if applicable.

  Example:
    resolves #1234

  Please review our pull request review process in CONTRIBUTING.md before your proceed.
-->

### Description

We would like to release our 1.9.0 soon, but dbt-core 1.9.0 has been postponed to December.  In this PR I'm lowering our dependency to released versions, and hiding microbatch as a valid strategy if your installed version is too low (because it will super break otherwise).

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
