### PR TITLE
Redo constraints (since columns can only take one constraint at create time)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Under the Hood
 
-- Implement new constraint logic for use_materialization_v2 flag ([846](https://github.com/databricks/dbt-databricks/pull/846/files))
+- Implement new constraint logic for use_materialization_v2 flag ([846](https://github.com/databricks/dbt-databricks/pull/846/files)), ([876](https://github.com/databricks/dbt-databricks/pull/876))
 
 ## dbt-databricks 1.9.0 (Dec 9, 2024)
 

--- a/dbt/adapters/databricks/relation.py
+++ b/dbt/adapters/databricks/relation.py
@@ -2,7 +2,7 @@ from collections.abc import Iterable
 from dataclasses import dataclass, field
 from typing import Any, Optional, Type
 
-from dbt_common.contracts.constraints import ConstraintType, ModelLevelConstraint
+from dbt_common.contracts.constraints import ConstraintType
 from dbt_common.dataclass_schema import StrEnum
 from dbt_common.exceptions import DbtRuntimeError
 from dbt_common.utils import filter_null_values
@@ -11,7 +11,7 @@ from dbt.adapters.base.relation import BaseRelation, InformationSchema, Policy
 from dbt.adapters.contracts.relation import (
     ComponentName,
 )
-from dbt.adapters.databricks.constraints import parse_model_constraint, process_model_constraint
+from dbt.adapters.databricks.constraints import TypedConstraint, process_constraint
 from dbt.adapters.databricks.utils import remove_undefined
 from dbt.adapters.spark.impl import KEY_TABLE_OWNER, KEY_TABLE_STATISTICS
 from dbt.adapters.utils import classproperty
@@ -60,8 +60,8 @@ class DatabricksRelation(BaseRelation):
     quote_policy: Policy = field(default_factory=lambda: DatabricksQuotePolicy())
     include_policy: Policy = field(default_factory=lambda: DatabricksIncludePolicy())
     quote_character: str = "`"
-    create_constraints: list[ModelLevelConstraint] = field(default_factory=list)
-    alter_constraints: list[ModelLevelConstraint] = field(default_factory=list)
+    create_constraints: list[TypedConstraint] = field(default_factory=list)
+    alter_constraints: list[TypedConstraint] = field(default_factory=list)
     metadata: Optional[dict[str, Any]] = None
 
     @classmethod
@@ -151,21 +151,21 @@ class DatabricksRelation(BaseRelation):
     def StreamingTable(cls) -> str:
         return str(DatabricksRelationType.StreamingTable)
 
-    def add_constraint(self, constraint: ModelLevelConstraint) -> None:
+    def add_constraint(self, constraint: TypedConstraint) -> None:
         if constraint.type == ConstraintType.check:
             self.alter_constraints.append(constraint)
         else:
             self.create_constraints.append(constraint)
 
-    def enrich(self, raw_constraints: list[dict[str, Any]]) -> "DatabricksRelation":
+    def enrich(self, constraints: list[TypedConstraint]) -> "DatabricksRelation":
         copy = self.incorporate()
-        for constraint in raw_constraints:
-            copy.add_constraint(parse_model_constraint(constraint))
+        for constraint in constraints:
+            copy.add_constraint(constraint)
 
         return copy
 
     def render_constraints_for_create(self) -> str:
-        processed = [process_model_constraint(c) for c in self.create_constraints]
+        processed = map(process_constraint, self.create_constraints)
         return ", ".join(c for c in processed if c is not None)
 
 

--- a/tests/unit/test_adapter.py
+++ b/tests/unit/test_adapter.py
@@ -427,7 +427,6 @@ class TestDatabricksAdapter(DatabricksAdapterBase):
             "numeric_precision": None,
             "char_size": None,
             "comment": None,
-            "constraints": None,
             "not_null": None,
         }
 

--- a/tests/unit/test_column.py
+++ b/tests/unit/test_column.py
@@ -1,5 +1,4 @@
 import pytest
-from dbt_common.contracts.constraints import ColumnLevelConstraint, ConstraintType
 
 from dbt.adapters.databricks.column import DatabricksColumn
 
@@ -29,23 +28,6 @@ class TestSparkColumn:
         }
 
 
-class TestAddConstraint:
-    @pytest.fixture
-    def column(self):
-        return DatabricksColumn("id", "LONG")
-
-    def test_add_constraint__not_null(self, column):
-        column.add_constraint(ColumnLevelConstraint(type=ConstraintType.not_null))
-        assert column.not_null is True
-        assert column.constraints == []
-
-    def test_add_constraint__other_constraint(self, column):
-        constraint = ColumnLevelConstraint(type=ConstraintType.custom)
-        column.add_constraint(constraint)
-        assert column.not_null is False
-        assert column.constraints == [constraint]
-
-
 class TestEnrich:
     @pytest.fixture
     def column(self):
@@ -63,13 +45,10 @@ class TestEnrich:
         }
 
     def test_enrich(self, column, model_column):
-        enriched_column = column.enrich(model_column)
+        enriched_column = column.enrich(model_column, True)
         assert enriched_column.data_type == "bigint"
         assert enriched_column.comment == "this is a column"
         assert enriched_column.not_null is True
-        assert enriched_column.constraints == [
-            ColumnLevelConstraint(type=ConstraintType.primary_key, name="foo")
-        ]
 
 
 class TestRenderForCreate:
@@ -87,23 +66,6 @@ class TestRenderForCreate:
     def test_render_for_create__comment(self, column):
         column.comment = "this is a column"
         assert column.render_for_create() == "id INT COMMENT 'this is a column'"
-
-    def test_render_for_create__constraints(self, column):
-        column.constraints = [
-            ColumnLevelConstraint(type=ConstraintType.primary_key),
-        ]
-        assert column.render_for_create() == "id INT PRIMARY KEY"
-
-    def test_render_for_create__everything(self, column):
-        column.not_null = True
-        column.comment = "this is a column"
-        column.constraints = [
-            ColumnLevelConstraint(type=ConstraintType.primary_key),
-            ColumnLevelConstraint(type=ConstraintType.custom, expression="foo"),
-        ]
-        assert column.render_for_create() == (
-            "id INT NOT NULL COMMENT 'this is a column' " "PRIMARY KEY foo"
-        )
 
     def test_render_for_create__escaping(self, column):
         column.comment = "this is a 'column'"


### PR DESCRIPTION
<!---
  Include the number of the issue addressed by this PR above if applicable.

  Example:
    resolves #1234

  Please review our pull request review process in CONTRIBUTING.md before your proceed.
-->

### Description

When I went to apply the constraint logic from the previous PR, I discovered that Databricks does not like receiving multiple constraints for a single column in the table create syntax; however, you can add arbitrarily many table level constraints, so in this PR I aim to do the following:

* if a column has a not_null constraint, directly set not_null on the column
* any other column constraint gets converted to a TypedConstraint, a subclass of ModelLevelConstraint that enforces the requirements of the particular constraint, and holds the rendering logic.  The conversion required setting 'columns=[name]'. Because python makes operator overloading a pain in the butt, I'm going back to OOP for the render logic.
* If a model level constraint is not_null, convert to setting not_null on each affected column, since Databricks does not support not_null constraint definition as a table constraint
* any other model constraint gets converted to a TypedConstraint

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
