### PR TITLE
Fix inefficient query when getting column schema for MV/STs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## dbt-databricks 1.10.5 (TBD)
 
+### Fixes
+
+- Fix inefficient query when getting column schema for MV/STs ([1074](https://github.com/databricks/dbt-databricks/issues/1074))
+
 ## dbt-databricks 1.10.4 (June 24, 2025)
 
 ### Features

--- a/dbt/adapters/databricks/impl.py
+++ b/dbt/adapters/databricks/impl.py
@@ -406,7 +406,9 @@ class DatabricksAdapter(SparkAdapter):
     @available.parse(lambda *a, **k: [])
     def get_column_schema_from_query(self, sql: str) -> list[DatabricksColumn]:
         """Get a list of the Columns with names and data types from the given sql."""
-        _, cursor = self.connections.add_select_query(sql)
+        # Optimize by wrapping the query with LIMIT 0 to get schema without executing the full query
+        optimized_sql = f"{sql} LIMIT 0"
+        _, cursor = self.connections.add_select_query(optimized_sql)
         try:
             columns: list[DatabricksColumn] = [
                 self.Column.create(


### PR DESCRIPTION
<!-- Please review our pull request review process in CONTRIBUTING.md before your proceed. -->

Resolves #1074

<!---
  Include the number of the issue addressed by this PR above if applicable.

  Example:
    resolves #1234

  Please review our pull request review process in CONTRIBUTING.md before your proceed.
-->

### Description

The implementation of `get_column_schema_from_query` (used for MV/STs) runs the entire user query which is inefficient. Quick fix to do a `LIMIT 0` for faster execution

### Checklist

- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
