### PR TITLE
Add metric_view as a relation type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Fixes
 
 - Fix bug where schema update causes insert_overwrite strategy to fail on subsequent runs ([1057](https://github.com/databricks/dbt-databricks/issues/1057))
+- Fix bug where model run fails if catalog contains a metric view ([1045](https://github.com/databricks/dbt-databricks/issues/1045))
 
 ## dbt-databricks 1.10.3 (June 4, 2025)
 

--- a/dbt/adapters/databricks/relation.py
+++ b/dbt/adapters/databricks/relation.py
@@ -43,6 +43,7 @@ class DatabricksRelationType(StrEnum):
     External = "external"
     ManagedShallowClone = "managed_shallow_clone"
     ExternalShallowClone = "external_shallow_clone"
+    MetricView = "metric_view"
     Unknown = "unknown"
 
 

--- a/tests/functional/adapter/metric_views/test_metric_views.py
+++ b/tests/functional/adapter/metric_views/test_metric_views.py
@@ -1,0 +1,40 @@
+import pytest
+
+from dbt.tests.util import run_dbt
+
+
+# Extremely simple test to ensure model runs work in the presence of metric views
+class TestMetricViews:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"simple_model.sql": "select 1 as id"}
+
+    def test_model_with_metric_view(self, project):
+        # First create a source table
+        project.run_sql(f"""
+            CREATE TABLE {project.database}.{project.test_schema}.source_table (
+                id INT,
+                value INT
+            )
+        """)
+
+        # Create a minimal metric view
+        project.run_sql(f"""
+            CREATE OR REPLACE VIEW {project.database}.{project.test_schema}.test_metric_view
+            WITH METRICS
+            LANGUAGE YAML
+            AS $$
+            version: 0.1
+            source: {project.database}.{project.test_schema}.source_table
+            dimensions:
+            - name: id
+              expr: id
+            measures:
+            - name: count
+              expr: count(1)
+            $$;
+        """)
+
+        # Run a regular dbt model
+        results = run_dbt(["run"])
+        assert len(results) == 1

--- a/tests/functional/adapter/metric_views/test_metric_views.py
+++ b/tests/functional/adapter/metric_views/test_metric_views.py
@@ -4,6 +4,7 @@ from dbt.tests.util import run_dbt
 
 
 # Extremely simple test to ensure model runs work in the presence of metric views
+@pytest.mark.skip_profile("databricks_cluster")
 class TestMetricViews:
     @pytest.fixture(scope="class")
     def models(self):


### PR DESCRIPTION
<!-- Please review our pull request review process in CONTRIBUTING.md before your proceed. -->

Resolves #1045

<!---
  Include the number of the issue addressed by this PR above if applicable.

  Example:
    resolves #1234

  Please review our pull request review process in CONTRIBUTING.md before your proceed.
-->

### Description

Add metric view as a relation type so that models can be run against catalogs that have metric views

### Checklist

- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
