### PR TITLE
Fix regression related to insert_overwrite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 - Fix: DBT Python Model Canceled Notebook Job Treated as Successful ([985](https://github.com/databricks/dbt-databricks/pull/985))
 - Fix failures when models end with ';' ([990](https://github.com/databricks/dbt-databricks/pull/990))
 - Added internal table property delta.columnMapping.maxColumnId to ignore_list to allow enabling delta.columnMapping.mode without breaking concurrent job runs (thanks @
-iamatharkhan!) ([991](https://github.com/databricks/dbt-databricks/pull/991))
+  iamatharkhan!) ([991](https://github.com/databricks/dbt-databricks/pull/991))
+- For insert_overwrite, raise exception when using SQL Warehouse and inform users that such use causes truncate + insert ([992](https://github.com/databricks/dbt-databricks/pull/992))
 
 ## dbt-databricks 1.10.0 (Apr 08, 2025)
 

--- a/dbt/adapters/databricks/connections.py
+++ b/dbt/adapters/databricks/connections.py
@@ -204,6 +204,9 @@ class DatabricksConnectionManager(SparkConnectionManager):
             )
         return self._api_client
 
+    def is_cluster(self) -> bool:
+        return self.get_thread_connection().credentials.cluster_id is not None
+
     def cancel_open(self) -> list[str]:
         cancelled = super().cancel_open()
         logger.info("Cancelling open python jobs")

--- a/dbt/adapters/databricks/impl.py
+++ b/dbt/adapters/databricks/impl.py
@@ -809,6 +809,11 @@ class DatabricksAdapter(SparkAdapter):
                 f"Materialization {model.config.materialized} is not supported."
             )
 
+    @available
+    def is_cluster(self) -> bool:
+        """Check if the current connection is a cluster."""
+        return self.connections.is_cluster()
+
 
 @dataclass(frozen=True)
 class RelationAPIBase(ABC, Generic[DatabricksRelationConfig]):

--- a/dbt/include/databricks/macros/materializations/incremental/incremental.sql
+++ b/dbt/include/databricks/macros/materializations/incremental/incremental.sql
@@ -113,9 +113,7 @@
     {%- else -%}
       {#-- Set Overwrite Mode to DYNAMIC for subsequent incremental operations --#}
       {%- if incremental_strategy == 'insert_overwrite' and partition_by -%}
-        {%- call statement() -%}
-          set spark.sql.sources.partitionOverwriteMode = DYNAMIC
-        {%- endcall -%}
+        {{ set_overwrite_mode(DYNAMIC) }}
       {%- endif -%}
       {#-- Relation must be merged --#}
       {%- set _existing_config = adapter.get_relation_config(existing_relation) -%}
@@ -182,9 +180,11 @@
 {%- endmaterialization %}
 
 {% macro set_overwrite_mode(value) %}
-  {%- call statement('Setting partitionOverwriteMode: ' ~ value) -%}
-    set spark.sql.sources.partitionOverwriteMode = {{ value }}
-  {%- endcall -%}
+  {% if adapter.is_cluster() %}
+    {%- call statement('Setting partitionOverwriteMode: ' ~ value) -%}
+      set spark.sql.sources.partitionOverwriteMode = {{ value }}
+    {%- endcall -%}
+  {% endif %}
 {% endmacro %}
 
 {% macro get_build_sql(incremental_strategy, target_relation, intermediate_relation) %}

--- a/dbt/include/databricks/macros/materializations/incremental/incremental.sql
+++ b/dbt/include/databricks/macros/materializations/incremental/incremental.sql
@@ -184,6 +184,8 @@
     {%- call statement('Setting partitionOverwriteMode: ' ~ value) -%}
       set spark.sql.sources.partitionOverwriteMode = {{ value }}
     {%- endcall -%}
+  {% else %}
+    {{ exceptions.raise_compiler_error('INSERT OVERWRITE is only properly supported on all-purpose clusters.  On SQL Warehouses, this strategy would be equivalent to using the table materialization.') }}
   {% endif %}
 {% endmacro %}
 

--- a/dbt/include/databricks/macros/materializations/incremental/incremental.sql
+++ b/dbt/include/databricks/macros/materializations/incremental/incremental.sql
@@ -113,7 +113,7 @@
     {%- else -%}
       {#-- Set Overwrite Mode to DYNAMIC for subsequent incremental operations --#}
       {%- if incremental_strategy == 'insert_overwrite' and partition_by -%}
-        {{ set_overwrite_mode(DYNAMIC) }}
+        {{ set_overwrite_mode('DYNAMIC') }}
       {%- endif -%}
       {#-- Relation must be merged --#}
       {%- set _existing_config = adapter.get_relation_config(existing_relation) -%}


### PR DESCRIPTION
### Description

In 1.10.0, we starting failing users that previously were passing for INSERT OVERWRITE with SQL Warehouses.  They should have always failed, since without dynamic partition setting, INSERT OVERWRITE is just truncate + insert, which is no better than the table materialization.  Hence, we guard every call to this setting with a check for compute type, and if not cluster, raise an information error message.

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
