### PR TITLE
Update impl.py to use POSIX standard on location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### Under the Hood
 
 - Collapsing to a single connection manager (since the old one no longer works) ([910](https://github.com/databricks/dbt-databricks/pull/910))
-- Use POSIX standard when creating location for the tables ([911](https://github.com/databricks/dbt-databricks/pull/911))
+- Use POSIX standard when creating location for the tables ([919](https://github.com/databricks/dbt-databricks/pull/919))
 
 ## dbt-databricks 1.9.2 (Jan 21, 2024)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Under the Hood
 
 - Collapsing to a single connection manager (since the old one no longer works) ([910](https://github.com/databricks/dbt-databricks/pull/910))
+- Use POSIX standard when creating location for the tables ([911](https://github.com/databricks/dbt-databricks/pull/911))
 
 ## dbt-databricks 1.9.2 (Jan 21, 2024)
 

--- a/dbt/adapters/databricks/impl.py
+++ b/dbt/adapters/databricks/impl.py
@@ -1,4 +1,4 @@
-import os
+import posixpath
 import re
 from abc import ABC, abstractmethod
 from collections import defaultdict
@@ -214,9 +214,9 @@ class DatabricksAdapter(SparkAdapter):
             raise DbtConfigError("location_root is required for external tables.")
         include_full_name_in_path = config.get("include_full_name_in_path", False)
         if include_full_name_in_path:
-            path = os.path.join(location_root, database, schema, identifier)
+            path = posixpath.join(location_root, database, schema, identifier)
         else:
-            path = os.path.join(location_root, identifier)
+            path = posixpath.join(location_root, identifier)
         if is_incremental:
             path = path + "_tmp"
         return path


### PR DESCRIPTION
<!-- Please review our pull request review process in CONTRIBUTING.md before your proceed. -->



<!---
  Include the number of the issue addressed by this PR above if applicable.

  Example:
    resolves #1234

  Please review our pull request review process in CONTRIBUTING.md before your proceed.
-->

### Description

Executing dbt locally in a Windows machine is including front slash when using os.path.join function for separating different elements of the location and so generating issues when creating the tables. 
Using posix join it will always use back slash to separate the elements of the location and so work in any operating system.
<!--- Describe the Pull Request here -->

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
