### PR TITLE
Fix insert overwrite compile check when using model level compute override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Fixes
 
 - Fix bug where python model run starts before all libraries are installed on the cluster ([1028](https://github.com/databricks/dbt-databricks/issues/1028))
+- Fix bug where incorrect insert overwrite exception was being thrown when overriding compute at model level ([1032](https://github.com/databricks/dbt-databricks/issues/1032))
 
 ## dbt-databricks 1.10.2 (May 21, 2025)
 

--- a/dbt/adapters/databricks/connections.py
+++ b/dbt/adapters/databricks/connections.py
@@ -205,7 +205,13 @@ class DatabricksConnectionManager(SparkConnectionManager):
         return self._api_client
 
     def is_cluster(self) -> bool:
-        return self.get_thread_connection().credentials.cluster_id is not None
+        conn = self.get_thread_connection()
+        return (
+            conn.credentials.cluster_id is not None
+            # Credentials field is not updated when overriding the compute at model level.
+            # This secondary check is a workaround for that case
+            or "/warehouses/" not in cast(DatabricksDBTConnection, conn).http_path
+        )
 
     def cancel_open(self) -> list[str]:
         cancelled = super().cancel_open()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,6 +48,13 @@ def dbt_profile_data(unique_schema, dbt_profile_target, profiles_config_update):
     }
     target = dbt_profile_target
     target["schema"] = unique_schema
+
+    # For testing model-level compute override
+    target["compute"] = {
+        "alternate_uc_cluster": {
+            "http_path": get_databricks_cluster_target("databricks_uc_cluster")["http_path"]
+        }
+    }
     profile["test"]["outputs"]["default"] = target
 
     alternate_warehouse = target.copy()

--- a/tests/functional/adapter/incremental/test_incremental_strategies.py
+++ b/tests/functional/adapter/incremental/test_incremental_strategies.py
@@ -106,13 +106,43 @@ class TestInsertOverwriteWithPartitionsDelta(InsertOverwriteBase):
             "models": {
                 "+incremental_strategy": "insert_overwrite",
                 "+partition_by": "id",
-            }
+            },
         }
 
     @pytest.fixture(scope="class")
     def seeds(self):
         return {
             "upsert_expected.csv": fixtures.upsert_expected,
+        }
+
+    def test_incremental(self, project):
+        self.seed_and_run_twice()
+        util.check_relations_equal(project.adapter, ["overwrite_model", "upsert_expected"])
+
+
+# Only runs under SQL warehouse profile, but overrides compute at model level
+@pytest.mark.skip_profile("databricks_uc_cluster", "databricks_cluster")
+class TestInsertOverwriteWithModelComputeOverride(IncrementalBase):
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {
+            "models": {
+                "+incremental_strategy": "insert_overwrite",
+                "+partition_by": "id",
+                "+databricks_compute": "alternate_uc_cluster",
+            },
+        }
+
+    @pytest.fixture(scope="class")
+    def seeds(self):
+        return {
+            "upsert_expected.csv": fixtures.upsert_expected,
+        }
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "overwrite_model.sql": fixtures.base_model,
         }
 
     def test_incremental(self, project):


### PR DESCRIPTION
<!-- Please review our pull request review process in CONTRIBUTING.md before your proceed. -->

Resolves #1032

<!---
  Include the number of the issue addressed by this PR above if applicable.

  Example:
    resolves #1234

  Please review our pull request review process in CONTRIBUTING.md before your proceed.
-->

### Description

Looks like the bug is coming from the fact that the connection credentials always point to the project level compute details. When overriding compute at the model level, we need to check elsewhere to verify whether it is a cluster or SQL warehouse

### Checklist

- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
