### PR TITLE
More cleanup work for forward compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
-## dbt-databricks 1.9.0 (TBD)
+## dbt-databricks 1.9.1 (TBD)
+
+### Under the Hood
+
+- Remove pandas pin, and add UP ruleset ([865](https://github.com/databricks/dbt-databricks/pull/865))
+
+## dbt-databricks 1.9.0 (December 9, 2024)
 
 ### Features
 

--- a/dbt/adapters/databricks/api_client.py
+++ b/dbt/adapters/databricks/api_client.py
@@ -246,7 +246,7 @@ class PollableApi(DatabricksApi, ABC):
 
 
 @dataclass(frozen=True, eq=True, unsafe_hash=True)
-class CommandExecution(object):
+class CommandExecution:
     command_id: str
     context_id: str
     cluster_id: str

--- a/dbt/adapters/databricks/column.py
+++ b/dbt/adapters/databricks/column.py
@@ -28,7 +28,7 @@ class DatabricksColumn(SparkColumn):
         return self.translate_type(self.dtype)
 
     def __repr__(self) -> str:
-        return "<DatabricksColumn {} ({})>".format(self.name, self.data_type)
+        return f"<DatabricksColumn {self.name} ({self.data_type})>"
 
     @staticmethod
     def get_name(column: dict[str, Any]) -> str:

--- a/dbt/adapters/databricks/connections.py
+++ b/dbt/adapters/databricks/connections.py
@@ -5,13 +5,13 @@ import sys
 import time
 import uuid
 import warnings
-from collections.abc import Callable, Iterator, Sequence
+from collections.abc import Callable, Hashable, Iterator, Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass
 from multiprocessing.context import SpawnContext
 from numbers import Number
 from threading import get_ident
-from typing import TYPE_CHECKING, Any, Hashable, Optional, cast
+from typing import TYPE_CHECKING, Any, Optional, cast
 
 from dbt_common.events.contextvars import get_node_info
 from dbt_common.events.functions import fire_event
@@ -488,7 +488,7 @@ class DatabricksConnectionManager(SparkConnectionManager):
             try:
                 log_sql = redact_credentials(sql)
                 if abridge_sql_log:
-                    log_sql = "{}...".format(log_sql[:512])
+                    log_sql = f"{log_sql[:512]}..."
 
                 fire_event(
                     SQLQuery(

--- a/dbt/adapters/databricks/credentials.py
+++ b/dbt/adapters/databricks/credentials.py
@@ -136,9 +136,7 @@ class DatabricksCredentials(Credentials):
     def validate_creds(self) -> None:
         for key in ["host", "http_path"]:
             if not getattr(self, key):
-                raise DbtConfigError(
-                    f"The config '{key}' is required to connect to Databricks"
-                )
+                raise DbtConfigError(f"The config '{key}' is required to connect to Databricks")
         if not self.token and self.auth_type != "oauth":
             raise DbtConfigError(
                 "The config `auth_type: oauth` is required when not using access token"
@@ -146,10 +144,8 @@ class DatabricksCredentials(Credentials):
 
         if not self.client_id and self.client_secret:
             raise DbtConfigError(
-
-                    "The config 'client_id' is required to connect "
-                    "to Databricks when 'client_secret' is present"
-
+                "The config 'client_id' is required to connect "
+                "to Databricks when 'client_secret' is present"
             )
 
     @classmethod

--- a/dbt/adapters/databricks/credentials.py
+++ b/dbt/adapters/databricks/credentials.py
@@ -137,19 +137,19 @@ class DatabricksCredentials(Credentials):
         for key in ["host", "http_path"]:
             if not getattr(self, key):
                 raise DbtConfigError(
-                    "The config '{}' is required to connect to Databricks".format(key)
+                    f"The config '{key}' is required to connect to Databricks"
                 )
         if not self.token and self.auth_type != "oauth":
             raise DbtConfigError(
-                ("The config `auth_type: oauth` is required when not using access token")
+                "The config `auth_type: oauth` is required when not using access token"
             )
 
         if not self.client_id and self.client_secret:
             raise DbtConfigError(
-                (
+
                     "The config 'client_id' is required to connect "
                     "to Databricks when 'client_secret' is present"
-                )
+
             )
 
     @classmethod

--- a/dbt/adapters/databricks/impl.py
+++ b/dbt/adapters/databricks/impl.py
@@ -539,7 +539,7 @@ class DatabricksAdapter(SparkAdapter):
         used_schemas: frozenset[tuple[str, str]],
     ) -> tuple["Table", list[Exception]]:
         with executor(self.config) as tpe:
-            futures: list[Future["Table"]] = []
+            futures: list[Future[Table]] = []
             for schema, relations in relation_map.items():
                 if schema in used_schemas:
                     identifier = get_identifier_list_string(relations)
@@ -804,7 +804,7 @@ class DeltaLiveTableAPIBase(RelationAPIBase[DatabricksRelationConfig]):
     ) -> DatabricksRelationConfig:
         """Get the relation config from the relation."""
 
-        relation_config = super(DeltaLiveTableAPIBase, cls).get_from_relation(adapter, relation)
+        relation_config = super().get_from_relation(adapter, relation)
 
         # Ensure any current refreshes are completed before returning the relation config
         tblproperties = cast(TblPropertiesConfig, relation_config.config["tblproperties"])

--- a/dbt/adapters/databricks/python_models/run_tracking.py
+++ b/dbt/adapters/databricks/python_models/run_tracking.py
@@ -6,7 +6,7 @@ from dbt.adapters.databricks.api_client import CommandExecution, DatabricksApiCl
 from dbt.adapters.databricks.logging import logger
 
 
-class PythonRunTracker(object):
+class PythonRunTracker:
     _run_ids: set[str] = set()
     _commands: set[CommandExecution] = set()
     _lock = threading.Lock()

--- a/dbt/adapters/databricks/relation.py
+++ b/dbt/adapters/databricks/relation.py
@@ -1,6 +1,6 @@
 from collections.abc import Iterable
 from dataclasses import dataclass, field
-from typing import Any, Optional
+from typing import Any, Optional, Type
 
 from dbt_common.dataclass_schema import StrEnum
 from dbt_common.exceptions import DbtRuntimeError
@@ -131,7 +131,7 @@ class DatabricksRelation(BaseRelation):
         return match
 
     @classproperty
-    def get_relation_type(cls) -> type[DatabricksRelationType]:  # type: ignore
+    def get_relation_type(cls) -> Type[DatabricksRelationType]:  # noqa
         return DatabricksRelationType
 
     def information_schema(self, view_name: Optional[str] = None) -> InformationSchema:

--- a/dbt/adapters/databricks/relation.py
+++ b/dbt/adapters/databricks/relation.py
@@ -1,6 +1,6 @@
 from collections.abc import Iterable
 from dataclasses import dataclass, field
-from typing import Any, Optional, Type
+from typing import Any, Optional, Type  # noqa
 
 from dbt_common.dataclass_schema import StrEnum
 from dbt_common.exceptions import DbtRuntimeError

--- a/dbt/adapters/databricks/relation.py
+++ b/dbt/adapters/databricks/relation.py
@@ -1,6 +1,6 @@
 from collections.abc import Iterable
 from dataclasses import dataclass, field
-from typing import Any, Optional, Type
+from typing import Any, Optional
 
 from dbt_common.dataclass_schema import StrEnum
 from dbt_common.exceptions import DbtRuntimeError
@@ -131,7 +131,7 @@ class DatabricksRelation(BaseRelation):
         return match
 
     @classproperty
-    def get_relation_type(cls) -> Type[DatabricksRelationType]:
+    def get_relation_type(cls) -> type[DatabricksRelationType]:  # type: ignore
         return DatabricksRelationType
 
     def information_schema(self, view_name: Optional[str] = None) -> InformationSchema:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,7 @@ dependencies = [
     "ruff",
     "types-requests",
     "debugpy",
+    "pydantic>=1.10.0, <2",
 ]
 path = ".hatch"
 python = "3.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,8 +29,6 @@ dependencies = [
     "dbt-core>=1.8.7, <2.0",
     "dbt-spark>=1.8.0, <2.0",
     "keyring>=23.13.0",
-    "pandas<2.2.0",
-    "pydantic>=1.10.0, <2",
 ]
 
 [project.urls]
@@ -102,7 +100,7 @@ line-length = 100
 target-version = 'py39'
 
 [tool.ruff.lint]
-select = ["E", "W", "F", "I"]
+select = ["E", "W", "F", "I", "UP"]
 ignore = ["E203"]
 
 [tool.pytest.ini_options]

--- a/tests/functional/adapter/ephemeral/test_ephemeral.py
+++ b/tests/functional/adapter/ephemeral/test_ephemeral.py
@@ -33,7 +33,7 @@ class TestEphemeralNested(BaseEphemeral):
         results = util.run_dbt(["run"])
         assert len(results) == 2
         assert os.path.exists("./target/run/test/models/root_view.sql")
-        with open("./target/run/test/models/root_view.sql", "r") as fp:
+        with open("./target/run/test/models/root_view.sql") as fp:
             sql_file = fp.read()
 
         sql_file = re.sub(r"\d+", "", sql_file)

--- a/tests/functional/adapter/hooks/test_model_hooks.py
+++ b/tests/functional/adapter/hooks/test_model_hooks.py
@@ -49,7 +49,7 @@ class TestPrePostModelHooks(BaseTestPrePost):
             "invocation_id",
             "thread_id",
         ]
-        field_list = ", ".join(["{}".format(f) for f in fields])
+        field_list = ", ".join([f"{f}" for f in fields])
         query = (
             f"select {field_list} from {project.test_schema}.on_model_hook"
             f" where test_state = '{state}'"

--- a/tests/functional/adapter/hooks/test_run_hooks.py
+++ b/tests/functional/adapter/hooks/test_run_hooks.py
@@ -65,7 +65,7 @@ class TestPrePostRunHooks(BasePrePostRunHooks):
             "invocation_id",
             "thread_id",
         ]
-        field_list = ", ".join(["{}".format(f) for f in fields])
+        field_list = ", ".join([f"{f}" for f in fields])
         query = (
             f"select {field_list} from {project.test_schema}.on_run_hook where test_state = "
             f"'{state}'"

--- a/tests/functional/adapter/python_model/test_python_model.py
+++ b/tests/functional/adapter/python_model/test_python_model.py
@@ -58,7 +58,7 @@ class TestChangingSchema:
         )
         util.run_dbt(["run"])
         log_file = os.path.join(logs_dir, "dbt.log")
-        with open(log_file, "r") as f:
+        with open(log_file) as f:
             log = f.read()
             # validate #5510 log_code_execution works
             assert "On model.test.simple_python_model:" in log

--- a/tests/unit/api_client/test_workspace_api.py
+++ b/tests/unit/api_client/test_workspace_api.py
@@ -36,7 +36,7 @@ class TestWorkspaceApi(ApiTestBase):
 
     def test_upload_notebook__200(self, api, session, host):
         session.post.return_value.status_code = 200
-        encoded = base64.b64encode("code".encode()).decode()
+        encoded = base64.b64encode(b"code").decode()
         api.upload_notebook("path", "code")
         session.post.assert_called_once_with(
             f"https://{host}/api/2.0/workspace/import",

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -165,7 +165,7 @@ class MockKeyring(keyring.backend.KeyringBackend):
         if not os.path.exists(file_path):
             return None
 
-        with open(file_path, "r") as file:
+        with open(file_path) as file:
             password = file.read()
 
         return password


### PR DESCRIPTION
### Description

Adds and applies the UP ruff ruleset, which ensures that we're not using any deprecated python.  Also removed pandas pin for consistency with 1.8.x branch.

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
