### PR TITLE
Add new default tblproperties to be ignored by relation config diff

### DIFF
--- a/dbt/adapters/databricks/relation_configs/tblproperties.py
+++ b/dbt/adapters/databricks/relation_configs/tblproperties.py
@@ -42,6 +42,8 @@ class TblPropertiesConfig(DatabricksComponentConfig):
         "spark.internal.pipelines.top_level_entry.user_specified_name",
         "delta.columnMapping.maxColumnId",
         "spark.sql.internal.pipelines.parentTableId",
+        "delta.enableDeletionVectors",
+        "delta.feature.deletionVectors",
     ]
 
     def __eq__(self, __value: Any) -> bool:


### PR DESCRIPTION
<!-- Please review our pull request review process in CONTRIBUTING.md before your proceed. -->

Resolves #

<!---
  Include the number of the issue addressed by this PR above if applicable.

  Example:
    resolves #1234

  Please review our pull request review process in CONTRIBUTING.md before your proceed.
-->

### Description

There are new default tblproperties being added by Databricks (verified manually by creating a new table). PR to filter them out from relation config diffs. This should fix test failures like https://github.com/databricks/dbt-databricks/actions/runs/16009615743/job/45164217776?pr=1080

### Checklist

- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
