### PR TITLE
Introduce PySpark Session support ( enables the adapter usage for job clusters)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ logs/
 *.sublime*
 .python-version
 .hatch
+venv/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 ## dbt-databricks 1.9.0 (TBD)
 
 ### Features
-
 - Add config for generating unique tmp table names for enabling parralel merge (thanks @huangxingyi-git!) ([854](https://github.com/databricks/dbt-databricks/pull/854))
 - Add support for serverless job clusters on python models ([706](https://github.com/databricks/dbt-databricks/pull/706))
 - Add 'user_folder_for_python' behavior to switch writing python model notebooks to the user's folder ([835](https://github.com/databricks/dbt-databricks/pull/835))
@@ -18,6 +17,7 @@
 - Add a new `workflow_job` submission method for python, which creates a long-lived Databricks Workflow instead of a one-time run (thanks @kdazzle!) ([762](https://github.com/databricks/dbt-databricks/pull/762))
 - Allow for additional options to be passed to the Databricks Job API when using other python submission methods. For example, enable email_notifications (thanks @kdazzle!) ([762](https://github.com/databricks/dbt-databricks/pull/762))
 - Support microbatch incremental strategy using replace_where ([825](https://github.com/databricks/dbt-databricks/pull/825))
+- Support pyspark session connection ([862]https://github.com/databricks/dbt-databricks/pull/862)
 
 ### Fixes
 

--- a/dbt/adapters/databricks/session_connection.py
+++ b/dbt/adapters/databricks/session_connection.py
@@ -1,0 +1,42 @@
+import re
+import sys
+from typing import Tuple
+
+from dbt.adapters.spark.session import Connection
+from dbt.adapters.spark.session import SessionConnectionWrapper
+
+DBR_VERSION_REGEX = re.compile(r"([1-9][0-9]*)\.(x|0|[1-9][0-9]*)")
+
+
+class DatabricksSessionConnectionWrapper(SessionConnectionWrapper):
+    _is_cluster: bool
+    _dbr_version: Tuple[int, int]
+
+    def __init__(self, handle: Connection) -> None:
+        super().__init__(handle)
+        self._is_cluster = True
+        self.cursor()
+
+    @property
+    def dbr_version(self) -> Tuple[int, int]:
+        if not hasattr(self, "_dbr_version"):
+            if self._is_cluster:
+                with self._cursor() as cursor:
+                    cursor.execute("SET spark.databricks.clusterUsageTags.sparkVersion")
+                    results = cursor.fetchone()
+                    if results:
+                        dbr_version: str = results[1]
+
+                m = DBR_VERSION_REGEX.search(dbr_version)
+                assert m, f"Unknown DBR version: {dbr_version}"
+                major = int(m.group(1))
+                try:
+                    minor = int(m.group(2))
+                except ValueError:
+                    minor = sys.maxsize
+                self._dbr_version = (major, minor)
+            else:
+                # Assuming SQL Warehouse uses the latest version.
+                self._dbr_version = (sys.maxsize, sys.maxsize)
+
+        return self._dbr_version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,10 +91,29 @@ uc-cluster-e2e = "pytest --color=yes -v --profile databricks_uc_cluster -n auto 
 sqlw-e2e = "pytest --color=yes -v --profile databricks_uc_sql_endpoint -n auto --dist=loadscope tests/functional"
 
 [tool.hatch.envs.test.scripts]
-unit = "pytest --color=yes -v --profile databricks_cluster -n auto --dist=loadscope tests/unit"
+unit = """
+if [[ "$DBT_DATABRICKS_SESSION_CONNECTION" == "True" ]]; then
+  PROFILE="session_connection"
+else
+  PROFILE="databricks_cluster"
+fi
+
+pytest --color=yes -v --profile $PROFILE -n auto --dist=loadscope tests/unit
+"""
 
 [[tool.hatch.envs.test.matrix]]
 python = ["3.9", "3.10", "3.11", "3.12"]
+session_support = ["no_session", "session"]
+
+
+[tool.hatch.envs.test.overrides]
+matrix.session_support.env-vars = [
+  { key = "DBT_DATABRICKS_SESSION_CONNECTION", value = "False", if = ["no_session"]},
+  { key = "DBT_DATABRICKS_SESSION_CONNECTION", value = "True", if = ["session"] }
+]
+
+
+
 
 [tool.ruff]
 line-length = 100

--- a/tests/unit/test_adapter.py
+++ b/tests/unit/test_adapter.py
@@ -110,6 +110,7 @@ class TestDatabricksAdapter(DatabricksAdapterBase):
         test_http_headers(["a", "b"])
         test_http_headers({"a": 1, "b": 2})
 
+    @pytest.mark.skip_profile("session_connection")
     def test_invalid_custom_user_agent(self):
         with pytest.raises(DbtValidationError) as excinfo:
             config = self._get_config()
@@ -120,6 +121,7 @@ class TestDatabricksAdapter(DatabricksAdapterBase):
 
         assert "Invalid invocation environment" in str(excinfo.value)
 
+    @pytest.mark.skip_profile("session_connection")
     def test_custom_user_agent(self):
         config = self._get_config()
         adapter = DatabricksAdapter(config, get_context("spawn"))
@@ -134,12 +136,14 @@ class TestDatabricksAdapter(DatabricksAdapterBase):
                 connection = adapter.acquire_connection("dummy")
                 connection.handle  # trigger lazy-load
 
+    @pytest.mark.skip_profile("session_connection")
     def test_environment_single_http_header(self):
         self._test_environment_http_headers(
             http_headers_str='{"test":{"jobId":1,"runId":12123}}',
             expected_http_headers=[("test", '{"jobId": 1, "runId": 12123}')],
         )
 
+    @pytest.mark.skip_profile("session_connection")
     def test_environment_multiple_http_headers(self):
         self._test_environment_http_headers(
             http_headers_str='{"test":{"jobId":1,"runId":12123},"dummy":{"jobId":1,"runId":12123}}',
@@ -149,6 +153,7 @@ class TestDatabricksAdapter(DatabricksAdapterBase):
             ],
         )
 
+    @pytest.mark.skip_profile("session_connection")
     def test_environment_users_http_headers_intersection_error(self):
         with pytest.raises(DbtValidationError) as excinfo:
             self._test_environment_http_headers(
@@ -159,6 +164,7 @@ class TestDatabricksAdapter(DatabricksAdapterBase):
 
         assert "Intersection with reserved http_headers in keys: {'t'}" in str(excinfo.value)
 
+    @pytest.mark.skip_profile("session_connection")
     def test_environment_users_http_headers_union_success(self):
         self._test_environment_http_headers(
             http_headers_str='{"t":{"jobId":1,"runId":12123},"d":{"jobId":1,"runId":12123}}',
@@ -170,6 +176,7 @@ class TestDatabricksAdapter(DatabricksAdapterBase):
             ],
         )
 
+    @pytest.mark.skip_profile("session_connection")
     def test_environment_http_headers_string(self):
         self._test_environment_http_headers(
             http_headers_str='{"string":"some-string"}',
@@ -269,6 +276,7 @@ class TestDatabricksAdapter(DatabricksAdapterBase):
 
         return connect
 
+    @pytest.mark.skip_profile("session_connection")
     def test_databricks_sql_connector_connection(self):
         self._test_databricks_sql_connector_connection(self._connect_func())
 
@@ -291,6 +299,7 @@ class TestDatabricksAdapter(DatabricksAdapterBase):
             assert len(connection.credentials.session_properties) == 1
             assert connection.credentials.session_properties["spark.sql.ansi.enabled"] == "true"
 
+    @pytest.mark.skip_profile("session_connection")
     def test_databricks_sql_connector_catalog_connection(self):
         self._test_databricks_sql_connector_catalog_connection(
             self._connect_func(expected_catalog="main")
@@ -314,6 +323,7 @@ class TestDatabricksAdapter(DatabricksAdapterBase):
             assert connection.credentials.schema == "analytics"
             assert connection.credentials.database == "main"
 
+    @pytest.mark.skip_profile("session_connection")
     def test_databricks_sql_connector_http_header_connection(self):
         self._test_databricks_sql_connector_http_header_connection(
             {"aaa": "xxx"}, self._connect_func(expected_http_headers=[("aaa", "xxx")])


### PR DESCRIPTION
<!-- Please review our pull request review process in CONTRIBUTING.md before your proceed. -->

Resolves #


 Resolves: [[dbt-spark Issue #272](https://github.com/dbt-labs/dbt-spark/issues/272)] ,[[dbt-databricks Issue #575]](https://github.com/databricks/dbt-databricks/issues/575)


 

### Description

### Pull Request Description  

**Summary**  
This PR introduces support for defining a PySpark-based connection when using the adapter. This enhancement allows dbt to run as part of a running Databricks job cluster, expanding its usage beyond SQL warehouses or all-purpose clusters.  

**Background**  
The Spark session functionality referenced here was first discussed in [[dbt-spark Issue #272](https://github.com/dbt-labs/dbt-spark/issues/272)]. Specifically for databricks ,  the issue was raised here :[[dbt-databricks Issue #575]](https://github.com/databricks/dbt-databricks/issues/575)


**Key Features**  
1. **PySpark-Based Connection**:  
   A new environment variable, `DBT_DATABRICKS_SESSION_CONNECTION`, has been introduced.  
   - When this variable is set to `True`, a new `DatabricksSessionConnectionManager` is initialized.  
   - This manager assumes that the dbt code is being executed in the context of an existing Spark session, making it possible to integrate with running Databricks job clusters.  

2. **Testing**:  
   - A new pytest  matrix feature called session_support was introduced in to the unit tests. When the session support is enabled , the DBT_DATABRICKS_SESSION_CONNECTION env var is set to true and the unit tests are being executed against the new DatabricksSessionConnectionManager


3. **Functional Testing**:  
   Functional tests were conducted using a Databricks notebook.  
   - The notebook programmatically triggered dbt while ensuring the `DBT_DATABRICKS_SESSION_CONNECTION` variable was set to `True`.  
   - These tests confirmed that dbt works seamlessly within a running Spark session.  
   - example notebook  code: 
   `os.environ["DBT_DATABRICKS_SESSION_CONNECTION"] = "True"

     res = dbtRunner().invoke(["run","--profiles-dir","/Workspace/Users/doron.kruh@yotpo.com/dbt-dbx-session-test/","--project-dir","/Workspace/Users/user@databrciks.com/dbt-models","--target","prod", "--select","model_to_execute"] )`

**Why This Matters**  
- Enables running dbt within existing Spark sessions, providing more flexibility for advanced Databricks workflows.  
- Expands the range of cluster types supported by dbt.  
- Supports integration with Databricks job clusters, ensuring compatibility with real-world use cases.  

**Next Steps**  
- Document this feature for users who may need it.  
- Verify compatibility with additional Databricks environments as needed.
### Checklist

- [X ] I have run this code in development and it appears to resolve the stated issue
- [X ] This PR includes tests, or tests are not required/relevant for this PR
- [X ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.


