### PR TITLE
Add cloning for the external tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 - Support column tags (with Materialization V2) ([649](https://github.com/databricks/dbt-databricks/issues/649))
 - Support column masking (with Materialization V2) ([670](https://github.com/databricks/dbt-databricks/issues/670))
-- Add cloning support for the the external tables ([1079](https://github.com/databricks/dbt-databricks/pull/1079))
+- Add cloning support for the the external tables (thanks @samgans!) ([1079](https://github.com/databricks/dbt-databricks/pull/1079))
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Support column tags (with Materialization V2) ([649](https://github.com/databricks/dbt-databricks/issues/649))
 - Support column masking (with Materialization V2) ([670](https://github.com/databricks/dbt-databricks/issues/670))
+- Add cloning support for the the external tables ([1079](https://github.com/databricks/dbt-databricks/pull/1079))
 
 ### Fixes
 

--- a/dbt/adapters/databricks/relation.py
+++ b/dbt/adapters/databricks/relation.py
@@ -94,6 +94,10 @@ class DatabricksRelation(BaseRelation):
         return self.type == DatabricksRelationType.StreamingTable
 
     @property
+    def is_external_table(self) -> bool:
+        return self.type == DatabricksRelationType.External
+
+    @property
     def is_dlt(self) -> bool:
         return self.is_materialized_view or self.is_streaming_table
 

--- a/dbt/include/databricks/macros/materializations/clone/clone.sql
+++ b/dbt/include/databricks/macros/materializations/clone/clone.sql
@@ -2,18 +2,6 @@
     {{ return(True) }}
 {% endmacro %}
 
-{% macro databricks__create_or_replace_clone(this_relation, defer_relation) %}
-    create or replace
-    table {{ this_relation }}
-    shallow clone {{ defer_relation }}
-{% endmacro %}
-
-{% macro databricks__create_or_replace_clone_external(this_relation, defer_relation) %}
-    create or replace
-    table {{ this_relation }}
-    shallow clone {{ defer_relation }}
-    {{ location_clause(this_relation) }}
-{% endmacro %}
 
 {%- materialization clone, adapter='databricks' -%}
 

--- a/dbt/include/databricks/macros/materializations/clone/strategies.sql
+++ b/dbt/include/databricks/macros/materializations/clone/strategies.sql
@@ -1,0 +1,14 @@
+{% macro databricks__create_or_replace_clone(this_relation, defer_relation) %}
+    create or replace
+    table {{ this_relation.render() }}
+    shallow clone {{ defer_relation.render() }}
+{% endmacro %}
+
+{% macro databricks__create_or_replace_clone_external(this_relation, defer_relation) %}
+    {%- set catalog_relation = adapter.build_catalog_relation(config.model) -%}
+
+    create or replace
+    table {{ this_relation.render() }}
+    shallow clone {{ defer_relation.render() }}
+    {{ location_clause(catalog_relation) }}
+{% endmacro %}

--- a/tests/unit/macros/materializations/test_clone_macros.py
+++ b/tests/unit/macros/materializations/test_clone_macros.py
@@ -1,0 +1,97 @@
+from typing import Optional
+from unittest.mock import Mock
+
+import pytest
+
+from dbt.adapters.databricks import catalogs, constants
+from tests.unit.macros.base import MacroTestBase
+from tests.unit.utils import unity_relation
+
+
+class TestCloneStrategies(MacroTestBase):
+
+    t_location_root = "/mnt/root_dev/"
+
+    def render_clone_macro(
+        self,
+        template_bundle,
+        macro,
+        s_relation,
+        t_relation
+    ) -> str:
+
+        external_path = f"{self.t_location_root}{template_bundle.relation.identifier}"
+        adapter_mock = template_bundle.template.globals["adapter"]
+        adapter_mock.compute_external_path.return_value = external_path
+        return self.run_macro(
+            template_bundle.template,
+            macro,
+            t_relation,
+            s_relation,
+        )
+
+    @pytest.fixture(scope="class")
+    def template_name(self) -> str:
+        return "strategies.sql"
+
+    @pytest.fixture(scope="class")
+    def macro_folders_to_load(self) -> list:
+        return ["macros/materializations/clone", "macros/relations", "macros"]
+
+    @pytest.fixture(scope="class")
+    def databricks_template_names(self) -> list:
+        return ["location.sql"]
+
+    @pytest.fixture
+    def s_relation(self):
+        relation = Mock()
+        relation.database = "some_database"
+        relation.schema = "some_schema_prod"
+        relation.identifier = "some_table"
+        relation.render = Mock(return_value="`some_database`.`some_schema_prod`.`some_table`")
+        relation.without_identifier = Mock(return_value="`some_database`.`some_schema_prod`")
+        relation.type = "table"
+        return relation
+
+    @pytest.fixture
+    def catalog_relation(self, template_bundle):
+        t_relation = unity_relation(
+            file_format=constants.DELTA_FILE_FORMAT,
+            location_root=self.t_location_root,
+            location_path=template_bundle.relation.identifier,
+        )
+        template_bundle.context["adapter"].build_catalog_relation.return_value = t_relation
+        return t_relation
+
+    def test_create_or_replace_clone(self, template_bundle, s_relation):
+        sql = self.render_clone_macro(
+            template_bundle,
+            "databricks__create_or_replace_clone",
+            s_relation,
+            template_bundle.relation,
+        )
+
+        expected = self.clean_sql(
+            "create or replace "
+            f"table {template_bundle.relation.render()} "
+            f"shallow clone {s_relation.render()}"
+        )
+
+        assert expected == sql
+
+    def test_create_or_replace_clone_external(self, template_bundle, catalog_relation, s_relation):
+        sql = self.render_clone_macro(
+            template_bundle,
+            "databricks__create_or_replace_clone_external",
+            s_relation,
+            template_bundle.relation,
+        )
+
+        expected = self.clean_sql(
+            "create or replace "
+            f"table {template_bundle.relation.render()} "
+            f"shallow clone {s_relation.render()} "
+            f"location '{catalog_relation.location}'"
+        )
+
+        assert expected == sql

--- a/tests/unit/macros/materializations/test_clone_macros.py
+++ b/tests/unit/macros/materializations/test_clone_macros.py
@@ -1,25 +1,16 @@
-from typing import Optional
 from unittest.mock import Mock
 
 import pytest
 
-from dbt.adapters.databricks import catalogs, constants
+from dbt.adapters.databricks import constants
 from tests.unit.macros.base import MacroTestBase
 from tests.unit.utils import unity_relation
 
 
 class TestCloneStrategies(MacroTestBase):
-
     t_location_root = "/mnt/root_dev/"
 
-    def render_clone_macro(
-        self,
-        template_bundle,
-        macro,
-        s_relation,
-        t_relation
-    ) -> str:
-
+    def render_clone_macro(self, template_bundle, macro, s_relation, t_relation) -> str:
         external_path = f"{self.t_location_root}{template_bundle.relation.identifier}"
         adapter_mock = template_bundle.template.globals["adapter"]
         adapter_mock.compute_external_path.return_value = external_path

--- a/tests/unit/macros/relations/test_table_macros.py
+++ b/tests/unit/macros/relations/test_table_macros.py
@@ -1,8 +1,6 @@
-from typing import Optional
-
 import pytest
 
-from dbt.adapters.databricks import catalogs, constants
+from dbt.adapters.databricks import constants
 from tests.unit.macros.base import MacroTestBase
 from tests.unit.utils import unity_relation
 

--- a/tests/unit/macros/relations/test_table_macros.py
+++ b/tests/unit/macros/relations/test_table_macros.py
@@ -4,23 +4,7 @@ import pytest
 
 from dbt.adapters.databricks import catalogs, constants
 from tests.unit.macros.base import MacroTestBase
-
-
-def unity_relation(
-    table_format: Optional[str] = None,
-    file_format: Optional[str] = None,
-    location_root: Optional[str] = None,
-    location_path: Optional[str] = None,
-) -> catalogs.DatabricksCatalogRelation:
-    catalog_integration = constants.DEFAULT_UNITY_CATALOG
-    return catalogs.DatabricksCatalogRelation(
-        catalog_type=catalog_integration.catalog_type,
-        catalog_name=catalog_integration.catalog_name,
-        table_format=table_format or catalog_integration.table_format,
-        file_format=file_format or catalog_integration.file_format,
-        external_volume=location_root or catalog_integration.external_volume,
-        location_path=location_path,
-    )
+from tests.unit.utils import unity_relation
 
 
 class TestCreateTableAs(MacroTestBase):

--- a/tests/unit/utils.py
+++ b/tests/unit/utils.py
@@ -1,6 +1,8 @@
 import os
 from copy import deepcopy
+from typing import Optional
 
+from dbt.adapters.databricks import catalogs, constants
 from dbt.config import Profile, Project, RuntimeConfig
 from dbt.config.project import PartialProject
 from dbt.config.renderer import DbtProjectYamlRenderer, ProfileRenderer
@@ -78,3 +80,22 @@ def config_from_parts_or_dicts(project, profile, packages=None, selectors=None, 
     args.vars = cli_vars
     args.profile_dir = "/dev/null"
     return RuntimeConfig.from_parts(project=project, profile=profile, args=args)
+
+
+def unity_relation(
+    table_format: Optional[str] = None,
+    file_format: Optional[str] = None,
+    location_root: Optional[str] = None,
+    location_path: Optional[str] = None,
+) -> catalogs.DatabricksCatalogRelation:
+
+    catalog_integration = constants.DEFAULT_UNITY_CATALOG
+
+    return catalogs.DatabricksCatalogRelation(
+        catalog_type=catalog_integration.catalog_type,
+        catalog_name=catalog_integration.catalog_name,
+        table_format=table_format or catalog_integration.table_format,
+        file_format=file_format or catalog_integration.file_format,
+        external_volume=location_root or catalog_integration.external_volume,
+        location_path=location_path,
+    )

--- a/tests/unit/utils.py
+++ b/tests/unit/utils.py
@@ -88,7 +88,6 @@ def unity_relation(
     location_root: Optional[str] = None,
     location_path: Optional[str] = None,
 ) -> catalogs.DatabricksCatalogRelation:
-
     catalog_integration = constants.DEFAULT_UNITY_CATALOG
 
     return catalogs.DatabricksCatalogRelation(


### PR DESCRIPTION
<!-- Please review our pull request review process in CONTRIBUTING.md before your proceed. -->

### Description

This PR adds the ability to clone the external tables to the package. Without that, the `dbt clone` command fails as Databricks requires providing the location of the target if we are cloning the external table.

To achieve that, I've introduced the `is_external_table` property of the `DatabricksRelation` that provides the information if the table is external. Then, I've added the new macro named `databricks__create_or_replace_clone_external` that handles the logic of the external cloning and uses the `location_clause` macro to determine where to perform the clone based on the target table configs.

The decision which macro to choose is happening in the `clone` macro itself: if the `is_external_table` attribute of the relation returns True, we call the `_external` macro. If not, we perform the call of the already existing cloning macro.

The second macro was added based on the security considerations: I wouldn't want to break the existing cloning procedures in my release, thus I prefer to have completely separate branch for the new functionality which is more or less independent of already existing code.

### Checklist

- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
