### PR TITLE
Do cascading drop when primary key constraint is removed from config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - Fix inefficient query when getting column schema for MV/STs ([1074](https://github.com/databricks/dbt-databricks/issues/1074))
 
+### Under the Hood
+
+- Dropping primary key constraints in incremental runs now trigger cascading deletes (i.e. foreign key constraints referencing it will also be dropped)
+
 ## dbt-databricks 1.10.4 (June 24, 2025)
 
 ### Features

--- a/dbt/include/databricks/macros/relations/components/constraints.sql
+++ b/dbt/include/databricks/macros/relations/components/constraints.sql
@@ -131,5 +131,5 @@
 {%- endmacro -%}
 
 {% macro alter_unset_constraint(relation, constraint) -%}
-  ALTER {{ relation.type }} {{ relation.render() }} DROP CONSTRAINT IF EXISTS {{ constraint.name }} CASCADE;
+  ALTER {{ relation.type }} {{ relation.render() }} DROP CONSTRAINT IF EXISTS {{ constraint.name }};
 {%- endmacro -%}

--- a/dbt/include/databricks/macros/relations/components/constraints.sql
+++ b/dbt/include/databricks/macros/relations/components/constraints.sql
@@ -131,5 +131,5 @@
 {%- endmacro -%}
 
 {% macro alter_unset_constraint(relation, constraint) -%}
-  ALTER {{ relation.type }} {{ relation.render() }} DROP CONSTRAINT {{ constraint.name }};
+  ALTER {{ relation.type }} {{ relation.render() }} DROP CONSTRAINT IF EXISTS {{ constraint.name }} CASCADE;
 {%- endmacro -%}

--- a/tests/functional/adapter/incremental/fixtures.py
+++ b/tests/functional/adapter/incremental/fixtures.py
@@ -762,6 +762,22 @@ models:
         columns: [id]
 """
 
+schema_with_single_column_primary_key_constraint_removed = """
+version: 2
+
+models:
+  - name: primary_key_constraint_sql
+    columns:
+      - name: id
+        data_type: bigint
+        constraints:
+          - type: not_null
+      - name: version
+        data_type: int
+      - name: msg
+        data_type: string
+"""
+
 schema_with_composite_primary_key_constraint = """
 version: 2
 

--- a/tests/functional/adapter/incremental/test_incremental_constraints.py
+++ b/tests/functional/adapter/incremental/test_incremental_constraints.py
@@ -175,6 +175,49 @@ class TestIncrementalUpdatePrimaryKeyConstraint:
         assert not any(constraint[0] == "pk_model" for constraint in primary_key_constraints)
 
 
+@pytest.mark.skip_profile("databricks_cluster")
+class TestCascadingConstraintDrop:
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {
+            "flags": {"use_materialization_v2": True},
+        }
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "primary_key_constraint_sql.sql": fixtures.primary_key_constraint_sql,
+            "schema.yml": fixtures.schema_with_single_column_primary_key_constraint,
+        }
+
+    def test_cascading_constraint_drop(self, project):
+        # First run with single column primary key
+        util.run_dbt(["run"])
+
+        project.run_sql(
+            f"""
+            CREATE TABLE IF NOT EXISTS {project.database}.{project.test_schema}.ref_table (
+                id BIGINT,
+                name STRING,
+                CONSTRAINT fk_ref_table_pk_model FOREIGN KEY (id) REFERENCES {project.database}.{project.test_schema}.primary_key_constraint_sql (id)
+            )
+            """,
+            fetch="all",
+        )
+
+        referential_constraints = project.run_sql(referential_constraint_sql, fetch="all")
+        assert len(referential_constraints) == 1
+
+        util.write_file(
+            fixtures.schema_with_single_column_primary_key_constraint_removed,
+            "models",
+            "schema.yml",
+        )
+        util.run_dbt(["run"])
+        referential_constraints = project.run_sql(referential_constraint_sql, fetch="all")
+        assert len(referential_constraints) == 0
+
+
 referential_constraint_sql = """
     SELECT constraint_name, unique_constraint_name
     FROM {database}.information_schema.referential_constraints

--- a/tests/functional/adapter/incremental/test_incremental_constraints.py
+++ b/tests/functional/adapter/incremental/test_incremental_constraints.py
@@ -194,12 +194,14 @@ class TestCascadingConstraintDrop:
         # First run with single column primary key
         util.run_dbt(["run"])
 
+        # Create a table outside of dbt that has a FK to the PK created within dbt
         project.run_sql(
             f"""
             CREATE TABLE IF NOT EXISTS {project.database}.{project.test_schema}.ref_table (
                 id BIGINT,
                 name STRING,
-                CONSTRAINT fk_ref_table_pk_model FOREIGN KEY (id) REFERENCES {project.database}.{project.test_schema}.primary_key_constraint_sql (id)
+                CONSTRAINT fk_ref_table_pk_model FOREIGN KEY (id)
+                REFERENCES {project.database}.{project.test_schema}.primary_key_constraint_sql (id)
             )
             """,
             fetch="all",
@@ -208,6 +210,7 @@ class TestCascadingConstraintDrop:
         referential_constraints = project.run_sql(referential_constraint_sql, fetch="all")
         assert len(referential_constraints) == 1
 
+        # Remove PK constraint via dbt and verify that the FK constraint is removed via cascade
         util.write_file(
             fixtures.schema_with_single_column_primary_key_constraint_removed,
             "models",


### PR DESCRIPTION
<!-- Please review our pull request review process in CONTRIBUTING.md before your proceed. -->

Resolves #1081

<!---
  Include the number of the issue addressed by this PR above if applicable.

  Example:
    resolves #1234

  Please review our pull request review process in CONTRIBUTING.md before your proceed.
-->

### Description

Today, we handle PK and FK constraints in arbitrary order. This can result in a bug like the following:
1. Run models where table 1 has a PK, and table 2 has a FK referencing the table 1's PK
2. Drop both PK and FK, then re-run
3. If the statement to drop the PK is executed first, it will fail because there are existing references to it

This PR fixes this by using `CASCADE`. When the PK is deleted, it will delete the FK as part of the same statement. The subsequent statement to drop the FK will be a no-op due to the `IF EXISTS`

### Checklist

- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
