### PR TITLE
Fix insert_overwrite handling of schema update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
-## dbt-databricks 1.10.3 (TBD)
+## dbt-databricks 1.10.4 (TBD)
+
+### Fixes
+
+- Fix bug where schema update causes insert_overwrite strategy to fail on subsequent runs ([1057](https://github.com/databricks/dbt-databricks/issues/1057))
+
+## dbt-databricks 1.10.3 (June 4, 2025)
 
 ### Fixes
 

--- a/tests/functional/adapter/incremental/fixtures.py
+++ b/tests/functional/adapter/incremental/fixtures.py
@@ -223,6 +223,12 @@ overwrite_expected = """id,msg
 3,anyway
 """
 
+upsert_expected_no_msg = """id,msg
+1,hello
+2,null
+3,null
+"""
+
 upsert_expected = """id,msg
 1,hello
 2,yo
@@ -299,6 +305,26 @@ select cast(2 as bigint) as id, 'goodbye' as msg
 select cast(2 as bigint) as id, 'yo' as msg
 union all
 select cast(3 as bigint) as id, 'anyway' as msg
+
+{% endif %}
+"""
+
+update_schema_model = """
+{{ config(
+    materialized = 'incremental'
+) }}
+
+{% if not is_incremental() %}
+
+select cast(1 as bigint) as id, 'hello' as msg
+union all
+select cast(2 as bigint) as id, 'goodbye' as msg
+
+{% else %}
+
+select cast(2 as bigint) as id
+union all
+select cast(3 as bigint) as id
 
 {% endif %}
 """

--- a/tests/functional/adapter/incremental/test_incremental_strategies.py
+++ b/tests/functional/adapter/incremental/test_incremental_strategies.py
@@ -120,6 +120,34 @@ class TestInsertOverwriteWithPartitionsDelta(InsertOverwriteBase):
         util.check_relations_equal(project.adapter, ["overwrite_model", "upsert_expected"])
 
 
+@pytest.mark.skip_profile("databricks_uc_sql_endpoint")
+class TestInsertOverwriteChangeSchema(InsertOverwriteBase):
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "overwrite_model.sql": fixtures.update_schema_model,
+        }
+
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {
+            "models": {
+                "+incremental_strategy": "insert_overwrite",
+                "+partition_by": "id",
+            },
+        }
+
+    @pytest.fixture(scope="class")
+    def seeds(self):
+        return {
+            "overwrite_expected.csv": fixtures.upsert_expected_no_msg,
+        }
+
+    def test_incremental(self, project):
+        self.seed_and_run_twice()
+        util.check_relations_equal(project.adapter, ["overwrite_model", "overwrite_expected"])
+
+
 # Only runs under SQL warehouse profile, but overrides compute at model level
 @pytest.mark.skip_profile("databricks_uc_cluster", "databricks_cluster")
 class TestInsertOverwriteWithModelComputeOverride(IncrementalBase):


### PR DESCRIPTION
<!-- Please review our pull request review process in CONTRIBUTING.md before your proceed. -->

Resolves #1057

<!---
  Include the number of the issue addressed by this PR above if applicable.

  Example:
    resolves #1234

  Please review our pull request review process in CONTRIBUTING.md before your proceed.
-->

### Description

Update insert_overwrite SQL to do the same thing as append strategy in handling schema updates. Removed column is set to default values for new records

### Checklist

- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
