### PR TITLE
Upgrade `protobuf` pin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - Fix behavior flag use in init of DatabricksAdapter (thanks @VersusFacit!) ([836](https://github.com/databricks/dbt-databricks/pull/836))
 - Restrict pydantic to V1 per dbt Labs' request ([843](https://github.com/databricks/dbt-databricks/pull/843))
 - Switching to Ruff for formatting and linting ([847](https://github.com/databricks/dbt-databricks/pull/847))
+- Pin protobuf to 5.x to stop incompatibility breaks ([](https://github.com/databricks/dbt-databricks/pull/))
 
 ## dbt-databricks 1.8.7 (October 10, 2024)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@
 - Fix behavior flag use in init of DatabricksAdapter (thanks @VersusFacit!) ([836](https://github.com/databricks/dbt-databricks/pull/836))
 - Restrict pydantic to V1 per dbt Labs' request ([843](https://github.com/databricks/dbt-databricks/pull/843))
 - Switching to Ruff for formatting and linting ([847](https://github.com/databricks/dbt-databricks/pull/847))
-- Pin protobuf to 5.x to stop incompatibility breaks ([](https://github.com/databricks/dbt-databricks/pull/))
+- Pin protobuf to 5.x to stop incompatibility breaks ([850](https://github.com/databricks/dbt-databricks/pull/850))
 
 ## dbt-databricks 1.8.7 (October 10, 2024)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ dbt-common>=1.10.0, <2.0
 dbt-adapters>=1.7.0, <2.0
 databricks-sdk==0.17.0
 keyring>=23.13.0
-protobuf<5.0.0
+protobuf>=5.0.0,<6.0.0
 pydantic>=1.10.0, <2

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ setup(
         "databricks-sdk==0.17.0",
         "keyring>=23.13.0",
         "pandas<2.2.0",
-        "protobuf<5.0.0",
+        "protobuf>=5.0.0,<6.0.0",
         "pydantic>=1.10.0, <2",
     ],
     zip_safe=False,


### PR DESCRIPTION
Signed-off-by: Mike Alfare <alfare@gmail.com>

### Description

dbt is updating `protobuf` to `>=5.0,<6.0` in `dbt-common`, `dbt-adapters`, and `dbt-core`. This package was pinned in `dbt-databricks` to avoid version conflicts. Since `protobuf` does not allow for multiple majors in the same project, this needs to be updated as a breaking change. This PR mitigates the impact of upgrading in the dbt packages.

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.