### PR TITLE
Adding internal table property delta.columnMapping.maxColumnId to ignore_list (#987)

### DIFF
--- a/dbt/adapters/databricks/relation_configs/tblproperties.py
+++ b/dbt/adapters/databricks/relation_configs/tblproperties.py
@@ -40,6 +40,7 @@ class TblPropertiesConfig(DatabricksComponentConfig):
         "delta.rowTracking.materializedRowCommitVersionColumnName",
         "delta.rowTracking.materializedRowIdColumnName",
         "spark.internal.pipelines.top_level_entry.user_specified_name",
+        "delta.columnMapping.maxColumnId"
     ]
 
     def __eq__(self, __value: Any) -> bool:


### PR DESCRIPTION
Resolves #987 

### Description

This PR addresses #987 by adding internal, non-configurable Delta table properties to [ignore_list](https://github.com/databricks/dbt-databricks/blob/main/dbt/adapters/databricks/relation_configs/tblproperties.py#L22) in `tblproperties.py`, preventing unnecessary `SET TBLPROPERTIES` updates during incremental runs that cause concurrency issues like `MetadataChangedException`.

### Concurrency test

```
dbt run --select test_model --profiles-dir ci & dbt run --select test_model --profiles-dir ci & dbt run --select test_model --profiles-dir ci & dbt run --select test_model --profiles-dir ci & dbt run --select test_model --profiles-dir ci
```
Successfully completed all concurrent runs.

![Screenshot 2025-04-08 at 22 50 50](https://github.com/user-attachments/assets/8429873e-a17e-4118-a811-0dc8dfdc64e5)

### No SET TBLPROPERTIES operation

No longer running `SET TBLPROPERTIES`

<img width="1435" alt="Screenshot 2025-04-08 at 22 51 07" src="https://github.com/user-attachments/assets/ad38e792-53c9-480f-8944-7d0fa99a7c5c" />

#### Unit tests

```
hatch run unit
```

![Screenshot 2025-04-08 at 23 37 23](https://github.com/user-attachments/assets/8bd9a9fe-edf7-4827-bcc1-c106d7051bee)


### Checklist

- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
