### PR TITLE
Prepare for environments with serverless notebooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,12 @@
 ### Features
 
 - Add `auto_liquid_cluster` config to enable Auto Liquid Clustering for Delta-based dbt models ([935](https://github.com/databricks/dbt-databricks/pull/935))
+- Prepare for environments for python models with serverless clusters ([938](https://github.com/databricks/dbt-databricks/pull/938))
 
 ### Fixes
 
 - table_format: iceberg is unblocked for snapshots ([930](https://github.com/databricks/dbt-databricks/pull/930))
 - Fix for regression in glue table listing behavior ([934](https://github.com/databricks/dbt-databricks/pull/934))
-
 
 ### Under the Hood
 

--- a/dbt/adapters/databricks/api_client.py
+++ b/dbt/adapters/databricks/api_client.py
@@ -327,7 +327,8 @@ class JobRunsApi(PollableApi):
         self, run_name: str, job_spec: dict[str, Any], **additional_job_settings: dict[str, Any]
     ) -> str:
         logger.debug(
-            f"Submitting job with run_name={run_name} and job_spec={job_spec} and additional_job_settings={additional_job_settings}"
+            f"Submitting job with run_name={run_name} and job_spec={job_spec}"
+            " and additional_job_settings={additional_job_settings}"
         )
         submit_response = self.session.post(
             "/submit", json={"run_name": run_name, "tasks": [job_spec], **additional_job_settings}

--- a/dbt/adapters/databricks/api_client.py
+++ b/dbt/adapters/databricks/api_client.py
@@ -326,6 +326,9 @@ class JobRunsApi(PollableApi):
     def submit(
         self, run_name: str, job_spec: dict[str, Any], **additional_job_settings: dict[str, Any]
     ) -> str:
+        logger.debug(
+            f"Submitting job with run_name={run_name} and job_spec={job_spec} and additional_job_settings={additional_job_settings}"
+        )
         submit_response = self.session.post(
             "/submit", json={"run_name": run_name, "tasks": [job_spec], **additional_job_settings}
         )

--- a/dbt/adapters/databricks/python_models/python_config.py
+++ b/dbt/adapters/databricks/python_models/python_config.py
@@ -36,6 +36,8 @@ class PythonModelConfig(BaseModel):
     cluster_id: Optional[str] = None
     http_path: Optional[str] = None
     create_notebook: bool = False
+    environment_key: Optional[str] = None
+    environment_dependencies: list[str] = Field(default_factory=list)
 
 
 class ParsedPythonModel(BaseModel):

--- a/tests/functional/adapter/python_model/fixtures.py
+++ b/tests/functional/adapter/python_model/fixtures.py
@@ -42,6 +42,32 @@ sources:
         identifier: source
 """
 
+serverless_schema_with_environment = """version: 2
+
+models:
+  - name: my_versioned_sql_model
+    versions:
+      - v: 1
+  - name: my_python_model
+    config:
+      submission_method: serverless_cluster
+      create_notebook: true
+      environment_key: "test_key"
+      environment_dependencies: ["requests"]
+
+sources:
+  - name: test_source
+    loader: custom
+    schema: "{{ var(env_var('DBT_TEST_SCHEMA_NAME_VARIABLE')) }}"
+    quoting:
+      identifier: True
+    tags:
+      - my_test_source_tag
+    tables:
+      - name: test_table
+        identifier: source
+"""
+
 workflow_schema = """version: 2
 
 models:

--- a/tests/functional/adapter/python_model/test_python_model.py
+++ b/tests/functional/adapter/python_model/test_python_model.py
@@ -114,6 +114,21 @@ class TestServerlessCluster(BasePythonModelTests):
 
 
 @pytest.mark.python
+# @pytest.mark.skip_profile("databricks_cluster", "databricks_uc_cluster")
+@pytest.mark.skip("Not available in Databricks yet")
+class TestServerlessClusterWithEnvironment(BasePythonModelTests):
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "schema.yml": override_fixtures.serverless_schema_with_environment,
+            "my_sql_model.sql": fixtures.basic_sql,
+            "my_versioned_sql_model_v1.sql": fixtures.basic_sql,
+            "my_python_model.py": fixtures.basic_python,
+            "second_sql_model.sql": fixtures.second_sql,
+        }
+
+
+@pytest.mark.python
 @pytest.mark.external
 @pytest.mark.skip_profile("databricks_cluster", "databricks_uc_sql_endpoint")
 class TestComplexConfig:


### PR DESCRIPTION
<!---
  Include the number of the issue addressed by this PR above if applicable.

  Example:
    resolves #1234

  Please review our pull request review process in CONTRIBUTING.md before your proceed.
-->

### Description

Learned from working with jobs team today that to use environments, we need the tasks to take an environment key...but also learned this doesn't work yet with serverless notebooks.  This code is to prepare for that feature to come to Databricks, to minimize time without this feature for users.  Normally I hate doing that, but there are user workloads blocked on this.

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
