### PR TITLE
Pin SQL Connector to < 3.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,15 @@
-## dbt-databricks 1.9.3 (TBD)
+## dbt-databricks 1.9.4 (TBD)
 
 ### Under the Hood
 
 - Collapsing to a single connection manager (since the old one no longer works) ([910](https://github.com/databricks/dbt-databricks/pull/910))
 - Use POSIX standard when creating location for the tables ([919](https://github.com/databricks/dbt-databricks/pull/919))
+
+## dbt-databricks 1.9.3 (Jan 30, 2024)
+
+### Under the Hood
+
+- Pinned the python sql connector to 3.6.0 as a temporary measure while we investigate failure to wait for cluster start
 
 ## dbt-databricks 1.9.2 (Jan 21, 2024)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 ]
 dependencies = [
     "databricks-sdk==0.17.0",
-    "databricks-sql-connector>=3.5.0, <4.0.0",
+    "databricks-sql-connector>=3.5.0, <3.7.0",
     "dbt-adapters>=1.7.0, <2.0",
     "dbt-common>=1.10.0, <2.0",
     "dbt-core>=1.8.7, <2.0",


### PR DESCRIPTION
### Description

Preparing for 1.9.3 release to pin the SQL connector.  Since the 3.7 release, users have complained about retries ending with too many 503s, but the time elapsed is much shorter than previously allowed.  This pin is temporary to allow investigation by the sql connector team.  In 1.10.x we will hopefully be ready to move to 4.0.x anyway.

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
