### PR TITLE
Replace illegal characters in unique temporary table names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Added internal table property delta.columnMapping.maxColumnId to ignore_list to allow enabling delta.columnMapping.mode without breaking concurrent job runs (thanks @
   iamatharkhan!) ([991](https://github.com/databricks/dbt-databricks/pull/991))
 - For insert_overwrite, raise exception when using SQL Warehouse and inform users that such use causes truncate + insert ([992](https://github.com/databricks/dbt-databricks/pull/992))
-- Remove illegal characters in unique temporary table names which prevented dropping these tables on session close ([995](https://github.com/databricks/dbt-databricks/pull/995))
+- Remove illegal characters in unique temporary table names which prevented dropping these tables on session close (thanks @geo-martino!) ([995](https://github.com/databricks/dbt-databricks/pull/995))
 
 ## dbt-databricks 1.10.0 (Apr 08, 2025)
 

--- a/dbt/adapters/databricks/impl.py
+++ b/dbt/adapters/databricks/impl.py
@@ -753,8 +753,9 @@ class DatabricksAdapter(SparkAdapter):
         return return_columns
 
     @available
-    def generate_unique_temporary_table_suffix(self, suffix_initial: str = "__dbt_tmp") -> str:
-        return f"{suffix_initial}_{re.sub("[^A-Za-z0-9]+", "_", str(uuid.uuid4()))}"
+    @staticmethod
+    def generate_unique_temporary_table_suffix(suffix_initial: str = "__dbt_tmp") -> str:
+        return f"{suffix_initial}_{re.sub(r'[^A-Za-z0-9]+', '_', str(uuid4()))}"
 
     @available
     @staticmethod

--- a/dbt/adapters/databricks/impl.py
+++ b/dbt/adapters/databricks/impl.py
@@ -754,7 +754,7 @@ class DatabricksAdapter(SparkAdapter):
 
     @available
     def generate_unique_temporary_table_suffix(self, suffix_initial: str = "__dbt_tmp") -> str:
-        return f"{suffix_initial}_{str(uuid4())}"
+        return f"{suffix_initial}_{re.sub("[^A-Za-z0-9]+", "_", str(uuid.uuid4()))}"
 
     @available
     @staticmethod

--- a/tests/unit/test_adapter.py
+++ b/tests/unit/test_adapter.py
@@ -1,3 +1,4 @@
+import re
 from multiprocessing import get_context
 from typing import Any, Optional
 from unittest.mock import Mock, patch
@@ -944,6 +945,20 @@ class TestDatabricksAdapter(DatabricksAdapterBase):
             assert get_identifier_list_string(list(table_names)[:5]) == "|".join(
                 list(table_names)[:5]
             )
+
+    def test_generate_unique_temporary_table_suffix_adds_unique_identifier(self):
+        suffix_initial = "dbt_tmp"
+
+        result = DatabricksAdapter.generate_unique_temporary_table_suffix(suffix_initial)
+        assert result != suffix_initial
+        assert result.startswith(suffix_initial)
+        assert result != DatabricksAdapter.generate_unique_temporary_table_suffix(suffix_initial)
+
+    def test_generate_unique_temporary_table_suffix_generates_no_new_illegal_characters(self):
+        suffix_initial = "dbt_tmp"
+
+        result = DatabricksAdapter.generate_unique_temporary_table_suffix(suffix_initial)
+        assert not re.match(r"[^A-Za-z0-9_]+", result.replace(suffix_initial, ""))
 
 
 class TestCheckNotFound:


### PR DESCRIPTION
<!-- Please review our pull request review process in CONTRIBUTING.md before your proceed. -->

Resolves #994

<!---
  Include the number of the issue addressed by this PR above if applicable.

  Example:
    resolves #1234

  Please review our pull request review process in CONTRIBUTING.md before your proceed.
-->

### Description

Fixes a bug where temporary tables with unique identifiers would not be dropped on session close due to the table name containing illegal characters generated by the `uuid`.

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
