### PR TITLE
Switch to render for safest relation str substitution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Under the Hood
 
 - Refactor global state reading ([888](https://github.com/databricks/dbt-databricks/pull/888))
+- Switch to relation.render() for string interpolation ([903](https://github.com/databricks/dbt-databricks/pull/903))
 
 ## dbt-databricks 1.9.1 (December 16, 2024)
 

--- a/dbt/include/databricks/macros/adapters/columns.sql
+++ b/dbt/include/databricks/macros/adapters/columns.sql
@@ -32,13 +32,13 @@
       {{ exceptions.raise_compiler_error('Delta format required for dropping columns from tables') }}
     {% endif %}
     {%- call statement('alter_relation_remove_columns') -%}
-      ALTER TABLE {{ relation }} DROP COLUMNS ({{ api.Column.format_remove_column_list(remove_columns) }})
+      ALTER TABLE {{ relation.render() }} DROP COLUMNS ({{ api.Column.format_remove_column_list(remove_columns) }})
     {%- endcall -%}
   {% endif %}
 
   {% if add_columns %}
     {%- call statement('alter_relation_add_columns') -%}
-      ALTER TABLE {{ relation }} ADD COLUMNS ({{ api.Column.format_add_column_list(add_columns) }})
+      ALTER TABLE {{ relation.render() }} ADD COLUMNS ({{ api.Column.format_add_column_list(add_columns) }})
     {%- endcall -%}
   {% endif %}
 {% endmacro %}

--- a/dbt/include/databricks/macros/adapters/persist_docs.sql
+++ b/dbt/include/databricks/macros/adapters/persist_docs.sql
@@ -4,7 +4,7 @@
       {% set comment = column['description'] %}
       {% set escaped_comment = comment | replace('\'', '\\\'') %}
       {% set comment_query %}
-        alter table {{ relation }} change column {{ api.Column.get_name(column) }} comment '{{ escaped_comment }}';
+        alter table {{ relation.render()|lower }} change column {{ api.Column.get_name(column) }} comment '{{ escaped_comment }}';
       {% endset %}
       {% do run_query(comment_query) %}
     {% endfor %}
@@ -13,7 +13,7 @@
 
 {% macro alter_table_comment(relation, model) %}
   {% set comment_query %}
-    comment on table {{ relation|lower }} is '{{ model.description | replace("'", "\\'") }}'
+    comment on table {{ relation.render()|lower }} is '{{ model.description | replace("'", "\\'") }}'
   {% endset %}
   {% do run_query(comment_query) %}
 {% endmacro %}

--- a/dbt/include/databricks/macros/relations/constraints.sql
+++ b/dbt/include/databricks/macros/relations/constraints.sql
@@ -134,7 +134,7 @@
       {% set column = model.get('columns', {}).get(column_name) %}
       {% if column %}
         {% set quoted_name = api.Column.get_name(column) %}
-        {% set stmt = "alter table " ~ relation ~ " change column " ~ quoted_name ~ " set not null " ~ (constraint.expression or "") ~ ";" %}
+        {% set stmt = "alter table " ~ relation.render() ~ " change column " ~ quoted_name ~ " set not null " ~ (constraint.expression or "") ~ ";" %}
         {% do statements.append(stmt) %}
       {% else %}
         {{ exceptions.warn('not_null constraint on invalid column: ' ~ column_name) }}
@@ -170,7 +170,7 @@
         {{ exceptions.raise_compiler_error("Constraint of type " ~ type ~ " with no `name` provided, and no md5 utility.") }}
       {% endif %}
     {% endif %}
-    {% set stmt = "alter table " ~ relation ~ " add constraint " ~ name ~ " primary key(" ~ joined_names ~ ");" %}
+    {% set stmt = "alter table " ~ relation.render() ~ " add constraint " ~ name ~ " primary key(" ~ joined_names ~ ");" %}
     {% do statements.append(stmt) %}
   {% elif type == 'foreign_key' %}
 
@@ -191,7 +191,7 @@
         {% endif %}    
       {% endif %}
 
-      {% set stmt = "alter table " ~ relation ~ " add constraint " ~ name ~ " foreign key" ~ constraint.get('expression') %}
+      {% set stmt = "alter table " ~ relation.render() ~ " add constraint " ~ name ~ " foreign key" ~ constraint.get('expression') %}
     {% else %}
       {% set column_names = constraint.get('columns', []) %}
       {% if column and not column_names %}
@@ -227,7 +227,7 @@
         {% endif %}    
       {% endif %}
 
-      {% set stmt = "alter table " ~ relation ~ " add constraint " ~ name ~ " foreign key(" ~ joined_names ~ ") references " ~ parent %}
+      {% set stmt = "alter table " ~ relation.render() ~ " add constraint " ~ name ~ " foreign key(" ~ joined_names ~ ") references " ~ parent %}
       {% set parent_columns = constraint.get('to_columns') %}
       {% if parent_columns %}
         {% set stmt = stmt ~ "(" ~ parent_columns|join(", ") ~ ")"%}
@@ -251,7 +251,7 @@
         {{ exceptions.raise_compiler_error("Constraint of type " ~ type ~ " with no `name` provided, and no md5 utility.") }}
       {% endif %}
     {% endif %}
-    {% set stmt = "alter table " ~ relation ~ " add constraint " ~ name ~ " " ~ expression ~ ";" %}
+    {% set stmt = "alter table " ~ relation.render() ~ " add constraint " ~ name ~ " " ~ expression ~ ";" %}
     {% do statements.append(stmt) %}
   {% elif constraint.get('warn_unsupported') %}
     {{ exceptions.warn("unsupported constraint type: " ~ constraint.type)}}

--- a/dbt/include/databricks/macros/relations/liquid_clustering.sql
+++ b/dbt/include/databricks/macros/relations/liquid_clustering.sql
@@ -15,7 +15,7 @@
       {%- set cols = [cols] -%}
     {%- endif -%}
     {%- call statement('set_cluster_by_columns') -%}
-        ALTER {{ target_relation.type }} {{ target_relation }} CLUSTER BY ({{ cols | join(', ') }})
+        ALTER {{ target_relation.type }} {{ target_relation.render() }} CLUSTER BY ({{ cols | join(', ') }})
     {%- endcall -%}
   {%- endif %}
 {%- endmacro -%}

--- a/dbt/include/databricks/macros/relations/materialized_view/alter.sql
+++ b/dbt/include/databricks/macros/relations/materialized_view/alter.sql
@@ -46,6 +46,6 @@
 {% macro get_alter_mv_internal(relation, configuration_changes) %}
     {%- set refresh = configuration_changes.changes["refresh"] -%}
     -- Currently only schedule can be altered
-    ALTER MATERIALIZED VIEW {{ relation }}
+    ALTER MATERIALIZED VIEW {{ relation.render() }}
         {{ get_alter_sql_refresh_schedule(refresh.cron, refresh.time_zone_value, refresh.is_altered) -}}
 {% endmacro %}

--- a/dbt/include/databricks/macros/relations/materialized_view/drop.sql
+++ b/dbt/include/databricks/macros/relations/materialized_view/drop.sql
@@ -1,3 +1,3 @@
 {% macro databricks__drop_materialized_view(relation) -%}
-    drop materialized view if exists {{ relation }}
+    drop materialized view if exists {{ relation.render() }}
 {%- endmacro %}

--- a/dbt/include/databricks/macros/relations/materialized_view/refresh.sql
+++ b/dbt/include/databricks/macros/relations/materialized_view/refresh.sql
@@ -1,3 +1,3 @@
 {% macro databricks__refresh_materialized_view(relation) -%}
-  refresh materialized view {{ relation }}
+  refresh materialized view {{ relation.render() }}
 {% endmacro %}

--- a/dbt/include/databricks/macros/relations/streaming_table/drop.sql
+++ b/dbt/include/databricks/macros/relations/streaming_table/drop.sql
@@ -3,5 +3,5 @@
 {%- endmacro %}
 
 {% macro default__drop_streaming_table(relation) -%}
-    drop table if exists {{ relation }}
+    drop table if exists {{ relation.render() }}
 {%- endmacro %}

--- a/dbt/include/databricks/macros/relations/streaming_table/refresh.sql
+++ b/dbt/include/databricks/macros/relations/streaming_table/refresh.sql
@@ -3,7 +3,7 @@
 {%- endmacro %}
 
 {% macro databricks__refresh_streaming_table(relation, sql) -%}
-  create or refresh streaming table {{ relation }}
+  create or refresh streaming table {{ relation.render() }}
   as
     {{ sql }}
 {% endmacro %}

--- a/dbt/include/databricks/macros/relations/table/create.sql
+++ b/dbt/include/databricks/macros/relations/table/create.sql
@@ -5,9 +5,9 @@
     {%- else -%}
       {%- set file_format = config.get('file_format', default='delta') -%}
       {% if file_format == 'delta' %}
-        create or replace table {{ relation }}
+        create or replace table {{ relation.render() }}
       {% else %}
-        create table {{ relation }}
+        create table {{ relation.render() }}
       {% endif %}
       {%- set contract_config = config.get('contract') -%}
       {% if contract_config and contract_config.enforced %}

--- a/dbt/include/databricks/macros/relations/table/drop.sql
+++ b/dbt/include/databricks/macros/relations/table/drop.sql
@@ -1,3 +1,3 @@
 {% macro databricks__drop_table(relation) -%}
-    drop table if exists {{ relation }}
+    drop table if exists {{ relation.render() }}
 {%- endmacro %}

--- a/dbt/include/databricks/macros/relations/tags.sql
+++ b/dbt/include/databricks/macros/relations/tags.sql
@@ -33,7 +33,7 @@
 {%- endmacro -%}
 
 {% macro alter_set_tags(relation, tags) -%}
-  ALTER {{ relation.type }} {{ relation }} SET TAGS (
+  ALTER {{ relation.type }} {{ relation.render() }} SET TAGS (
     {% for tag in tags -%}
       '{{ tag }}' = '{{ tags[tag] }}' {%- if not loop.last %}, {% endif -%}
     {%- endfor %}
@@ -41,7 +41,7 @@
 {%- endmacro -%}
 
 {% macro alter_unset_tags(relation, tags) -%}
-  ALTER {{ relation.type }} {{ relation }} UNSET TAGS (
+  ALTER {{ relation.type }} {{ relation.render() }} UNSET TAGS (
     {% for tag in tags -%}
       '{{ tag }}' {%- if not loop.last %}, {%- endif %}
     {%- endfor %}

--- a/dbt/include/databricks/macros/relations/tblproperties.sql
+++ b/dbt/include/databricks/macros/relations/tblproperties.sql
@@ -17,7 +17,7 @@
   {% set tblproperty_statment = databricks__tblproperties_clause(tblproperties) %}
   {% if tblproperty_statment %}
     {%- call statement('apply_tblproperties') -%}
-      ALTER {{ relation.type }} {{ relation }} SET {{ tblproperty_statment}}
+      ALTER {{ relation.type }} {{ relation.render() }} SET {{ tblproperty_statment}}
     {%- endcall -%}
   {% endif %}
 {%- endmacro -%}

--- a/dbt/include/databricks/macros/relations/view/create.sql
+++ b/dbt/include/databricks/macros/relations/view/create.sql
@@ -1,5 +1,5 @@
 {% macro databricks__create_view_as(relation, sql) -%}
-  create or replace view {{ relation }}
+  create or replace view {{ relation.render() }}
   {% if config.persist_column_docs() -%}
     {% set model_columns = model.columns %}
     {% set query_columns = get_columns_in_query(sql) %}

--- a/dbt/include/databricks/macros/relations/view/drop.sql
+++ b/dbt/include/databricks/macros/relations/view/drop.sql
@@ -1,3 +1,3 @@
 {% macro databricks__drop_view(relation) -%}
-    drop view if exists {{ relation }}
+    drop view if exists {{ relation.render() }}
 {%- endmacro %}


### PR DESCRIPTION
### Description

We have historically relied on `{{ relation }}` to substitute the 3-layer relation name into templates.  `{{ relation.render() }}` is preferred because it correctly backticks, and I believe might be replaced at run-time when users ask for the `--empty` flag, with a `limit 0` version.

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
