### PR TITLE
fix pydantic deprecation: allow_population_by_field_name -> populate_by_name

### DIFF
--- a/dbt/adapters/databricks/python_models/python_config.py
+++ b/dbt/adapters/databricks/python_models/python_config.py
@@ -56,4 +56,4 @@ class ParsedPythonModel(BaseModel):
         return f"{self.catalog}-{self.schema_}-{self.identifier}-{uuid.uuid4()}"
 
     class Config:
-        allow_population_by_field_name = True
+        populate_by_name = True


### PR DESCRIPTION

### Description

Fixes a deprecation warning

### Checklist

- [ ] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
