### PR TITLE
Fix issue where we delegate to the wrong method.

### DIFF
--- a/dbt/adapters/databricks/behaviors/columns.py
+++ b/dbt/adapters/databricks/behaviors/columns.py
@@ -67,8 +67,8 @@ class GetColumnsByInformationSchema(GetColumnsByDescribe):
         rows = cls._get_columns_with_comments(
             adapter, relation, "get_columns_comments_via_information_schema"
         )
-        return cls._parse_columns(rows)
+        return cls._parse_info_columns(rows)
 
     @classmethod
-    def _parse_columns(cls, rows: list[AttrDict]) -> list[DatabricksColumn]:
+    def _parse_info_columns(cls, rows: list[AttrDict]) -> list[DatabricksColumn]:
         return [DatabricksColumn(column=row[0], dtype=row[1], comment=row[2]) for row in rows]


### PR DESCRIPTION
<!---
  Include the number of the issue addressed by this PR above if applicable.

  Example:
    resolves #1234

  Please review our pull request review process in CONTRIBUTING.md before your proceed.
-->

### Description

While investigating for solutions to complex types in temporary views, discovered this issue where we delegate to super, it calls the overridden _parse_columns of the child, which leads to issues.  Hence, renaming the method for the child rather than overriding.

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
