### PR TITLE
Output the stack trace log when the DBT Python model job fails

### DIFF
--- a/dbt/adapters/databricks/api_client.py
+++ b/dbt/adapters/databricks/api_client.py
@@ -354,7 +354,7 @@ class JobRunsApi(PollableApi):
         result_state = state.get("result_state")
         life_cycle_state = state["life_cycle_state"]
 
-        if result_state is not None and result_state != "SUCCESS":
+        if result_state == "CANCELED":
             raise DbtRuntimeError(f"Python model run ended in result_state {result_state}")
 
         if life_cycle_state != "TERMINATED":


### PR DESCRIPTION
<!-- Please review our pull request review process in CONTRIBUTING.md before your proceed. -->

Resolves #
https://github.com/databricks/dbt-databricks/issues/1020

<!---
  Include the number of the issue addressed by this PR above if applicable.

  Example:
    resolves #1234

  Please review our pull request review process in CONTRIBUTING.md before your proceed.
-->

### Description
Output the stack trace log when the DBT Python model job fails.Previously made the following fix. While it resolved the issue, it also caused the stack trace to no longer be output when the job fails, making it harder to investigate the root cause.Sorry for that.

```
Python model run ended in result_state FAILED
```

https://github.com/databricks/dbt-databricks/pull/985

By applying this modification, the job will fail with an error upon cancellation, and if it fails for any other reason, the error will be displayed along with the full stack trace.

FAILED
```
08:36:37 Databricks adapter: Job submission response=b'{"run_id":409733473259621}'
08:36:58 1 of 1 ERROR creating python table model<catalog>.<schema>.model.......... [ERROR in 22.65s]
08:36:58 
08:36:58 Finished running 1 table model in 0 hours 0 minutes and 37.84 seconds (37.84s).
08:36:58 
08:36:58 Completed with 1 error, 0 partial successes, and 0 warnings:
08:36:58 
08:36:58 Runtime Error in model ddl (../../models/sample/sample.py)
 Python model failed with traceback as:
 (Note that the line number here does not match the line number in your code due to dbt templating)
 <span class='ansi-red-fg'>Py4JJavaError</span>: An error occurred while calling o419.sql.
 : com.databricks.sql.managedcatalog.acl.UnauthorizedAccessException: PERMISSION_DENIED: User does not have MANAGE on Routine or Model '<catalog>.<schema>.hello'.
```
CANCELED
```
Python model run ended in result_state CANCELED
```

<!--- Describe the Pull Request here -->

### Checklist
```
[gw3] [ 99%] PASSED tests/unit/test_adapter.py::TestDatabricksAdapter::test_generate_unique_temporary_table_suffix_adds_unique_identifier 
tests/unit/test_adapter.py::TestDatabricksAdapter::test_generate_unique_temporary_table_suffix_generates_no_new_illegal_characters 
[gw3] [100%] PASSED tests/unit/test_adapter.py::TestDatabricksAdapter::test_generate_unique_temporary_table_suffix_generates_no_new_illegal_characters 

===================================== 472 passed, 6 skipped in 9.61s =====================================
```

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
