### PR TITLE
MERGE EXTENSION: when not matched by source - update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 - Add 'user_folder_for_python' behavior to switch writing python model notebooks to the user's folder ([835](https://github.com/databricks/dbt-databricks/pull/835))
 - Merge capabilities are extended ([739](https://github.com/databricks/dbt-databricks/pull/739)) to include the support for the following features (thanks @mi-volodin):
   - `with schema evolution` clause (requires Databricks Runtime 15.2 or above);
-  - `when not matched by source` clause, only for `delete` action
+  - `when not matched by source` clause allows both `delete` and `update set ...` with explicit action list.
   - `matched`, `not matched` and `not matched by source` condition clauses;
   - custom aliases for source and target tables can be specified and used in condition clauses;
   - `matched` and `not matched` steps can now be skipped;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## dbt-databricks 1.9.1 (TBD)
 
+### Features
+
+- Merge strategy now supports the `update set ...` action with the explicit list of updates for `when not matched by source` ([866](https://github.com/databricks/dbt-databricks/pull/866)) (thanks @mi-volodin).
+
 ### Under the Hood
 
 - Removed pins for pandas and pydantic to ease user burdens ([874](https://github.com/databricks/dbt-databricks/pull/874))
@@ -13,7 +17,7 @@
 - Add 'user_folder_for_python' behavior to switch writing python model notebooks to the user's folder ([835](https://github.com/databricks/dbt-databricks/pull/835))
 - Merge capabilities are extended ([739](https://github.com/databricks/dbt-databricks/pull/739)) to include the support for the following features (thanks @mi-volodin):
   - `with schema evolution` clause (requires Databricks Runtime 15.2 or above);
-  - `when not matched by source` clause allows both `delete` and `update set ...` with explicit action list.
+  - `when not matched by source` clause, only for `delete` action
   - `matched`, `not matched` and `not matched by source` condition clauses;
   - custom aliases for source and target tables can be specified and used in condition clauses;
   - `matched` and `not matched` steps can now be skipped;

--- a/dbt/include/databricks/macros/materializations/incremental/strategies.sql
+++ b/dbt/include/databricks/macros/materializations/incremental/strategies.sql
@@ -91,6 +91,13 @@ select {{source_cols_csv}} from {{ source_relation }}
 
   {%- set not_matched_by_source_action = config.get('not_matched_by_source_action') -%}
   {%- set not_matched_by_source_condition = config.get('not_matched_by_source_condition') -%}
+
+  {%- set not_matched_by_source_action_trimmed = not_matched_by_source_action | trim(' \n\t') %}
+  {%- set not_matched_by_source_action_is_set = (
+      not_matched_by_source_action_trimmed.startswith('delete') 
+      or not_matched_by_source_action_trimmed.startswith('update')
+    )
+  %}
   
 
   {% if unique_key %}
@@ -137,12 +144,12 @@ select {{source_cols_csv}} from {{ source_relation }}
         then insert
             {{ get_merge_insert(on_schema_change, source_columns, source_alias) }}
     {%- endif %}
-    {%- if not_matched_by_source_action == 'delete' %}
+    {%- if not_matched_by_source_action_is_set %}
     when not matched by source
         {%- if not_matched_by_source_condition %}
         and ({{ not_matched_by_source_condition }})
         {%- endif %}
-        then delete
+        then {{ not_matched_by_source_action }}
     {%- endif %}
 {% endmacro %}
 

--- a/dbt/include/databricks/macros/materializations/incremental/strategies.sql
+++ b/dbt/include/databricks/macros/materializations/incremental/strategies.sql
@@ -92,14 +92,14 @@ select {{source_cols_csv}} from {{ source_relation }}
   {%- set not_matched_by_source_action = config.get('not_matched_by_source_action') -%}
   {%- set not_matched_by_source_condition = config.get('not_matched_by_source_condition') -%}
 
-  {%- set not_matched_by_source_action_trimmed = not_matched_by_source_action | trim(' \n\t') %}
+  {%- set not_matched_by_source_action_trimmed = not_matched_by_source_action | lower | trim(' \n\t') %}
   {%- set not_matched_by_source_action_is_set = (
-      not_matched_by_source_action_trimmed.startswith('delete') 
+      not_matched_by_source_action_trimmed == 'delete'
       or not_matched_by_source_action_trimmed.startswith('update')
     )
   %}
   
-
+  
   {% if unique_key %}
       {% if unique_key is sequence and unique_key is not mapping and unique_key is not string %}
           {% for key in unique_key %}

--- a/docs/databricks-merge.md
+++ b/docs/databricks-merge.md
@@ -46,7 +46,7 @@ Example below illustrates how these parameters affect the merge statement genera
     not_matched_by_source_condition='t.tech_change_ts < current_timestamp()',
     not_matched_by_source_action='''
         update set
-            t.attr1 = \'deleted\',
+            t.attr1 = 'deleted',
             t.tech_change_ts = current_timestamp()
     ''',
     merge_with_schema_evolution=true

--- a/docs/databricks-merge.md
+++ b/docs/databricks-merge.md
@@ -18,8 +18,11 @@ From v.1.9 onwards `merge` behavior can be tuned by setting the additional param
 
   - `skip_matched_step`: if set to `true`, dbt will completely skip the `matched` clause of the merge statement.
   - `skip_not_matched_step`: similarly if `true` the `not matched` clause will be skipped.
-  - `not_matched_by_source_action`: if set to `delete` the corresponding `when not matched by source ... then delete` clause will be added to the merge statement. 
-    Another option is to set it to `update set <actions>` format, which will run update statement syntactically as provided.
+  - `not_matched_by_source_action`: can be set to an action for the case the record does not exist in a source dataset. 
+    - if set to `delete` the corresponding `when not matched by source ... then delete` clause will be added to the merge statement. 
+    - if the action starts with `update` then the format `update set <actions>` is assumed, which will run update statement syntactically as provided.
+      Can be multiline formatted.
+    - in other cases by default no action is taken and now error raised.
   - `merge_with_schema_evolution`: when set to `true` dbt generates the merge statement with `WITH SCHEMA EVOLUTION` clause.
 
 - Step conditions that are expressed with an explicit SQL predicates allow to execute corresponding action only in case the conditions are met in addition to matching by the `unique_key`.
@@ -41,7 +44,11 @@ Example below illustrates how these parameters affect the merge statement genera
     matched_condition='t.tech_change_ts < s.tech_change_ts',
     not_matched_condition='s.attr1 IS NOT NULL',
     not_matched_by_source_condition='t.tech_change_ts < current_timestamp()',
-    not_matched_by_source_action='delete',
+    not_matched_by_source_action='''
+        update set
+            t.attr1 = \'deleted\',
+            t.tech_change_ts = current_timestamp()
+    ''',
     merge_with_schema_evolution=true
 ) }}
 
@@ -94,5 +101,7 @@ when not matched
 
 when not matched by source
     and t.tech_change_ts < current_timestamp()
-    then delete
+    then update set
+        t.attr1 = 'deleted',
+        t.tech_change_ts = current_timestamp()
 ```

--- a/docs/databricks-merge.md
+++ b/docs/databricks-merge.md
@@ -18,7 +18,8 @@ From v.1.9 onwards `merge` behavior can be tuned by setting the additional param
 
   - `skip_matched_step`: if set to `true`, dbt will completely skip the `matched` clause of the merge statement.
   - `skip_not_matched_step`: similarly if `true` the `not matched` clause will be skipped.
-  - `not_matched_by_source_action`: if set to `delete` the corresponding `when not matched by source ... then delete` clause will be added to the merge statement.
+  - `not_matched_by_source_action`: if set to `delete` the corresponding `when not matched by source ... then delete` clause will be added to the merge statement. 
+    Another option is to set it to `update set <actions>` format, which will run update statement syntactically as provided.
   - `merge_with_schema_evolution`: when set to `true` dbt generates the merge statement with `WITH SCHEMA EVOLUTION` clause.
 
 - Step conditions that are expressed with an explicit SQL predicates allow to execute corresponding action only in case the conditions are met in addition to matching by the `unique_key`.

--- a/tests/functional/adapter/incremental/fixtures.py
+++ b/tests/functional/adapter/incremental/fixtures.py
@@ -464,8 +464,8 @@ not_matched_by_source_then_update_model = """
     not_matched_by_source_condition='t.V > 0',
     not_matched_by_source_action='''
         update set
-            t.first = \'--\',
-            t.second = \'--\',
+            t.first = \\\'--\\\',
+            t.second = \\\'--\\\',
             t.V = -1
     ''',
 ) }}

--- a/tests/functional/adapter/incremental/fixtures.py
+++ b/tests/functional/adapter/incremental/fixtures.py
@@ -264,7 +264,14 @@ matching_condition_expected = """id,first,second,V
 4,Baron,Harkonnen,1
 """
 
-not_matched_by_source_expected = """id,first,second,V
+not_matched_by_source_then_del_expected = """id,first,second,V
+2,Paul,Atreides,0
+3,Dunkan,Aidaho,1
+4,Baron,Harkonnen,1
+"""
+
+not_matched_by_source_then_upd_expected = """id,first,second,V
+1,--,--,-1
 2,Paul,Atreides,0
 3,Dunkan,Aidaho,1
 4,Baron,Harkonnen,1
@@ -411,7 +418,7 @@ select 5 as id, 'Raban' as first, '' as second, 0 as V -- no append
 {% endif %}
 """
 
-not_matched_by_source_model = """
+not_matched_by_source_then_delete_model = """
 {{ config(
     materialized = 'incremental',
     unique_key = 'id',
@@ -438,6 +445,46 @@ select 3 as id, 'Dunkan' as first, 'Aidaho' as second, 1 as V
 -- data for subsequent incremental update
 
 -- id = 1 should be deleted
+-- id = 2 should be kept as condition doesn't hold (t.V = 0)
+select 3 as id, 'Dunkan' as first, 'Aidaho' as second, 2 as V -- No update, skipped
+union all
+select 4 as id, 'Baron' as first, 'Harkonnen' as second, 1 as V -- should append
+
+{% endif %}
+"""
+
+not_matched_by_source_then_update_model = """
+{{ config(
+    materialized = 'incremental',
+    unique_key = 'id',
+    incremental_strategy='merge',
+    target_alias='t',
+    source_alias='s',
+    skip_matched_step=true,
+    not_matched_by_source_condition='t.V > 0',
+    not_matched_by_source_action='''
+        update set
+            t.first = \'--\',
+            t.second = \'--\',
+            t.V = -1
+    ''',
+) }}
+
+{% if not is_incremental() %}
+
+-- data for first invocation of model
+
+select 1 as id, 'Vasya' as first, 'Pupkin' as second, 1 as V
+union all
+select 2 as id, 'Paul' as first, 'Atreides' as second, 0 as V
+union all
+select 3 as id, 'Dunkan' as first, 'Aidaho' as second, 1 as V
+
+{% else %}
+
+-- data for subsequent incremental update
+
+-- id = 1 should be updated with
 -- id = 2 should be kept as condition doesn't hold (t.V = 0)
 select 3 as id, 'Dunkan' as first, 'Aidaho' as second, 2 as V -- No update, skipped
 union all

--- a/tests/functional/adapter/incremental/test_incremental_strategies.py
+++ b/tests/functional/adapter/incremental/test_incremental_strategies.py
@@ -288,17 +288,38 @@ class TestMatchedAndNotMatchedCondition(IncrementalBase):
         )
 
 
-class TestNotMatchedBySourceAndCondition(IncrementalBase):
+class TestNotMatchedBySourceAndConditionThenDelete(IncrementalBase):
     @pytest.fixture(scope="class")
     def seeds(self):
         return {
-            "not_matched_by_source_expected.csv": fixtures.not_matched_by_source_expected,
+            "not_matched_by_source_expected.csv": fixtures.not_matched_by_source_then_del_expected,
         }
 
     @pytest.fixture(scope="class")
     def models(self):
         return {
-            "not_matched_by_source.sql": fixtures.not_matched_by_source_model,
+            "not_matched_by_source.sql": fixtures.not_matched_by_source_then_delete_model,
+        }
+
+    def test_merge(self, project):
+        self.seed_and_run_twice()
+        util.check_relations_equal(
+            project.adapter,
+            ["not_matched_by_source", "not_matched_by_source_expected"],
+        )
+
+
+class TestNotMatchedBySourceAndConditionThenUpdate(IncrementalBase):
+    @pytest.fixture(scope="class")
+    def seeds(self):
+        return {
+            "not_matched_by_source_expected.csv": fixtures.not_matched_by_source_then_upd_expected,
+        }
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "not_matched_by_source.sql": fixtures.not_matched_by_source_then_update_model,
         }
 
     def test_merge(self, project):


### PR DESCRIPTION
<!-- Please review our pull request review process in CONTRIBUTING.md before your proceed. -->

Resolves #860 

<!---
  Include the number of the issue addressed by this PR above if applicable.

  Example:
    resolves #1234

  Please review our pull request review process in CONTRIBUTING.md before your proceed.
-->

### Description

This PR will address the missing use case shared in the issue #860. When there's no match by source and condition holds now it will be possible to set update rule manually (will be executed syntactically as part of `update set` block).

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
