### PR TITLE
Wait for library installation on python submission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## dbt-databricks 1.10.3 (TBD)
 
+### Fixes
+
+- Fix bug where python model run starts before all libraries are installed on the cluster ([1028](https://github.com/databricks/dbt-databricks/issues/1028))
+
 ## dbt-databricks 1.10.2 (May 21, 2025)
 
 ### Features

--- a/dbt/adapters/databricks/api_client.py
+++ b/dbt/adapters/databricks/api_client.py
@@ -19,6 +19,7 @@ from dbt.adapters.databricks.logging import logger
 DEFAULT_POLLING_INTERVAL = 10
 SUBMISSION_LANGUAGE = "python"
 USER_AGENT = f"dbt-databricks/{version}"
+LIBRARY_VALID_STATUSES = {"INSTALLED", "RESTORED", "SKIPPED"}
 
 
 class PrefixSession:
@@ -47,10 +48,41 @@ class DatabricksApi(ABC):
         self.session = PrefixSession(session, host, api)
 
 
+class LibraryApi(DatabricksApi):
+    def __init__(self, session: Session, host: str):
+        super().__init__(session, host, "/api/2.0/libraries")
+
+    def all_libraries_installed(self, cluster_id: str) -> bool:
+        return all(
+            library["status"] in LIBRARY_VALID_STATUSES
+            for library in self.get_cluster_libraries_status(cluster_id)["library_statuses"]
+        )
+
+    def get_cluster_libraries_status(self, cluster_id: str) -> dict[str, Any]:
+        response = self.session.get(
+            "/cluster-status",
+            json={"cluster_id": cluster_id},
+        )
+        if response.status_code != 200:
+            raise DbtRuntimeError(
+                f"Error getting status of libraries of a cluster.\n {response.content!r}"
+            )
+
+        json_response = response.json()
+        return json_response
+
+
 class ClusterApi(DatabricksApi):
-    def __init__(self, session: Session, host: str, max_cluster_start_time: int = 900):
+    def __init__(
+        self,
+        session: Session,
+        host: str,
+        libraries: LibraryApi,
+        max_cluster_start_time: int = 900,
+    ):
         super().__init__(session, host, "/api/2.0/clusters")
         self.max_cluster_start_time = max_cluster_start_time
+        self.libraries = libraries
 
     def status(self, cluster_id: str) -> str:
         # https://docs.databricks.com/dev-tools/api/latest/clusters.html#get
@@ -68,10 +100,19 @@ class ClusterApi(DatabricksApi):
 
         while time.time() - start_time < self.max_cluster_start_time:
             status_response = self.status(cluster_id)
-            if status_response == "RUNNING":
-                return
-            else:
+
+            if status_response != "RUNNING":
+                logger.debug("Waiting for cluster to start")
                 time.sleep(5)
+                continue
+
+            libraries_status = self.libraries.get_cluster_libraries_status(cluster_id)
+            if not self.libraries.all_libraries_installed(cluster_id):
+                logger.debug(f"Waiting for all libraries to be installed: {libraries_status}")
+                time.sleep(5)
+                continue
+
+            return
 
         raise DbtRuntimeError(
             f"Cluster {cluster_id} restart timed out after {self.max_cluster_start_time} seconds"
@@ -96,9 +137,12 @@ class ClusterApi(DatabricksApi):
 
 
 class CommandContextApi(DatabricksApi):
-    def __init__(self, session: Session, host: str, cluster_api: ClusterApi):
+    def __init__(
+        self, session: Session, host: str, cluster_api: ClusterApi, library_api: LibraryApi
+    ):
         super().__init__(session, host, "/api/1.2/contexts")
         self.cluster_api = cluster_api
+        self.library_api = library_api
 
     def create(self, cluster_id: str) -> str:
         current_status = self.cluster_api.status(cluster_id)
@@ -107,7 +151,9 @@ class CommandContextApi(DatabricksApi):
             logger.debug(f"Cluster {cluster_id} is not running. Attempting to restart.")
             self.cluster_api.start(cluster_id)
             logger.debug(f"Cluster {cluster_id} is now running.")
-        elif current_status != "RUNNING":
+        elif current_status != "RUNNING" or not self.library_api.all_libraries_installed(
+            cluster_id
+        ):
             self.cluster_api.wait_for_cluster(cluster_id)
 
         response = self.session.post(
@@ -532,8 +578,9 @@ class DatabricksApiClient:
         timeout: int,
         use_user_folder: bool,
     ):
-        self.clusters = ClusterApi(session, host)
-        self.command_contexts = CommandContextApi(session, host, self.clusters)
+        self.libraries = LibraryApi(session, host)
+        self.clusters = ClusterApi(session, host, self.libraries)
+        self.command_contexts = CommandContextApi(session, host, self.clusters, self.libraries)
         self.curr_user = CurrUserApi(session, host)
         if use_user_folder:
             self.folders: FolderApi = UserFolderApi(session, host, self.curr_user)

--- a/dbt/adapters/databricks/api_client.py
+++ b/dbt/adapters/databricks/api_client.py
@@ -53,10 +53,14 @@ class LibraryApi(DatabricksApi):
         super().__init__(session, host, "/api/2.0/libraries")
 
     def all_libraries_installed(self, cluster_id: str) -> bool:
-        return all(
-            library["status"] in LIBRARY_VALID_STATUSES
-            for library in self.get_cluster_libraries_status(cluster_id)["library_statuses"]
-        )
+        status = self.get_cluster_libraries_status(cluster_id)
+        if "library_statuses" in status:
+            return all(
+                library["status"] in LIBRARY_VALID_STATUSES
+                for library in status["library_statuses"]
+            )
+        else:
+            return True
 
     def get_cluster_libraries_status(self, cluster_id: str) -> dict[str, Any]:
         response = self.session.get(

--- a/tests/unit/api_client/test_cluster_api.py
+++ b/tests/unit/api_client/test_cluster_api.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import freezegun
 import pytest
@@ -10,8 +10,12 @@ from tests.unit.api_client.api_test_base import ApiTestBase
 
 class TestClusterApi(ApiTestBase):
     @pytest.fixture
-    def api(self, session, host):
-        return ClusterApi(session, host)
+    def library_api(self):
+        return Mock()
+
+    @pytest.fixture
+    def api(self, session, host, library_api):
+        return ClusterApi(session, host, library_api)
 
     def test_status__non_200(self, api, session):
         self.assert_non_200_raises_error(lambda: api.status("cluster_id"), session)
@@ -26,10 +30,33 @@ class TestClusterApi(ApiTestBase):
         )
 
     @patch("dbt.adapters.databricks.api_client.time.sleep")
-    def test_wait_for_cluster__success(self, _, api, session):
+    def test_wait_for_cluster__success(self, _, api, session, library_api):
         session.get.return_value.status_code = 200
         session.get.return_value.json.side_effect = [{"state": "pending"}, {"state": "running"}]
+        library_api.get_cluster_libraries_status.return_value = {"library_statuses": []}
         api.wait_for_cluster("cluster_id")
+
+    @patch("dbt.adapters.databricks.api_client.time.sleep")
+    def test_wait_for_cluster_with_installed_library__success(
+        self, mock_sleep, api, session, library_api
+    ):
+        session.get.return_value.status_code = 200
+        session.get.return_value.json.return_value = {"state": "running"}
+        library_api.get_cluster_libraries_status.return_value = {
+            "library_statuses": [{"status": "INSTALLED"}]
+        }
+        api.wait_for_cluster("cluster_id")
+        mock_sleep.assert_not_called()
+
+    @patch("dbt.adapters.databricks.api_client.time.sleep")
+    def test_wait_for_cluster_with_pending_library__success(
+        self, mock_sleep, api, session, library_api
+    ):
+        session.get.return_value.status_code = 200
+        session.get.return_value.json.side_effect = [{"state": "running"}, {"state": "running"}]
+        library_api.all_libraries_installed.side_effect = [False, True]
+        api.wait_for_cluster("cluster_id")
+        mock_sleep.assert_called_with(5)
 
     @freezegun.freeze_time("2020-01-01", auto_tick_seconds=900)
     @patch("dbt.adapters.databricks.api_client.time.sleep")
@@ -42,10 +69,11 @@ class TestClusterApi(ApiTestBase):
     def test_start__non_200(self, api, session):
         self.assert_non_200_raises_error(lambda: api.start("cluster_id"), session)
 
-    def test_start__200(self, api, session, host):
+    def test_start__200(self, api, session, host, library_api):
         session.post.return_value.status_code = 200
         session.get.return_value.status_code = 200
         session.get.return_value.json.return_value = {"state": "running"}
+        library_api.get_cluster_libraries_status.return_value = {"library_statuses": []}
         api.start("cluster_id")
         session.post.assert_called_once_with(
             f"https://{host}/api/2.0/clusters/start", json={"cluster_id": "cluster_id"}, params=None

--- a/tests/unit/api_client/test_library_api.py
+++ b/tests/unit/api_client/test_library_api.py
@@ -41,3 +41,10 @@ class TestLibraryApi(ApiTestBase):
 
         result = api.all_libraries_installed("cluster_id")
         assert result is False
+
+    def test_library_statuses_not_present(self, api, session, host):
+        session.get.return_value.status_code = 200
+        session.get.return_value.json.return_value = {"cluster-id": "abc-123"}
+
+        result = api.all_libraries_installed("cluster_id")
+        assert result is True

--- a/tests/unit/api_client/test_library_api.py
+++ b/tests/unit/api_client/test_library_api.py
@@ -1,0 +1,43 @@
+import pytest
+
+from dbt.adapters.databricks.api_client import LibraryApi
+from tests.unit.api_client.api_test_base import ApiTestBase
+
+
+class TestLibraryApi(ApiTestBase):
+    @pytest.fixture
+    def api(self, session, host):
+        return LibraryApi(session, host)
+
+    def test_get_cluster_libraries_status__non_200(self, api, session):
+        self.assert_non_200_raises_error(
+            lambda: api.get_cluster_libraries_status("cluster_id"), session
+        )
+
+    def test_get_cluster_libraries_status__200(self, api, session, host):
+        cluster_id = "cluster_id"
+        expected_response = {"library_statuses": [{"status": "INSTALLED"}, {"status": "PENDING"}]}
+        session.get.return_value.status_code = 200
+        session.get.return_value.json.return_value = expected_response
+
+        result = api.get_cluster_libraries_status(cluster_id)
+        assert result == expected_response
+        session.get.assert_called_once_with(
+            f"https://{host}/api/2.0/libraries/cluster-status",
+            json={"cluster_id": cluster_id},
+            params=None,
+        )
+
+    def test_all_libraries_installed__true(self, api, session, host):
+        session.get.return_value.status_code = 200
+        session.get.return_value.json.return_value = {"library_statuses": [{"status": "INSTALLED"}]}
+
+        result = api.all_libraries_installed("cluster_id")
+        assert result is True
+
+    def test_all_libraries_installed__false(self, api, session, host):
+        session.get.return_value.status_code = 200
+        session.get.return_value.json.return_value = {"library_statuses": [{"status": "PENDING"}]}
+
+        result = api.all_libraries_installed("cluster_id")
+        assert result is False

--- a/tests/unit/api_client/test_library_api.py
+++ b/tests/unit/api_client/test_library_api.py
@@ -46,5 +46,5 @@ class TestLibraryApi(ApiTestBase):
         session.get.return_value.status_code = 200
         session.get.return_value.json.return_value = {"cluster-id": "abc-123"}
 
-        result = api.all_libraries_installed("cluster_id")
+        result = api.all_libraries_installed("abc-123")
         assert result is True


### PR DESCRIPTION
<!-- Please review our pull request review process in CONTRIBUTING.md before your proceed. -->

Resolves #1028

<!---
  Include the number of the issue addressed by this PR above if applicable.

  Example:
    resolves #1234

  Please review our pull request review process in CONTRIBUTING.md before your proceed.
-->

### Description

We currently check cluster status in 2 places for python submissions
- `CommandContextApi.create`
- `ClusterApi.wait_for_cluster`

This PR introduces a new `LibraryApi` to check the status of additional libraries added via the managed libraries API. It is invoked in the two places mentioned above to prevent the job from starting prematurely

Tested this E2E manually. The logs indicate that the additional libraries start off with status `PENDING`. The command is not executed until the libs are installed
```
[0m11:46:19.373884 [debug] [Thread-6  ]: Databricks adapter: Waiting for all libraries to be installed: {'cluster_id': '0520-174627-h5fgyjhc', 'library_statuses': [{'library': {'pypi': {'package': 'pyarrow'}}, 'status': 'PENDING', 'messages': ['Library status is temporarily unavailable'], 'is_library_for_all_clusters': False}, {'library': {'pypi': {'package': 'pydantic'}}, 'status': 'PENDING', 'messages': ['Library status is temporarily unavailable'], 'is_library_for_all_clusters': False}]}
[0m11:46:24.471639 [debug] [Thread-6  ]: Databricks adapter: Cluster status response=b'{"cluster_id":"0520-174627-h5fgyjhc","creator_user_name":"eric.jang@databricks.com","driver":{"private_ip":"10.139.64.5","node_id":"432f9ed9c630412e848988cec6fe2485","instance_id":"7a0312a6d1d041328a92da4222b6e4ad","start_timestamp":1747939472278,"node_type_id":"Standard_D4ds_v5","node_attributes":{"is_spot":false},"host_private_ip":"10.139.0.4","ngrok_endpoint_base_domain":"green.mux.ngrok-dataplane.wildcard"},"executors":[{"private_ip":"10.139.64.4","public_dns":"","node_id":"a88968db13ce47158a4562a31ae56090","instance_id":"38c9cba7962d415099673db8837ee733","start_timestamp":1747939472308,"node_type_id":"Standard_D4ds_v5","node_attributes":{"is_spot":true},"host_private_ip":"10.139.0.6","ngrok_endpoint_base_domain":"green.mux.ngrok-dataplane.wildcard"},{"private_ip":"10.139.64.6","public_dns":"","node_id":"4a621e873dcd4945b99c647207020eec","instance_id":"96974911f8c541799bd5ad4e3903a76b","start_timestamp":1747939472332,"node_type_id":"Standard_D4ds_v5","node_attributes":{"is_spot":true},"host_private_ip":"10.139.0.5","ngrok_endpoint_base_domain":"green.mux.ngrok-dataplane.wildcard"}],"spark_context_id":8129706681381784629,"driver_healthy":true,"jdbc_port":10000,"cluster_name":"Eric Jang\'s Cluster","spark_version":"15.4.x-scala2.12","azure_attributes":{"first_on_demand":1,"availability":"SPOT_WITH_FALLBACK_AZURE","spot_bid_max_price":-1.0},"node_type_id":"Standard_D4ds_v5","driver_node_type_id":"Standard_D4ds_v5","spark_env_vars":{"PYSPARK_PYTHON":"/databricks/python3/bin/python3"},"autotermination_minutes":120,"enable_elastic_disk":true,"disk_spec":{},"cluster_source":"UI","single_user_name":"eric.jang@databricks.com","enable_local_disk_encryption":false,"instance_source":{"node_type_id":"Standard_D4ds_v5"},"driver_instance_source":{"node_type_id":"Standard_D4ds_v5"},"data_security_mode":"SINGLE_USER","runtime_engine":"PHOTON","effective_spark_version":"15.4.x-photon-scala2.12","assigned_principal":"user:eric.jang@databricks.com","release_version":"15.4.15","state":"RUNNING","state_message":"","start_time":1747763187900,"last_state_loss_time":1747939544546,"last_activity_time":1747939497072,"last_restarted_time":1747939544629,"autoscale":{"min_workers":2,"max_workers":8,"target_workers":2},"cluster_memory_mb":49152,"cluster_cores":12.0,"default_tags":{"Vendor":"Databricks","Creator":"eric.jang@databricks.com","ClusterName":"Eric Jang\'s Cluster","ClusterId":"0520-174627-h5fgyjhc"},"init_scripts_safe_mode":false,"spec":{"cluster_name":"Eric Jang\'s Cluster","spark_version":"15.4.x-scala2.12","azure_attributes":{"first_on_demand":1,"availability":"SPOT_WITH_FALLBACK_AZURE","spot_bid_max_price":-1.0},"node_type_id":"Standard_D4ds_v5","spark_env_vars":{"PYSPARK_PYTHON":"/databricks/python3/bin/python3"},"autotermination_minutes":120,"single_user_name":"eric.jang@databricks.com","data_security_mode":"SINGLE_USER","runtime_engine":"PHOTON","autoscale":{"min_workers":2,"max_workers":8}}}'
[0m11:46:24.649198 [debug] [Thread-6  ]: Databricks adapter: Cluster 0520-174627-h5fgyjhc is now running.
[0m11:46:24.863524 [info ] [Thread-6  ]: Databricks adapter: Creating execution context response=<Response [200]>
[0m11:46:25.226340 [debug] [Thread-6  ]: Databricks adapter: Command execution response={'id': 'c31e054bc1694491b73273b5d9784f86'}
```

### Checklist

- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
