### PR TITLE
Dealing with changes to the info schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## dbt-databricks 1.9.8 (TBD)
+
+### Fixes
+
+- Switch to using full_data_type column when using info schema for column info ([950](https://github.com/databricks/dbt-databricks/pull/950))
+
 ## dbt-databricks 1.9.7 (Feb 25, 2025)
 
 ### Fixes

--- a/dbt/adapters/databricks/behaviors/columns.py
+++ b/dbt/adapters/databricks/behaviors/columns.py
@@ -57,7 +57,11 @@ class GetColumnsByInformationSchema(GetColumnsByDescribe):
     def get_columns_in_relation(
         cls, adapter: SQLAdapter, relation: DatabricksRelation
     ) -> list[DatabricksColumn]:
-        if relation.is_hive_metastore() or relation.type == DatabricksRelation.View:
+        if (
+            relation.is_hive_metastore()
+            or relation.type == DatabricksRelation.View
+            or not relation.is_delta
+        ):
             return super().get_columns_in_relation(adapter, relation)
 
         rows = cls._get_columns_with_comments(

--- a/dbt/adapters/databricks/impl.py
+++ b/dbt/adapters/databricks/impl.py
@@ -312,6 +312,7 @@ class DatabricksAdapter(SparkAdapter):
                     identifier=name,
                     type=self.Relation.get_relation_type(kind),
                     metadata=metadata,
+                    is_delta=file_format == "delta",
                 )
             )
 
@@ -463,6 +464,7 @@ class DatabricksAdapter(SparkAdapter):
                 identifier=relation.identifier,
                 type=relation.type,  # type: ignore
                 metadata=metadata,
+                is_delta=metadata.get(KEY_TABLE_PROVIDER) == "delta",
             ),
             columns,
         )
@@ -561,16 +563,26 @@ class DatabricksAdapter(SparkAdapter):
         relations: list[tuple[DatabricksRelation, str]] = []
         if results:
             for name, information in results.select(["tableName", "information"]):
-                rel_type = RelationType.View if "Type: VIEW" in information else RelationType.Table
+                rel_type = self._get_relation_type(information)
                 relation = self.Relation.create(
                     database=schema_relation.database.lower() if schema_relation.database else None,
                     schema=schema_relation.schema.lower() if schema_relation.schema else None,
                     identifier=name,
-                    type=rel_type,
+                    type=rel_type,  # type: ignore
+                    is_delta="Provider: delta" in information,
                 )
                 relations.append((relation, information))
 
         return relations
+
+    def _get_relation_type(self, information: str) -> str:
+        if "Type: VIEW" in information:
+            return RelationType.View
+        if "TYPE: MATERIALIZED_VIEW" in information:
+            return DatabricksRelationType.MaterializedView
+        if "TYPE: STREAMING_TABLE" in information:
+            return DatabricksRelationType.StreamingTable
+        return DatabricksRelationType.Table
 
     def _show_table_extended(self, schema_relation: DatabricksRelation) -> Optional["Table"]:
         kwargs = {"schema_relation": schema_relation}

--- a/dbt/adapters/databricks/relation.py
+++ b/dbt/adapters/databricks/relation.py
@@ -60,7 +60,7 @@ class DatabricksRelation(BaseRelation):
     quote_policy: Policy = field(default_factory=lambda: DatabricksQuotePolicy())
     include_policy: Policy = field(default_factory=lambda: DatabricksIncludePolicy())
     quote_character: str = "`"
-
+    is_delta: Optional[bool] = None
     metadata: Optional[dict[str, Any]] = None
 
     @classmethod
@@ -85,11 +85,6 @@ class DatabricksRelation(BaseRelation):
     @property
     def is_streaming_table(self) -> bool:
         return self.type == DatabricksRelationType.StreamingTable
-
-    @property
-    def is_delta(self) -> bool:
-        assert self.metadata is not None
-        return self.metadata.get(KEY_TABLE_PROVIDER) == "delta"
 
     @property
     def is_hudi(self) -> bool:

--- a/dbt/include/databricks/macros/adapters/catalog.sql
+++ b/dbt/include/databricks/macros/adapters/catalog.sql
@@ -55,7 +55,7 @@
         table_name,
         column_name,
         ordinal_position as column_index,
-        lower(data_type) as column_type,
+        lower(full_data_type) as column_type,
         comment as column_comment
     from `system`.`information_schema`.`columns`
     where table_catalog = '{{ information_schema.database|lower }}'


### PR DESCRIPTION
### Description

Colin brought to my attention that there is a full_data_type column now in the info schema that is more apt, since it gives the details of struct.

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
