### PR TITLE
Try setting queue enabled for Python notebook jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 ### Fixes
 
 - Replace array indexing with 'get' in split_part so as not to raise exception when indexing beyond bounds ([839](https://github.com/databricks/dbt-databricks/pull/839))
+- Set queue enabled for Python notebook jobs ([856](https://github.com/databricks/dbt-databricks/pull/856))
 
 ### Under the Hood
 

--- a/dbt/adapters/databricks/python_models/python_submissions.py
+++ b/dbt/adapters/databricks/python_models/python_submissions.py
@@ -224,6 +224,7 @@ class PythonJobConfigCompiler:
         if access_control_list:
             job_spec["access_control_list"] = access_control_list
 
+        job_spec["queue"] = {"enabled": True}
         return PythonJobDetails(self.run_name, job_spec, additional_job_config)
 
 

--- a/tests/unit/python/test_python_job_support.py
+++ b/tests/unit/python/test_python_job_support.py
@@ -158,6 +158,7 @@ class TestPythonJobConfigCompiler:
                 "notebook_path": "path",
             },
             "libraries": [],
+            "queue": {"enabled": True},
         }
         assert details.additional_job_config == {}
 
@@ -182,5 +183,6 @@ class TestPythonJobConfigCompiler:
             "cluster_id": "id",
             "libraries": [{"pypi": {"package": "foo"}}],
             "access_control_list": [{"user_name": "user", "permission_level": "IS_OWNER"}],
+            "queue": {"enabled": True},
         }
         assert details.additional_job_config == {"foo": "bar"}


### PR DESCRIPTION
<!---
  Include the number of the issue addressed by this PR above if applicable.

  Example:
    resolves #1234

  Please review our pull request review process in CONTRIBUTING.md before your proceed.
-->

### Description

Hearing again from users about multiple python models having concurrency issues.  We definitely want to queue if necessary, but not sure if this is actually the problem.  Setting this shouldn't hurt though.

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
