### PR TITLE
Fixing view replace logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
   ([999](https://github.com/databricks/dbt-databricks/pull/999))
 - Error no longer thrown when setting `requires_full_refresh` attribute after comment is changed on view and `view_update_via_alter` is true (thanks @geo-martino!)
   ([1000](https://github.com/databricks/dbt-databricks/pull/1000))
-- Many fixes related to how we handle view replacements, but specifically allowing views to function properly with using unique temporary names ([1004](https://github.com/databricks/dbt-databricks/pull/1004))
+- Many fixes related to how we handle view replacements, but specifically allowing views to function properly with using unique temporary names (thanks @geo-martino for help with validation!) ([1004](https://github.com/databricks/dbt-databricks/pull/1004))
 
 ## dbt-databricks 1.10.0 (Apr 08, 2025)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Remove illegal characters in unique temporary table names which prevented dropping these tables on session close (thanks @geo-martino!) ([995](https://github.com/databricks/dbt-databricks/pull/995))
 - Error no longer thrown when setting `requires_full_refresh` attribute after comment is changed on view and `view_update_via_alter` is true (thanks @geo-martino!)
   ([1000](https://github.com/databricks/dbt-databricks/pull/1000))
+- Many fixes related to how we handle view replacements, but specifically allowing views to function properly with using unique temporary names ([1004](https://github.com/databricks/dbt-databricks/pull/1004))
 
 ## dbt-databricks 1.10.0 (Apr 08, 2025)
 

--- a/dbt/adapters/databricks/relation.py
+++ b/dbt/adapters/databricks/relation.py
@@ -111,9 +111,10 @@ class DatabricksRelation(BaseRelation):
 
     @property
     def can_be_replaced(self) -> bool:
-        return self.is_delta is True and self.type in (
-            DatabricksRelationType.Table,
-            DatabricksRelationType.View,
+        return (
+            self.type == DatabricksRelationType.View
+            or self.is_delta is True
+            and self.type == DatabricksRelationType.Table
         )
 
     @property

--- a/dbt/adapters/databricks/relation_configs/column_comments.py
+++ b/dbt/adapters/databricks/relation_configs/column_comments.py
@@ -27,7 +27,8 @@ class ColumnCommentsConfig(DatabricksComponentConfig):
                     )
                     comments[column_name] = comment
             logger.debug(f"Comments: {comments}")
-            return ColumnCommentsConfig(comments=comments, persist=True)
+            if len(comments) > 0:
+                return ColumnCommentsConfig(comments=comments, persist=True)
         return None
 
 

--- a/dbt/include/databricks/macros/adapters/persist_docs.sql
+++ b/dbt/include/databricks/macros/adapters/persist_docs.sql
@@ -36,6 +36,6 @@ COMMENT ON {{ relation.type.upper() }} {{ relation.render() }} IS '{{ descriptio
     {{ log('Updating comment for column ' ~ column ~ ' with comment ' ~ comment) }}
     {% set escaped_comment = comment | replace('\'', '\\\'') %}
     {% set column_path = relation.render() ~ '.' ~ column %}
-    {{ run_query_as(comment_on_column_sql(column_path, escaped_comment), 'alter_column_comment', fetch_result=False) }}
+    {{ run_query_as(comment_on_column_sql(column_path, escaped_comment), 'main', fetch_result=False) }}
   {% endfor %}
 {% endmacro %}

--- a/dbt/include/databricks/macros/adapters/relation.sql
+++ b/dbt/include/databricks/macros/adapters/relation.sql
@@ -1,4 +1,8 @@
 {% macro make_staging_relation(base_relation, suffix='__dbt_stg', type='table') %}
+  {% set unique_tmp_table_suffix = config.get('unique_tmp_table_suffix', False) | as_bool %}
+  {% if unique_tmp_table_suffix %}
+    {% set suffix = adapter.generate_unique_temporary_table_suffix(suffix) %}
+  {% endif %}
   {% set stg_identifier = base_relation.identifier ~ suffix %}
   {% set stg_relation = api.Relation.create(database=base_relation.database, schema=base_relation.schema, identifier=stg_identifier, type=type) %}
   {% do return(stg_relation) %}

--- a/dbt/include/databricks/macros/materializations/table.sql
+++ b/dbt/include/databricks/macros/materializations/table.sql
@@ -25,7 +25,7 @@
       {% if safe_create and existing_relation.can_be_renamed %}
         {{ safe_relation_replace(existing_relation, staging_relation, intermediate_relation, compiled_code) }}
       {% else %}
-        {% if existing_relation and not (existing_relation.can_be_replaced and config.get('file_format', default='delta') == 'delta') -%}
+        {% if existing_relation and (existing_relation.type != 'table' or not (existing_relation.can_be_replaced and config.get('file_format', default='delta') == 'delta')) -%}
           {{ adapter.drop_relation(existing_relation) }}
         {%- endif %}
         {{ create_table_at(target_relation, intermediate_relation, compiled_code) }}
@@ -41,7 +41,7 @@
     -- setup: if the target relation already exists, drop it
     -- in case if the existing and future table is delta, we want to do a
     -- create or replace table instead of dropping, so we don't have the table unavailable
-    {% if existing_relation and not (existing_relation.can_be_replaced and config.get('file_format', default='delta') == 'delta') -%}
+    {% if existing_relation and (existing_relation.type != 'table' or not (existing_relation.can_be_replaced and config.get('file_format', default='delta') == 'delta')) -%}
       {{ adapter.drop_relation(existing_relation) }}
     {%- endif %}
 

--- a/dbt/include/databricks/macros/materializations/view.sql
+++ b/dbt/include/databricks/macros/materializations/view.sql
@@ -13,8 +13,11 @@
         {% set configuration_changes = get_configuration_changes(existing_relation) %}
         {% if configuration_changes and configuration_changes.changes %}
           {% if configuration_changes.requires_full_refresh %}
+            {{ log('Using replace_with_view') }}
             {{ replace_with_view(existing_relation, target_relation) }}
           {% else %}
+            {{ log('Using alter_view') }}
+            {{ log(configuration_changes.changes) }}
             {{ alter_view(target_relation, configuration_changes.changes) }}
           {% endif %}
         {% else %}

--- a/dbt/include/databricks/macros/materializations/view.sql
+++ b/dbt/include/databricks/macros/materializations/view.sql
@@ -17,9 +17,9 @@
           {% else %}
             {{ alter_view(target_relation, configuration_changes.changes) }}
           {% endif %}
+        {% else %}
+          {{ execute_no_op(target_relation) }}
         {% endif %}
-        {# This is to satisfy dbt as there are no changes needed here #}
-        {{ execute_no_op(target_relation) }}
       {% else %}
         {{ replace_with_view(existing_relation, target_relation) }}
       {% endif %}

--- a/dbt/include/databricks/macros/relations/replace.sql
+++ b/dbt/include/databricks/macros/relations/replace.sql
@@ -36,6 +36,7 @@
 
 {# Create target at a staging location, then rename existing, then rename target, then drop existing #}
 {% macro safely_replace(existing_relation, target_relation, sql) %}
+  {{ log('Using safely_replace') }}
   {% set staging_relation = make_staging_relation(target_relation) %}
   {{ drop_relation_if_exists(staging_relation) }}
   {% call statement(name="main") %}
@@ -50,6 +51,7 @@
 
 {# Stage the target relation, then drop and replace the existing relation #}
 {% macro stage_then_replace(existing_relation, target_relation, sql) %}
+  {{ log('Using stage_then_replace') }}
   {% set staging_relation = make_staging_relation(target_relation) %}
   {{ drop_relation_if_exists(staging_relation) }}
   {% call statement(name="main") %}
@@ -64,6 +66,7 @@
 
 {# Backup the existing relation, then create the target relation in place #}
 {% macro backup_and_create_in_place(existing_relation, target_relation, sql) %}
+  {{ log('Using backup_and_create_in_place') }}
   {{ create_backup(existing_relation) }}
   {{ return([
     get_create_sql(target_relation, sql),
@@ -73,6 +76,7 @@
 
 {# Drop the existing relation, then create the target relation #}
 {% macro drop_and_create(existing_relation, target_relation, sql) %}
+  {{ log('Using drop_and_create') }}
   {{ return([
     get_drop_sql(existing_relation),
     get_create_sql(target_relation, sql)

--- a/dbt/include/databricks/macros/relations/replace.sql
+++ b/dbt/include/databricks/macros/relations/replace.sql
@@ -37,7 +37,7 @@
 {# Create target at a staging location, then rename existing, then rename target, then drop existing #}
 {% macro safely_replace(existing_relation, target_relation, sql) %}
   {{ log('Using safely_replace') }}
-  {% set staging_relation = make_staging_relation(target_relation) %}
+  {% set staging_relation = make_staging_relation(target_relation, type='view') %}
   {{ drop_relation_if_exists(staging_relation) }}
   {% call statement(name="main") %}
     {{ get_create_sql(staging_relation, sql) }}
@@ -52,7 +52,7 @@
 {# Stage the target relation, then drop and replace the existing relation #}
 {% macro stage_then_replace(existing_relation, target_relation, sql) %}
   {{ log('Using stage_then_replace') }}
-  {% set staging_relation = make_staging_relation(target_relation) %}
+  {% set staging_relation = make_staging_relation(target_relation, type='view') %}
   {{ drop_relation_if_exists(staging_relation) }}
   {% call statement(name="main") %}
     {{ get_create_sql(staging_relation, sql) }}

--- a/dbt/include/databricks/macros/relations/replace.sql
+++ b/dbt/include/databricks/macros/relations/replace.sql
@@ -44,7 +44,7 @@
   {% endcall %}
   {{ create_backup(existing_relation) }}
   {{ return([
-    get_rename_sql(staging_relation, existing_relation.identifier),
+    get_rename_sql(staging_relation, existing_relation.render()),
     get_drop_backup_sql(existing_relation)
   ]) }}
 {% endmacro %}
@@ -60,7 +60,7 @@
 
   {{ return([
     get_drop_sql(existing_relation),
-    get_rename_sql(staging_relation, existing_relation.identifier),
+    get_rename_sql(staging_relation, existing_relation.render()),
   ]) }}
 {% endmacro %}
 

--- a/dbt/include/databricks/macros/relations/tags.sql
+++ b/dbt/include/databricks/macros/relations/tags.sql
@@ -22,12 +22,12 @@
     {{ exceptions.raise_compiler_error("Tags are only supported for Unity Catalog") }}
   {%- endif -%}
   {%- if set_tags %}
-    {%- call statement('set_tags') -%}
+    {%- call statement('main') -%}
        {{ alter_set_tags(relation, set_tags) }}
     {%- endcall -%}
   {%- endif %}
   {%- if unset_tags %}
-    {%- call statement('unset_tags') -%}
+    {%- call statement('main') -%}
        {{ alter_unset_tags(relation, unset_tags) }}
     {%- endcall -%}
   {%- endif %}

--- a/dbt/include/databricks/macros/relations/tblproperties.sql
+++ b/dbt/include/databricks/macros/relations/tblproperties.sql
@@ -16,7 +16,7 @@
 {% macro apply_tblproperties(relation, tblproperties) -%}
   {% set tblproperty_statment = databricks__tblproperties_clause(tblproperties) %}
   {% if tblproperty_statment %}
-    {%- call statement('apply_tblproperties') -%}
+    {%- call statement('main') -%}
       ALTER {{ relation.type }} {{ relation.render() }} SET {{ tblproperty_statment}}
     {%- endcall -%}
   {% endif %}

--- a/dbt/include/databricks/macros/relations/view/rename.sql
+++ b/dbt/include/databricks/macros/relations/view/rename.sql
@@ -1,3 +1,3 @@
 {% macro databricks__get_rename_view_sql(relation, new_name) %}
-  ALTER VIEW {{ relation.render() }} RENAME TO `{{ new_name }}`
+  ALTER VIEW {{ relation.render() }} RENAME TO {{ new_name }}
 {% endmacro %}

--- a/dbt/include/databricks/macros/relations/view/replace.sql
+++ b/dbt/include/databricks/macros/relations/view/replace.sql
@@ -1,3 +1,3 @@
 {% macro databricks__get_replace_view_sql(target_relation, sql) %}
-  {{ create_view_as(relation, sql) }}
+  {{ create_view_as(target_relation, sql) }}
 {% endmacro %}


### PR DESCRIPTION
<!-- Please review our pull request review process in CONTRIBUTING.md before your proceed. -->

Resolves #997 

### Description

Thanks to @geo-martino for raising issues around view replacement with unique temp locations, I found a bunch of small issues with view replacement generally.

Context: In materializations V2, we were making some really odd choices around view replacement due to a number of small bugs.  A customer noticed that when using unique names for temporary objects, we ended up trying to drop a different object than the one we had used, causing an error.  This led me down a long rabbit hole of finding a bunch of bugs that didn't show up on tests because for the majority of cases, the external behavior was the same, but the process was not what we had intended.  These are basically options that the user can specify to control how they want to materialization to play out, without changing what the final view looks like.  Anyway, long story short, @geo-martino helped me validate a bunch of different cases related to view replacement, leading to this PR.

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
