### PR TITLE
Compress to one connection manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## dbt-databricks 1.9.3 (TBD)
+
+### Under the Hood
+
+- Collapsing to a single connection manager (since the old one no longer works) ([910](https://github.com/databricks/dbt-databricks/pull/910))
+
 ## dbt-databricks 1.9.2 (Jan 21, 2024)
 
 ### Features

--- a/dbt/adapters/databricks/connections.py
+++ b/dbt/adapters/databricks/connections.py
@@ -1,5 +1,4 @@
 import decimal
-import os
 import re
 import sys
 import time
@@ -10,7 +9,6 @@ from contextlib import contextmanager
 from dataclasses import dataclass
 from multiprocessing.context import SpawnContext
 from numbers import Number
-from threading import get_ident
 from typing import TYPE_CHECKING, Any, Optional, cast
 
 from dbt_common.events.contextvars import get_node_info
@@ -59,7 +57,6 @@ from dbt.adapters.databricks.events.cursor_events import (
     CursorCreate,
 )
 from dbt.adapters.databricks.events.other_events import QueryError
-from dbt.adapters.databricks.global_state import GlobalState
 from dbt.adapters.databricks.logging import logger
 from dbt.adapters.databricks.python_models.run_tracking import PythonRunTracker
 from dbt.adapters.databricks.utils import redact_credentials
@@ -383,6 +380,9 @@ class DatabricksConnectionManager(SparkConnectionManager):
         super().__init__(profile, mp_context)
         creds = cast(DatabricksCredentials, self.profile.credentials)
         self.api_client = DatabricksApiClient.create(creds, 15 * 60)
+        self.threads_compute_connections: dict[
+            Hashable, dict[Hashable, DatabricksDBTConnection]
+        ] = {}
 
     def cancel_open(self) -> list[str]:
         cancelled = super().cancel_open()
@@ -431,39 +431,19 @@ class DatabricksConnectionManager(SparkConnectionManager):
         'connection_named', called by 'connection_for(node)'.
         Creates a connection for this thread if one doesn't already
         exist, and will rename an existing connection."""
+        self._cleanup_idle_connections()
 
         conn_name: str = "master" if name is None else name
 
         # Get a connection for this thread
-        conn = self.get_if_exists()
-
-        if conn and conn.name == conn_name and conn.state == ConnectionState.OPEN:
-            # Found a connection and nothing to do, so just return it
-            return conn
+        conn = self._get_if_exists_compute_connection(_get_compute_name(query_header_context) or "")
 
         if conn is None:
-            # Create a new connection
-            conn = DatabricksDBTConnection(
-                type=Identifier(self.TYPE),
-                name=conn_name,
-                state=ConnectionState.INIT,
-                transaction_open=False,
-                handle=None,
-                credentials=self.profile.credentials,
-            )
-            conn.handle = LazyHandle(self.get_open_for_context(query_header_context))
-            # Add the connection to thread_connections for this thread
-            self.set_thread_connection(conn)
-            fire_event(
-                NewConnection(conn_name=conn_name, conn_type=self.TYPE, node_info=get_node_info())
-            )
+            conn = self._create_compute_connection(conn_name, query_header_context)
         else:  # existing connection either wasn't open or didn't have the right name
-            if conn.state != ConnectionState.OPEN:
-                conn.handle = LazyHandle(self.get_open_for_context(query_header_context))
-            if conn.name != conn_name:
-                orig_conn_name: str = conn.name or ""
-                conn.name = conn_name
-                fire_event(ConnectionReused(orig_conn_name=orig_conn_name, conn_name=conn_name))
+            conn = self._update_compute_connection(conn, conn_name)
+
+        conn._acquire(query_header_context)
 
         return conn
 
@@ -601,142 +581,6 @@ class DatabricksConnectionManager(SparkConnectionManager):
             ),
         )
 
-    @classmethod
-    def get_open_for_context(
-        cls, query_header_context: Any = None
-    ) -> Callable[[Connection], Connection]:
-        # If there is no node we can simply return the exsting class method open.
-        # If there is a node create a closure that will call cls._open with the node.
-        if not query_header_context:
-            return cls.open
-
-        def open_for_model(connection: Connection) -> Connection:
-            return cls._open(connection, query_header_context)
-
-        return open_for_model
-
-    @classmethod
-    def open(cls, connection: Connection) -> Connection:
-        # Simply call _open with no ResultNode argument.
-        # Because this is an overridden method we can't just add
-        # a ResultNode parameter to open.
-        return cls._open(connection)
-
-    @classmethod
-    def _open(cls, connection: Connection, query_header_context: Any = None) -> Connection:
-        if connection.state == ConnectionState.OPEN:
-            return connection
-
-        creds: DatabricksCredentials = connection.credentials
-        timeout = creds.connect_timeout
-
-        # gotta keep this so we don't prompt users many times
-        cls.credentials_provider = creds.authenticate(cls.credentials_provider)
-
-        invocation_env = creds.get_invocation_env()
-        user_agent_entry = cls._user_agent
-        if invocation_env:
-            user_agent_entry = f"{cls._user_agent}; {invocation_env}"
-
-        connection_parameters = creds.connection_parameters.copy()  # type: ignore[union-attr]
-
-        http_headers: list[tuple[str, str]] = list(
-            creds.get_all_http_headers(connection_parameters.pop("http_headers", {})).items()
-        )
-
-        # If a model specifies a compute resource the http path
-        # may be different than the http_path property of creds.
-        http_path = _get_http_path(query_header_context, creds)
-
-        def connect() -> DatabricksSQLConnectionWrapper:
-            try:
-                # TODO: what is the error when a user specifies a catalog they don't have access to
-                conn: DatabricksSQLConnection = dbsql.connect(
-                    server_hostname=creds.host,
-                    http_path=http_path,
-                    credentials_provider=cls.credentials_provider,
-                    http_headers=http_headers if http_headers else None,
-                    session_configuration=creds.session_properties,
-                    catalog=creds.database,
-                    use_inline_params="silent",
-                    # schema=creds.schema,  # TODO: Explicitly set once DBR 7.3LTS is EOL.
-                    _user_agent_entry=user_agent_entry,
-                    **connection_parameters,
-                )
-                logger.debug(ConnectionCreated(str(conn)))
-
-                return DatabricksSQLConnectionWrapper(
-                    conn,
-                    is_cluster=creds.cluster_id is not None,
-                    creds=creds,
-                    user_agent=user_agent_entry,
-                )
-            except Error as exc:
-                logger.error(ConnectionCreateError(exc))
-                raise
-
-        def exponential_backoff(attempt: int) -> int:
-            return attempt * attempt
-
-        retryable_exceptions = []
-        # this option is for backwards compatibility
-        if creds.retry_all:
-            retryable_exceptions = [Error]
-
-        return cls.retry_connection(
-            connection,
-            connect=connect,
-            logger=logger,
-            retryable_exceptions=retryable_exceptions,
-            retry_limit=creds.connect_retries,
-            retry_timeout=(timeout if timeout is not None else exponential_backoff),
-        )
-
-    @classmethod
-    def get_response(cls, cursor: DatabricksSQLCursorWrapper) -> DatabricksAdapterResponse:
-        _query_id = getattr(cursor, "hex_query_id", None)
-        if cursor is None:
-            logger.debug("No cursor was provided. Query ID not available.")
-            query_id = "N/A"
-        else:
-            query_id = _query_id
-        message = "OK"
-        return DatabricksAdapterResponse(_message=message, query_id=query_id)  # type: ignore
-
-
-class ExtendedSessionConnectionManager(DatabricksConnectionManager):
-    def __init__(self, profile: AdapterRequiredConfig, mp_context: SpawnContext) -> None:
-        assert (
-            GlobalState.get_use_long_sessions()
-        ), "This connection manager should only be used when USE_LONG_SESSIONS is enabled"
-        super().__init__(profile, mp_context)
-        self.threads_compute_connections: dict[
-            Hashable, dict[Hashable, DatabricksDBTConnection]
-        ] = {}
-
-    def set_connection_name(
-        self, name: Optional[str] = None, query_header_context: Any = None
-    ) -> Connection:
-        """Called by 'acquire_connection' in DatabricksAdapter, which is called by
-        'connection_named', called by 'connection_for(node)'.
-        Creates a connection for this thread if one doesn't already
-        exist, and will rename an existing connection."""
-        self._cleanup_idle_connections()
-
-        conn_name: str = "master" if name is None else name
-
-        # Get a connection for this thread
-        conn = self._get_if_exists_compute_connection(_get_compute_name(query_header_context) or "")
-
-        if conn is None:
-            conn = self._create_compute_connection(conn_name, query_header_context)
-        else:  # existing connection either wasn't open or didn't have the right name
-            conn = self._update_compute_connection(conn, conn_name)
-
-        conn._acquire(query_header_context)
-
-        return conn
-
     # override
     def release(self) -> None:
         with self.lock:
@@ -745,16 +589,6 @@ class ExtendedSessionConnectionManager(DatabricksConnectionManager):
                 return
 
         conn._release()
-
-    # override
-    @classmethod
-    def close(cls, connection: Connection) -> Connection:
-        try:
-            return super().close(connection)
-        except Exception as e:
-            logger.warning(f"ignoring error when closing connection: {e}")
-            connection.state = ConnectionState.CLOSED
-            return connection
 
     # override
     def cleanup_all(self) -> None:
@@ -775,144 +609,22 @@ class ExtendedSessionConnectionManager(DatabricksConnectionManager):
             self.thread_connections.clear()
             self.threads_compute_connections.clear()
 
-    def _update_compute_connection(
-        self, conn: DatabricksDBTConnection, new_name: str
-    ) -> DatabricksDBTConnection:
-        if conn.name == new_name and conn.state == ConnectionState.OPEN:
-            # Found a connection and nothing to do, so just return it
-            return conn
+    @classmethod
+    def get_open_for_context(
+        cls, query_header_context: Any = None
+    ) -> Callable[[Connection], Connection]:
+        # If there is no node we can simply return the exsting class method open.
+        # If there is a node create a closure that will call cls._open with the node.
+        if not query_header_context:
+            return cls.open
 
-        orig_conn_name: str = conn.name or ""
+        def open_for_model(connection: Connection) -> Connection:
+            return cls._open(connection, query_header_context)
 
-        if conn.state != ConnectionState.OPEN:
-            conn.handle = LazyHandle(self.open)
-        if conn.name != new_name:
-            conn.name = new_name
-            fire_event(ConnectionReused(orig_conn_name=orig_conn_name, conn_name=new_name))
-
-        current_thread_conn = cast(Optional[DatabricksDBTConnection], self.get_if_exists())
-        if current_thread_conn and current_thread_conn.compute_name != conn.compute_name:
-            self.clear_thread_connection()
-            self.set_thread_connection(conn)
-
-        logger.debug(ConnectionReuse(str(conn), orig_conn_name))
-
-        return conn
-
-    def _add_compute_connection(self, conn: DatabricksDBTConnection) -> None:
-        """Add a new connection to the map of connection per thread per compute."""
-
-        with self.lock:
-            thread_map = self._get_compute_connections()
-            if conn.compute_name in thread_map:
-                raise DbtInternalError(
-                    f"In set_thread_compute_connection, connection exists for `{conn.compute_name}`"
-                )
-            thread_map[conn.compute_name] = conn
-
-    def _get_compute_connections(
-        self,
-    ) -> dict[Hashable, DatabricksDBTConnection]:
-        """Retrieve a map of compute name to connection for the current thread."""
-
-        thread_id = self.get_thread_identifier()
-        with self.lock:
-            thread_map = self.threads_compute_connections.get(thread_id)
-            if not thread_map:
-                thread_map = {}
-                self.threads_compute_connections[thread_id] = thread_map
-            return thread_map
-
-    def _get_if_exists_compute_connection(
-        self, compute_name: str
-    ) -> Optional[DatabricksDBTConnection]:
-        """Get the connection for the current thread and named compute, if it exists."""
-
-        with self.lock:
-            threads_map = self._get_compute_connections()
-            return threads_map.get(compute_name)
-
-    def _cleanup_idle_connections(self) -> None:
-        with self.lock:
-            # Get all connections associated with this thread. There can be multiple connections
-            # if different models use different compute resources
-            thread_conns = self._get_compute_connections()
-            for conn in thread_conns.values():
-                logger.debug(ConnectionIdleCheck(str(conn)))
-
-                # Generally speaking we only want to close/refresh the connection if the
-                # acquire_release_count is zero.  i.e. the connection is not currently in use.
-                # However python models acquire a connection then run the pyton model, which
-                # doesn't actually use the connection. If the python model takes lone enought to
-                # run the connection can be idle long enough to timeout on the back end.
-                # If additional sql needs to be run after the python model, but before the
-                # connection is released, the connection needs to be refreshed or there will
-                # be a failure.  Making an exception when language is 'python' allows the
-                # the call to _cleanup_idle_connections from get_thread_connection to refresh the
-                # connection in this scenario.
-                if (
-                    conn.acquire_release_count == 0 or conn.language == "python"
-                ) and conn._idle_too_long():
-                    logger.debug(ConnectionIdleClose(str(conn)))
-                    self.close(conn)
-                    conn._reset_handle(self._open)
-
-    def _create_compute_connection(
-        self, conn_name: str, query_header_context: Any = None
-    ) -> DatabricksDBTConnection:
-        """Create anew connection for the combination of current thread and compute associated
-        with the given node."""
-
-        # Create a new connection
-        compute_name = _get_compute_name(query_header_context) or ""
-
-        conn = DatabricksDBTConnection(
-            type=Identifier(self.TYPE),
-            name=conn_name,
-            state=ConnectionState.INIT,
-            transaction_open=False,
-            handle=None,
-            credentials=self.profile.credentials,
-        )
-        conn.compute_name = compute_name
-        creds = cast(DatabricksCredentials, self.profile.credentials)
-        conn.http_path = _get_http_path(query_header_context, creds=creds) or ""
-        conn.thread_identifier = cast(tuple[int, int], self.get_thread_identifier())
-        conn.max_idle_time = _get_max_idle_time(query_header_context, creds=creds)
-
-        conn.handle = LazyHandle(self.open)
-
-        logger.debug(ConnectionCreate(str(conn)))
-
-        # Add this connection to the thread/compute connection pool.
-        self._add_compute_connection(conn)
-        # Remove the connection currently in use by this thread from the thread connection pool.
-        self.clear_thread_connection()
-        # Add the connection to thread connection pool.
-        self.set_thread_connection(conn)
-
-        fire_event(
-            NewConnection(conn_name=conn_name, conn_type=self.TYPE, node_info=get_node_info())
-        )
-
-        return conn
-
-    def get_thread_connection(self) -> Connection:
-        conn = super().get_thread_connection()
-        self._cleanup_idle_connections()
-        dbr_conn = cast(DatabricksDBTConnection, conn)
-        logger.debug(ConnectionRetrieve(str(dbr_conn)))
-
-        return conn
+        return open_for_model
 
     @classmethod
     def open(cls, connection: Connection) -> Connection:
-        # Once long session management is no longer under the USE_LONG_SESSIONS toggle
-        # this should be renamed and replace the _open class method.
-        assert (
-            GlobalState.get_use_long_sessions()
-        ), "This path, '_open2', should only be reachable with USE_LONG_SESSIONS"
-
         databricks_connection = cast(DatabricksDBTConnection, connection)
 
         if connection.state == ConnectionState.OPEN:
@@ -987,6 +699,227 @@ class ExtendedSessionConnectionManager(DatabricksConnectionManager):
             retry_timeout=(timeout if timeout is not None else exponential_backoff),
         )
 
+    @classmethod
+    def _open(cls, connection: Connection, query_header_context: Any = None) -> Connection:
+        if connection.state == ConnectionState.OPEN:
+            return connection
+
+        creds: DatabricksCredentials = connection.credentials
+        timeout = creds.connect_timeout
+
+        # gotta keep this so we don't prompt users many times
+        cls.credentials_provider = creds.authenticate(cls.credentials_provider)
+
+        invocation_env = creds.get_invocation_env()
+        user_agent_entry = cls._user_agent
+        if invocation_env:
+            user_agent_entry = f"{cls._user_agent}; {invocation_env}"
+
+        connection_parameters = creds.connection_parameters.copy()  # type: ignore[union-attr]
+
+        http_headers: list[tuple[str, str]] = list(
+            creds.get_all_http_headers(connection_parameters.pop("http_headers", {})).items()
+        )
+
+        # If a model specifies a compute resource the http path
+        # may be different than the http_path property of creds.
+        http_path = _get_http_path(query_header_context, creds)
+
+        def connect() -> DatabricksSQLConnectionWrapper:
+            try:
+                # TODO: what is the error when a user specifies a catalog they don't have access to
+                conn: DatabricksSQLConnection = dbsql.connect(
+                    server_hostname=creds.host,
+                    http_path=http_path,
+                    credentials_provider=cls.credentials_provider,
+                    http_headers=http_headers if http_headers else None,
+                    session_configuration=creds.session_properties,
+                    catalog=creds.database,
+                    use_inline_params="silent",
+                    # schema=creds.schema,  # TODO: Explicitly set once DBR 7.3LTS is EOL.
+                    _user_agent_entry=user_agent_entry,
+                    **connection_parameters,
+                )
+                logger.debug(ConnectionCreated(str(conn)))
+
+                return DatabricksSQLConnectionWrapper(
+                    conn,
+                    is_cluster=creds.cluster_id is not None,
+                    creds=creds,
+                    user_agent=user_agent_entry,
+                )
+            except Error as exc:
+                logger.error(ConnectionCreateError(exc))
+                raise
+
+        def exponential_backoff(attempt: int) -> int:
+            return attempt * attempt
+
+        retryable_exceptions = []
+        # this option is for backwards compatibility
+        if creds.retry_all:
+            retryable_exceptions = [Error]
+
+        return cls.retry_connection(
+            connection,
+            connect=connect,
+            logger=logger,
+            retryable_exceptions=retryable_exceptions,
+            retry_limit=creds.connect_retries,
+            retry_timeout=(timeout if timeout is not None else exponential_backoff),
+        )
+
+    # override
+    @classmethod
+    def close(cls, connection: Connection) -> Connection:
+        try:
+            return super().close(connection)
+        except Exception as e:
+            logger.warning(f"ignoring error when closing connection: {e}")
+            connection.state = ConnectionState.CLOSED
+            return connection
+
+    @classmethod
+    def get_response(cls, cursor: DatabricksSQLCursorWrapper) -> DatabricksAdapterResponse:
+        _query_id = getattr(cursor, "hex_query_id", None)
+        if cursor is None:
+            logger.debug("No cursor was provided. Query ID not available.")
+            query_id = "N/A"
+        else:
+            query_id = _query_id
+        message = "OK"
+        return DatabricksAdapterResponse(_message=message, query_id=query_id)  # type: ignore
+
+    def get_thread_connection(self) -> Connection:
+        conn = super().get_thread_connection()
+        self._cleanup_idle_connections()
+        dbr_conn = cast(DatabricksDBTConnection, conn)
+        logger.debug(ConnectionRetrieve(str(dbr_conn)))
+
+        return conn
+
+    def _add_compute_connection(self, conn: DatabricksDBTConnection) -> None:
+        """Add a new connection to the map of connection per thread per compute."""
+
+        with self.lock:
+            thread_map = self._get_compute_connections()
+            if conn.compute_name in thread_map:
+                raise DbtInternalError(
+                    f"In set_thread_compute_connection, connection exists for `{conn.compute_name}`"
+                )
+            thread_map[conn.compute_name] = conn
+
+    def _cleanup_idle_connections(self) -> None:
+        with self.lock:
+            # Get all connections associated with this thread. There can be multiple connections
+            # if different models use different compute resources
+            thread_conns = self._get_compute_connections()
+            for conn in thread_conns.values():
+                logger.debug(ConnectionIdleCheck(str(conn)))
+
+                # Generally speaking we only want to close/refresh the connection if the
+                # acquire_release_count is zero.  i.e. the connection is not currently in use.
+                # However python models acquire a connection then run the pyton model, which
+                # doesn't actually use the connection. If the python model takes lone enought to
+                # run the connection can be idle long enough to timeout on the back end.
+                # If additional sql needs to be run after the python model, but before the
+                # connection is released, the connection needs to be refreshed or there will
+                # be a failure.  Making an exception when language is 'python' allows the
+                # the call to _cleanup_idle_connections from get_thread_connection to refresh the
+                # connection in this scenario.
+                if (
+                    conn.acquire_release_count == 0 or conn.language == "python"
+                ) and conn._idle_too_long():
+                    logger.debug(ConnectionIdleClose(str(conn)))
+                    self.close(conn)
+                    conn._reset_handle(self._open)
+
+    def _create_compute_connection(
+        self, conn_name: str, query_header_context: Any = None
+    ) -> DatabricksDBTConnection:
+        """Create anew connection for the combination of current thread and compute associated
+        with the given node."""
+
+        # Create a new connection
+        compute_name = _get_compute_name(query_header_context) or ""
+
+        conn = DatabricksDBTConnection(
+            type=Identifier(self.TYPE),
+            name=conn_name,
+            state=ConnectionState.INIT,
+            transaction_open=False,
+            handle=None,
+            credentials=self.profile.credentials,
+        )
+        conn.compute_name = compute_name
+        creds = cast(DatabricksCredentials, self.profile.credentials)
+        conn.http_path = _get_http_path(query_header_context, creds=creds) or ""
+        conn.thread_identifier = cast(tuple[int, int], self.get_thread_identifier())
+        conn.max_idle_time = _get_max_idle_time(query_header_context, creds=creds)
+
+        conn.handle = LazyHandle(self.open)
+
+        logger.debug(ConnectionCreate(str(conn)))
+
+        # Add this connection to the thread/compute connection pool.
+        self._add_compute_connection(conn)
+        # Remove the connection currently in use by this thread from the thread connection pool.
+        self.clear_thread_connection()
+        # Add the connection to thread connection pool.
+        self.set_thread_connection(conn)
+
+        fire_event(
+            NewConnection(conn_name=conn_name, conn_type=self.TYPE, node_info=get_node_info())
+        )
+
+        return conn
+
+    def _get_if_exists_compute_connection(
+        self, compute_name: str
+    ) -> Optional[DatabricksDBTConnection]:
+        """Get the connection for the current thread and named compute, if it exists."""
+
+        with self.lock:
+            threads_map = self._get_compute_connections()
+            return threads_map.get(compute_name)
+
+    def _get_compute_connections(
+        self,
+    ) -> dict[Hashable, DatabricksDBTConnection]:
+        """Retrieve a map of compute name to connection for the current thread."""
+
+        thread_id = self.get_thread_identifier()
+        with self.lock:
+            thread_map = self.threads_compute_connections.get(thread_id)
+            if not thread_map:
+                thread_map = {}
+                self.threads_compute_connections[thread_id] = thread_map
+            return thread_map
+
+    def _update_compute_connection(
+        self, conn: DatabricksDBTConnection, new_name: str
+    ) -> DatabricksDBTConnection:
+        if conn.name == new_name and conn.state == ConnectionState.OPEN:
+            # Found a connection and nothing to do, so just return it
+            return conn
+
+        orig_conn_name: str = conn.name or ""
+
+        if conn.state != ConnectionState.OPEN:
+            conn.handle = LazyHandle(self.open)
+        if conn.name != new_name:
+            conn.name = new_name
+            fire_event(ConnectionReused(orig_conn_name=orig_conn_name, conn_name=new_name))
+
+        current_thread_conn = cast(Optional[DatabricksDBTConnection], self.get_if_exists())
+        if current_thread_conn and current_thread_conn.compute_name != conn.compute_name:
+            self.clear_thread_connection()
+            self.set_thread_connection(conn)
+
+        logger.debug(ConnectionReuse(str(conn), orig_conn_name))
+
+        return conn
+
 
 def _get_compute_name(query_header_context: Any) -> Optional[str]:
     # Get the name of the specified compute resource from the node's
@@ -1005,24 +938,18 @@ def _get_http_path(query_header_context: Any, creds: DatabricksCredentials) -> O
     """Get the http_path for the compute specified for the node.
     If none is specified default will be used."""
 
-    thread_id = (os.getpid(), get_ident())
-
     # ResultNode *should* have relation_name attr, but we work around a core
     # issue by checking.
     relation_name = getattr(query_header_context, "relation_name", "[unknown]")
 
     # If there is no node we return the http_path for the default compute.
     if not query_header_context:
-        if not GlobalState.get_use_long_sessions():
-            logger.debug(f"Thread {thread_id}: using default compute resource.")
         return creds.http_path
 
     # Get the name of the compute resource specified in the node's config.
     # If none is specified return the http_path for the default compute.
     compute_name = _get_compute_name(query_header_context)
     if not compute_name:
-        if not GlobalState.get_use_long_sessions():
-            logger.debug(f"On thread {thread_id}: {relation_name} using default compute resource.")
         return creds.http_path
 
     # Get the http_path for the named compute.
@@ -1035,11 +962,6 @@ def _get_http_path(query_header_context: Any, creds: DatabricksCredentials) -> O
         raise DbtRuntimeError(
             f"Compute resource {compute_name} does not exist or "
             f"does not specify http_path, relation: {relation_name}"
-        )
-
-    if not GlobalState.get_use_long_sessions():
-        logger.debug(
-            f"On thread {thread_id}: {relation_name} using compute resource '{compute_name}'."
         )
 
     return http_path

--- a/dbt/adapters/databricks/global_state.py
+++ b/dbt/adapters/databricks/global_state.py
@@ -7,16 +7,6 @@ class GlobalState:
     single place than scattered throughout the codebase.
     """
 
-    __use_long_sessions: ClassVar[Optional[bool]] = None
-
-    @classmethod
-    def get_use_long_sessions(cls) -> bool:
-        if cls.__use_long_sessions is None:
-            cls.__use_long_sessions = (
-                os.getenv("DBT_DATABRICKS_LONG_SESSIONS", "True").upper() == "TRUE"
-            )
-        return cls.__use_long_sessions
-
     __invocation_env: ClassVar[Optional[str]] = None
     __invocation_env_set: ClassVar[bool] = False
 

--- a/dbt/adapters/databricks/impl.py
+++ b/dbt/adapters/databricks/impl.py
@@ -31,10 +31,7 @@ from dbt.adapters.databricks.behaviors.columns import (
     GetColumnsByInformationSchema,
 )
 from dbt.adapters.databricks.column import DatabricksColumn
-from dbt.adapters.databricks.connections import (
-    DatabricksConnectionManager,
-    ExtendedSessionConnectionManager,
-)
+from dbt.adapters.databricks.connections import DatabricksConnectionManager
 from dbt.adapters.databricks.global_state import GlobalState
 from dbt.adapters.databricks.python_models.python_submissions import (
     AllPurposeClusterPythonJobHelper,
@@ -154,10 +151,7 @@ class DatabricksAdapter(SparkAdapter):
     Relation = DatabricksRelation
     Column = DatabricksColumn
 
-    if GlobalState.get_use_long_sessions():
-        ConnectionManager: type[DatabricksConnectionManager] = ExtendedSessionConnectionManager
-    else:
-        ConnectionManager = DatabricksConnectionManager
+    ConnectionManager = DatabricksConnectionManager
 
     connections: DatabricksConnectionManager
 


### PR DESCRIPTION
<!---
  Include the number of the issue addressed by this PR above if applicable.

  Example:
    resolves #1234

  Please review our pull request review process in CONTRIBUTING.md before your proceed.
-->

### Description

For a long time we've had code that suggested that you could either reuse sessions or not by setting an env variable.  This hasn't worked for a long time, and since I need to refactor some of this code to improve cancellation behavior, I want to first compress to a single ConnectionManager, so that I don't need to make changes against both.  I eventually want to get rid of session reuse, but its too large to do as part of 1.9.x, where I want to improve cancellation behavior, so for now, let the code include only the paths that are actually reachable.

Note: no new code here, just collapsing into the parent class, and keeping the union of the code from the child and the parent.  Each method comes either from the parent (if the previous child didn't override) or the child (if the child did override, or added a new method).

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
