### PR TITLE
Use single quotes in gets in templates

### DIFF
--- a/dbt/include/databricks/macros/materializations/seeds/helpers.sql
+++ b/dbt/include/databricks/macros/materializations/seeds/helpers.sql
@@ -6,7 +6,7 @@
 
   {% set batch_size = get_batch_size() %}
   {% set column_override = model['config'].get('column_types', {}) %}
-  {% set must_cast = model['config'].get("file_format", "delta") == "parquet" %}
+  {% set must_cast = model['config'].get('file_format', 'delta') == 'parquet' %}
 
   {% set statements = [] %}
 

--- a/dbt/include/databricks/macros/relations/constraints.sql
+++ b/dbt/include/databricks/macros/relations/constraints.sql
@@ -106,19 +106,19 @@
 
 {% macro get_constraint_sql(relation, constraint, model, column={}) %}
   {% set statements = [] %}
-  {% set type = constraint.get("type", "") %}
+  {% set type = constraint.get('type', '') %}
 
   {% if type == 'check' %}
-    {% set expression = constraint.get("expression", "") %}
+    {% set expression = constraint.get('expression', '') %}
     {% if not expression %}
       {{ exceptions.raise_compiler_error('Invalid check constraint expression') }}
     {% endif %}
 
-    {% set name = constraint.get("name") %}
+    {% set name = constraint.get('name') %}
     {% if not name %}
       {% if local_md5 %}
         {{ exceptions.warn("Constraint of type " ~ type ~ " with no `name` provided. Generating hash instead for relation " ~ relation.identifier) }}
-        {%- set name = local_md5 (relation.identifier ~ ";" ~ column.get("name", "") ~ ";" ~ expression ~ ";") -%}
+        {%- set name = local_md5 (relation.identifier ~ ";" ~ column.get('name', '') ~ ";" ~ expression ~ ";") -%}
       {% else %}
         {{ exceptions.raise_compiler_error("Constraint of type " ~ type ~ " with no `name` provided, and no md5 utility.") }}
       {% endif %}
@@ -126,7 +126,7 @@
     {% set stmt = "alter table " ~ relation ~ " add constraint " ~ name ~ " check (" ~ expression ~ ");" %}
     {% do statements.append(stmt) %}
   {% elif type == 'not_null' %}
-    {% set column_names = constraint.get("columns", []) %}
+    {% set column_names = constraint.get('columns', []) %}
     {% if column and not column_names %}
       {% set column_names = [column['name']] %}
     {% endif %}
@@ -144,7 +144,7 @@
     {% if constraint.get('warn_unenforced') %}
       {{ exceptions.warn("unenforced constraint type: " ~ type)}}
     {% endif %}
-    {% set column_names = constraint.get("columns", []) %}
+    {% set column_names = constraint.get('columns', []) %}
     {% if column and not column_names %}
       {% set column_names = [column['name']] %}
     {% endif %}
@@ -161,7 +161,7 @@
 
     {% set joined_names = quoted_names|join(", ") %}
 
-    {% set name = constraint.get("name") %}
+    {% set name = constraint.get('name') %}
     {% if not name %}
       {% if local_md5 %}
         {{ exceptions.warn("Constraint of type " ~ type ~ " with no `name` provided. Generating hash instead for relation " ~ relation.identifier) }}
@@ -178,7 +178,7 @@
       {{ exceptions.warn("unenforced constraint type: " ~ constraint.type)}}
     {% endif %}
 
-    {% set name = constraint.get("name") %}
+    {% set name = constraint.get('name') %}
     
     {% if constraint.get('expression') %}
 
@@ -193,7 +193,7 @@
 
       {% set stmt = "alter table " ~ relation ~ " add constraint " ~ name ~ " foreign key" ~ constraint.get('expression') %}
     {% else %}
-      {% set column_names = constraint.get("columns", []) %}
+      {% set column_names = constraint.get('columns', []) %}
       {% if column and not column_names %}
         {% set column_names = [column['name']] %}
       {% endif %}
@@ -210,7 +210,7 @@
 
       {% set joined_names = quoted_names|join(", ") %}
 
-      {% set parent = constraint.get("to") %}
+      {% set parent = constraint.get('to') %}
       {% if not parent %}
         {{ exceptions.raise_compiler_error('No parent table defined for foreign key: ' ~ expression) }}
       {% endif %}
@@ -228,7 +228,7 @@
       {% endif %}
 
       {% set stmt = "alter table " ~ relation ~ " add constraint " ~ name ~ " foreign key(" ~ joined_names ~ ") references " ~ parent %}
-      {% set parent_columns = constraint.get("to_columns") %}
+      {% set parent_columns = constraint.get('to_columns') %}
       {% if parent_columns %}
         {% set stmt = stmt ~ "(" ~ parent_columns|join(", ") ~ ")"%}
       {% endif %}
@@ -236,13 +236,13 @@
     {% set stmt = stmt ~ ";" %}
     {% do statements.append(stmt) %}
   {% elif type == 'custom' %}
-    {% set expression = constraint.get("expression", "") %}
+    {% set expression = constraint.get('expression', '') %}
     {% if not expression %}
       {{ exceptions.raise_compiler_error('Missing custom constraint expression') }}
     {% endif %}
 
-    {% set name = constraint.get("name") %}
-    {% set expression = constraint.get("expression") %}
+    {% set name = constraint.get('name') %}
+    {% set expression = constraint.get('expression') %}
     {% if not name %}
       {% if local_md5 %}
         {{ exceptions.warn("Constraint of type " ~ type ~ " with no `name` provided. Generating hash instead for relation " ~ relation.identifier) }}
@@ -264,15 +264,15 @@
   {# convert constraints defined using the original databricks format #}
   {% set dbt_constraints = [] %}
   {% for constraint in constraints %}
-    {% if constraint.get and constraint.get("type") %}
+    {% if constraint.get and constraint.get('type') %}
       {# already in model contract format #}
       {% do dbt_constraints.append(constraint) %}
     {% else %}
       {% if column %}
         {% if constraint == "not_null" %}
-          {% do dbt_constraints.append({"type": "not_null", "columns": [column.get("name")]}) %}
+          {% do dbt_constraints.append({"type": "not_null", "columns": [column.get('name')]}) %}
         {% else %}
-          {{ exceptions.raise_compiler_error('Invalid constraint for column ' ~ column.get("name", "") ~ '. Only `not_null` is supported.') }}
+          {{ exceptions.raise_compiler_error('Invalid constraint for column ' ~ column.get('name', "") ~ '. Only `not_null` is supported.') }}
         {% endif %}
       {% else %}
         {% set name = constraint['name'] %}


### PR DESCRIPTION
### Description

Discovered when I was trying to add a new config entry that:

```
config.get('foo')
```

and

```
config.get("foo")
```

behave differently in Jinja templates.  This is crazy.  I believe this only applies to the config dictionary, but to be safe, every place we use `get` in the templates, I want to use single quotes.
### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
