### PR TITLE
quote columns for foreign key and primary key constraints, if quote: true in column config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 - Update pinned python SDK version from 0.17.0 to 0.41.0. ([827](https://github.com/databricks/dbt-databricks/pull/827))
 - Implement new constraint logic for use_materialization_v2 flag ([846](https://github.com/databricks/dbt-databricks/pull/846/files)), ([876](https://github.com/databricks/dbt-databricks/pull/876))
+  - Quote constraint names if we quote column names (thanks @samuelberntzen!) ([966](https://github.com/databricks/dbt-databricks/pull/966))
 - Streamlining debug logging to make it more usable ([946](https://github.com/databricks/dbt-databricks/pull/946))
 - Upgrading Databricks SQL Connector to V4 ([962](https://github.com/databricks/dbt-databricks/pull/962))
 - Validation of sample mode ([961](https://github.com/databricks/dbt-databricks/pull/961))

--- a/dbt/adapters/databricks/constraints.py
+++ b/dbt/adapters/databricks/constraints.py
@@ -184,7 +184,9 @@ def parse_column_constraints(
             if constraint["type"] == ConstraintType.not_null:
                 column_names.add(column["name"])
             else:
-                constraint["columns"] = [column["name"]]
+                constraint["columns"] = [
+                    f"`{column['name']}`" if column.get("quote") else column["name"]
+                ]
                 constraints.append(parse_constraint(constraint))
 
     return column_names, constraints


### PR DESCRIPTION
Quotes/backticks are not applied for foreign key and primary key constraints in 1.10.0a1, even if the column's config specifies `quote: true`. By retrieving the (optional) `quote` argument from the column config in `parse_column_constraints` we can apply backticks to the constraint definition.


<!-- Please review our pull request review process in CONTRIBUTING.md before your proceed. -->

Resolves #965 

### Description

Modifies the `parse_column_constraints` to dynamically apply backticks on columns with foreign key and primary key constraints, if specified in the model's configuration:
```
    columns:
      - name: speciål_char_pk
        data_type: string
        quote: true
        constraints:
          - type: not_null
          - type: primary_key
```

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
