### PR TITLE
Fix multiple foreign key constraints bug

### DIFF
--- a/dbt/include/databricks/macros/relations/components/constraints.sql
+++ b/dbt/include/databricks/macros/relations/components/constraints.sql
@@ -71,7 +71,7 @@
   WHERE kcu.table_catalog = '{{ relation.database|lower }}'
     AND kcu.table_schema = '{{ relation.schema|lower }}'
     AND kcu.table_name = '{{ relation.identifier|lower }}'
-    AND kcu.constraint_name = (
+    AND kcu.constraint_name IN (
       SELECT constraint_name
       FROM `{{ relation.database|lower }}`.information_schema.table_constraints
       WHERE table_catalog = '{{ relation.database|lower }}'

--- a/tests/functional/adapter/incremental/fixtures.py
+++ b/tests/functional/adapter/incremental/fixtures.py
@@ -791,6 +791,16 @@ select
     'parent' as type
 """
 
+fk_referenced_to_table_2 = """
+{{ config(
+    materialized = 'incremental',
+) }}
+
+select
+    cast(1 as bigint) as id,
+    'hello' as name
+"""
+
 constraint_schema_without_fk_constraint = """
 version: 2
 
@@ -814,7 +824,7 @@ models:
         data_type: string
 """
 
-constraint_schema_with_fk_constraint = """
+constraint_schema_with_fk_constraints = """
 version: 2
 
 models:
@@ -835,6 +845,19 @@ models:
       - name: type
         data_type: string
 
+  - name: fk_referenced_to_table_2
+    constraints:
+      - type: primary_key
+        columns: [id]
+        name: pk_parent_2
+    columns:
+      - name: id
+        data_type: bigint
+        constraints:
+          - type: not_null
+      - name: name
+        data_type: string
+
   - name: fk_referenced_from_table
     columns:
       - name: id
@@ -849,4 +872,9 @@ models:
         columns: [id, version]
         to: ref('fk_referenced_to_table')
         to_columns: [id, version]
+      - type: foreign_key
+        name: fk_to_parent_2
+        columns: [id]
+        to: ref('fk_referenced_to_table_2')
+        to_columns: [id]
 """

--- a/tests/functional/adapter/incremental/test_incremental_constraints.py
+++ b/tests/functional/adapter/incremental/test_incremental_constraints.py
@@ -194,6 +194,7 @@ class TestIncrementalSetForeignKeyConstraint:
     def models(self):
         return {
             "fk_referenced_to_table.sql": fixtures.fk_referenced_to_table,
+            "fk_referenced_to_table_2.sql": fixtures.fk_referenced_to_table_2,
             "fk_referenced_from_table.sql": fixtures.fk_referenced_from_table,
             "schema.yml": fixtures.constraint_schema_without_fk_constraint,
         }
@@ -205,12 +206,14 @@ class TestIncrementalSetForeignKeyConstraint:
 
         # Foreign key constraint is informational only, so we cannot verify enforcement.
         # Instead, check that the metadata is updated correctly.
-        util.write_file(fixtures.constraint_schema_with_fk_constraint, "models", "schema.yml")
+        util.write_file(fixtures.constraint_schema_with_fk_constraints, "models", "schema.yml")
         util.run_dbt(["run"])
         referential_constraints = project.run_sql(referential_constraint_sql, fetch="all")
-        assert len(referential_constraints) == 1
+        assert len(referential_constraints) == 2
         assert referential_constraints[0][0] == "fk_to_parent"
         assert referential_constraints[0][1] == "pk_parent"
+        assert referential_constraints[1][0] == "fk_to_parent_2"
+        assert referential_constraints[1][1] == "pk_parent_2"
 
 
 @pytest.mark.skip_profile("databricks_cluster")
@@ -225,8 +228,9 @@ class TestIncrementalRemoveForeignKeyConstraint:
     def models(self):
         return {
             "fk_referenced_to_table.sql": fixtures.fk_referenced_to_table,
+            "fk_referenced_to_table_2.sql": fixtures.fk_referenced_to_table_2,
             "fk_referenced_from_table.sql": fixtures.fk_referenced_from_table,
-            "schema.yml": fixtures.constraint_schema_with_fk_constraint,
+            "schema.yml": fixtures.constraint_schema_with_fk_constraints,
         }
 
     def test_remove_foreign_key_constraint(self, project):
@@ -235,9 +239,11 @@ class TestIncrementalRemoveForeignKeyConstraint:
 
         # Verify the constraint exists
         referential_constraints = project.run_sql(referential_constraint_sql, fetch="all")
-        assert len(referential_constraints) == 1
+        assert len(referential_constraints) == 2
         assert referential_constraints[0][0] == "fk_to_parent"
         assert referential_constraints[0][1] == "pk_parent"
+        assert referential_constraints[1][0] == "fk_to_parent_2"
+        assert referential_constraints[1][1] == "pk_parent_2"
 
         # Remove foreign key constraint and verify
         util.write_file(fixtures.constraint_schema_without_fk_constraint, "models", "schema.yml")


### PR DESCRIPTION
<!-- Please review our pull request review process in CONTRIBUTING.md before your proceed. -->

Resolves #1034

<!---
  Include the number of the issue addressed by this PR above if applicable.

  Example:
    resolves #1234

  Please review our pull request review process in CONTRIBUTING.md before your proceed.
-->

### Description

Foreign key fetching is broken when more than one is defined in the model. This is because the SQL query assumes that there is only 1 FK per table, which is not true. The fix is to us `IN` instead of `=` check

### Checklist

- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
