### PR TITLE
[FIX] Include job_id, run_id and task_id in adapter_response in the results on-run-end context variable - Issue #722

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ logs/
 *.sublime*
 .python-version
 .hatch
+ 

--- a/.gitignore
+++ b/.gitignore
@@ -19,4 +19,4 @@ logs/
 .venv*
 *.sublime*
 .python-version
-.hatch 
+.hatch

--- a/.gitignore
+++ b/.gitignore
@@ -20,4 +20,3 @@ logs/
 *.sublime*
 .python-version
 .hatch
- 

--- a/.gitignore
+++ b/.gitignore
@@ -19,4 +19,4 @@ logs/
 .venv*
 *.sublime*
 .python-version
-.hatch
+.hatch 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,3 +13,4 @@ repos:
     hooks:
       - id: mypy
         additional_dependencies: [types-requests]
+        language: python

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,4 +13,3 @@ repos:
     hooks:
       - id: mypy
         additional_dependencies: [types-requests]
-        language: python

--- a/dbt/adapters/databricks/connections.py
+++ b/dbt/adapters/databricks/connections.py
@@ -300,6 +300,9 @@ class DatabricksMacroQueryStringSetter(MacroQueryStringSetter):
 @dataclass
 class DatabricksAdapterResponse(AdapterResponse):
     query_id: str = ""
+    job_id: str = ""
+    run_id: str = ""
+    task_run_id: str = ""
 
 
 @dataclass(init=False)
@@ -699,9 +702,20 @@ class DatabricksConnectionManager(SparkConnectionManager):
             logger.debug("No cursor was provided. Query ID not available.")
             query_id = "N/A"
         else:
-            query_id = _query_id
+            query_id = str(_query_id)
         message = "OK"
-        return DatabricksAdapterResponse(_message=message, query_id=query_id)  # type: ignore
+        # Fetch additional job metadata
+        job_id = os.getenv("DATABRICKS_JOB_ID", "unknown")
+        run_id = os.getenv("DATABRICKS_RUN_ID", "unknown")
+        task_run_id = os.getenv("DATABRICKS_TASK_RUN_ID", "unknown")
+
+        return DatabricksAdapterResponse(
+            _message=message,
+            query_id=query_id,
+            job_id=job_id,
+            run_id=run_id,
+            task_run_id=task_run_id,
+        )  # type: ignore
 
 
 class ExtendedSessionConnectionManager(DatabricksConnectionManager):


### PR DESCRIPTION
<!-- Please review our pull request review process in CONTRIBUTING.md before your proceed. -->

Resolves #722 

<!---
  Include the number of the issue addressed by this PR above if applicable.

  Example:
    resolves #722 

  Please review our pull request review process in CONTRIBUTING.md before your proceed.
-->

### Description

<!--- Describe the Pull Request here -->

### Checklist

- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
