### PR TITLE
Handle complex data types that are truncated by DESCRIBE TABLE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fix inefficient query when getting column schema for MV/STs ([1074](https://github.com/databricks/dbt-databricks/issues/1074))
 - Fix bug causing false positives in diffing constraints between existing relation and model config for incremental runs ([1081](https://github.com/databricks/dbt-databricks/issues/1081))
 - Fix bug causing "main is not being called during running model" errors for some view updates ([1077](https://github.com/databricks/dbt-databricks/issues/1077))
+- Fix bug that causes materialization (V2) to fail when data type is long enough to be truncated by DESCRIBE TABLE ([1083](https://github.com/databricks/dbt-databricks/issues/1083))
 
 ### Under the Hood
 

--- a/dbt/adapters/databricks/behaviors/columns.py
+++ b/dbt/adapters/databricks/behaviors/columns.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+from typing import Any
 
 from dbt_common.utils.dict import AttrDict
 
@@ -33,23 +34,95 @@ class GetColumnsByDescribe(GetColumnsBehavior):
     def get_columns_in_relation(
         cls, adapter: SQLAdapter, relation: DatabricksRelation
     ) -> list[DatabricksColumn]:
-        rows = cls._get_columns_with_comments(adapter, relation, "get_columns_comments")
-        return cls._parse_columns(rows)
+        json_metadata = cls._get_columns_with_comments(
+            adapter, relation, "get_columns_comments_as_json"
+        )[0]["json_metadata"]
+        return cls._parse_columns_from_json(json_metadata)
 
     @classmethod
-    def _parse_columns(cls, rows: list[AttrDict]) -> list[DatabricksColumn]:
+    def _parse_columns_from_json(cls, json_metadata: str) -> list[DatabricksColumn]:
+        import json
+
+        data = json.loads(json_metadata)
         columns = []
 
-        for row in rows:
-            if row["col_name"].startswith("#"):
-                break
-            columns.append(
-                DatabricksColumn(
-                    column=row["col_name"], dtype=row["data_type"], comment=row["comment"]
-                )
-            )
+        for col_info in data.get("columns", []):
+            col_name = col_info.get("name")
+            col_type = cls._parse_type(col_info.get("type"))
+            comment = col_info.get("comment")
+            columns.append(DatabricksColumn(column=col_name, dtype=col_type, comment=comment))
 
         return columns
+
+    @classmethod
+    def _parse_type(cls, type_info: Any) -> str:
+        """
+        Convert type information from JSON format to Databricks DDL
+        https://docs.databricks.com/aws/en/sql/language-manual/sql-ref-syntax-aux-describe-table#json-formatted-output
+
+        Complex types with properties other than type name in JSON schema:
+          - struct: nested types handled
+          - array: nested types handled
+          - map: nested types handled
+          - decimal: precision, scale handled
+          - string: collation handled
+          - varchar: Handled just in case, but the JSON should never contain a varchar type as
+                     these are just STRING types under the hood in Databricks.
+          - char: Handled just in case, but the JSON should never contain a char type as these are
+                  just STRING types under the hood in Databricks.
+
+        Complex types can have other properties in the JSON schema such as nullable, defaults, etc.
+        but those are ignored as they are not part of data type DDL
+        """
+
+        type_name = type_info.get("name")
+        if type_name == "struct":
+            fields = type_info.get("fields", [])
+            field_strs = []
+            for field in fields:
+                field_name = field.get("name")
+                field_type = cls._parse_type(field.get("type"))
+                field_strs.append(f"{field_name}: {field_type}")
+            return f"struct<{', '.join(field_strs)}>"
+
+        elif type_name == "array":
+            element_type = cls._parse_type(type_info.get("element_type"))
+            return f"array<{element_type}>"
+
+        elif type_name == "map":
+            # Handle map types with element_nullable
+            key_type = cls._parse_type(type_info.get("key_type"))
+            value_type = cls._parse_type(type_info.get("value_type"))
+            return f"map<{key_type}, {value_type}>"
+
+        elif type_name == "decimal":
+            # Handle decimal types with precision and scale
+            precision = type_info.get("precision")
+            scale = type_info.get("scale")
+            if precision is not None and scale is not None:
+                return f"decimal({precision}, {scale})"
+            elif precision is not None:
+                return f"decimal({precision})"
+            else:
+                return "decimal"
+
+        elif type_name == "string":
+            # Handle string types with collation
+            collation = type_info.get("collation")
+            if collation is not None:
+                return f"string COLLATE {collation}"
+            else:
+                return "string"
+
+        elif type_name == "varchar":
+            return "string"
+
+        elif type_name == "char":
+            return "string"
+
+        else:
+            # Handle primitive types and any other types
+            return str(type_name)
 
 
 class GetColumnsByInformationSchema(GetColumnsByDescribe):

--- a/dbt/include/databricks/macros/adapters/columns.sql
+++ b/dbt/include/databricks/macros/adapters/columns.sql
@@ -1,10 +1,10 @@
 
-{% macro get_columns_comments(relation) -%}
-  {{ return(run_query_as(get_columns_comments_sql(relation), 'get_columns_comments')) }}
+{% macro get_columns_comments_as_json(relation) -%}
+  {{ return(run_query_as(get_columns_comments_as_json_sql(relation), 'get_columns_comments_as_json')) }}
 {% endmacro %}
 
-{% macro get_columns_comments_sql(relation) %}
-DESCRIBE TABLE {{ relation.render() }}
+{% macro get_columns_comments_as_json_sql(relation) %}
+  DESCRIBE TABLE EXTENDED {{ relation.render() }} AS JSON
 {% endmacro %}
 
 {% macro get_columns_comments_via_information_schema(relation) -%}

--- a/tests/functional/adapter/basic/fixtures.py
+++ b/tests/functional/adapter/basic/fixtures.py
@@ -21,3 +21,75 @@ class AnyStringOrNone:
 
     def __eq__(self, other):
         return isinstance(other, str) or other is None
+
+
+all_types_model_sql = """
+{{ config(
+    materialized = 'table'
+)}}
+
+SELECT
+  -- Numeric types
+  CAST(42 AS TINYINT) AS tinyint_col,
+  CAST(30000 AS SMALLINT) AS smallint_col,
+  CAST(2000000000 AS INT) AS int_col,
+  CAST(9000000000000000000 AS BIGINT) AS bigint_col,
+  CAST(3.14 AS FLOAT) AS float_col,
+  CAST(2.718281828459 AS DOUBLE) AS double_col,
+  CAST(12345.6789 AS DECIMAL(10,4)) AS decimal_col,
+
+  -- Boolean type
+  CAST(TRUE AS BOOLEAN) AS boolean_col,
+
+  -- String types
+  CAST('Hello' AS STRING) AS string_col,
+  CAST('Databricks' AS VARCHAR(50)) AS varchar_col,
+  CAST('abc' AS CHAR(10)) AS char_col,
+
+  -- Binary type
+  CAST(X'DEADBEEF' AS BINARY) AS binary_col,
+
+  -- Date and time types
+  CAST('2024-07-08' AS DATE) AS date_col,
+  CAST('2024-07-08 12:34:56' AS TIMESTAMP) AS timestamp_col,
+
+  -- Variant type
+  CAST(1 AS VARIANT) AS variant_col,
+
+  -- Complex types: Array, Map, Struct
+  CAST(ARRAY(CAST(1 AS INT), CAST(2 AS INT), CAST(3 AS INT)) AS ARRAY<INT>) AS array_int_col,
+
+  CAST(MAP(CAST('key1' AS STRING), CAST('value1' AS STRING), CAST('key2' AS STRING), CAST('value2' AS STRING)) AS MAP<STRING,STRING>) AS map_col,
+
+  -- Nested STRUCT up to depth 3
+  CAST(NAMED_STRUCT(
+    'level1_field', CAST(1 AS INT),
+    'level1_struct', CAST(NAMED_STRUCT(
+      'level2_field', CAST('abc' AS STRING),
+      'level2_array', CAST(ARRAY(
+        CAST(NAMED_STRUCT(
+          'level3_field', CAST(TRUE AS BOOLEAN)
+        ) AS STRUCT<level3_field: BOOLEAN>)
+      ) AS ARRAY<STRUCT<level3_field: BOOLEAN>>)
+    ) AS STRUCT<level2_field: STRING, level2_array: ARRAY<STRUCT<level3_field: BOOLEAN>>>)
+  ) AS STRUCT<level1_field: INT, level1_struct: STRUCT<level2_field: STRING, level2_array: ARRAY<STRUCT<level3_field: BOOLEAN>>>>) AS complex_struct
+"""
+
+# Create a flat struct with 30 fields to test cases where DESCRIBE TABLE returns truncated type info
+pairs = []
+for i in range(0, 30):
+    pairs.append(f"'field{i}', CAST({i} AS INT)")
+
+# Join the pairs with commas
+pairs_str = ",".join(pairs)
+
+# Wrap in SELECT named_struct
+big_struct_model_sql = f"""
+{{{{ config(
+    materialized = 'table'
+)}}}}
+
+SELECT named_struct(
+  {pairs_str}
+) AS big_struct;
+"""

--- a/tests/functional/adapter/basic/test_table_materialization.py
+++ b/tests/functional/adapter/basic/test_table_materialization.py
@@ -1,5 +1,76 @@
+import json
+
+import pytest
+
+from dbt.tests import util
 from dbt.tests.adapter.basic.test_table_materialization import BaseTableMaterialization
+from tests.functional.adapter.basic import fixtures
+from tests.functional.adapter.fixtures import MaterializationV2Mixin
 
 
 class TestTableMat(BaseTableMaterialization):
     pass
+
+
+class TestAllColumnTypesV2(MaterializationV2Mixin):
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"all_types_model.sql": fixtures.all_types_model_sql}
+
+    def test_all_column_types_materialization(self, project):
+        # Test table materialization with a large struct
+        util.run_dbt(["run"])
+
+        # Verify the table was created and contains data
+        relation = util.relation_from_name(project.adapter, "all_types_model")
+        results = project.run_sql(
+            f"""
+            DESCRIBE TABLE {relation};
+            """,
+            fetch="all",
+        )
+        # Check that the results match the expected columns and types
+        expected = [
+            ("tinyint_col", "tinyint"),
+            ("smallint_col", "smallint"),
+            ("int_col", "int"),
+            ("bigint_col", "bigint"),
+            ("float_col", "float"),
+            ("double_col", "double"),
+            ("decimal_col", "decimal(10,4)"),
+            ("boolean_col", "boolean"),
+            # It is expected that varchar and char end up being represented as strings in Databricks
+            ("string_col", "string"),
+            ("varchar_col", "string"),
+            ("char_col", "string"),
+            ("binary_col", "binary"),
+            ("date_col", "date"),
+            ("timestamp_col", "timestamp"),
+            ("variant_col", "variant"),
+            ("array_int_col", "array<int>"),
+            ("map_col", "map<string,string>"),
+            (
+                "complex_struct",
+                "struct<level1_field:int,level1_struct:struct<level2_field:string,level2_array:array<struct<level3_field:boolean>>>>",
+            ),
+        ]
+        actual = [(row[0], row[1]) for row in results[: len(expected)]]
+        assert actual == expected
+
+
+class TestTruncatedStructV2(MaterializationV2Mixin):
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"big_struct_model.sql": fixtures.big_struct_model_sql}
+
+    def test_truncated_struct_materialization(self, project):
+        util.run_dbt(["run"])
+        results = project.run_sql(
+            """
+            SELECT COLUMN_NAME, FULL_DATA_TYPE FROM {database}.information_schema.columns WHERE table_schema = '{schema}' AND table_name = 'big_struct_model';
+            """,
+            fetch="all",
+        )
+        assert results[0][0] == "big_struct"
+        expected_struct_type = "struct<" + ",".join([f"field{i}:int" for i in range(30)]) + ">"
+        assert results[0][1] == expected_struct_type

--- a/tests/unit/behaviors/test_columns.py
+++ b/tests/unit/behaviors/test_columns.py
@@ -1,0 +1,172 @@
+import json
+
+from dbt.adapters.databricks.behaviors.columns import GetColumnsByDescribe
+from dbt.adapters.databricks.column import DatabricksColumn
+
+
+# Tests are based on possible JSON output from "DESCRIBE EXTENDED <table> AS JSON"
+# https://docs.databricks.com/aws/en/sql/language-manual/sql-ref-syntax-aux-describe-table#json-formatted-output
+class TestGetColumnsByDescribe:
+    def test_parse_columns_from_json_happy_path(self):
+        """Test _parse_columns_from_json with a variety of column types"""
+        json_metadata = json.dumps(
+            {
+                "columns": [
+                    {"name": "id", "type": {"name": "bigint"}, "comment": "Primary key"},
+                    {"name": "name", "type": {"name": "string"}, "comment": "User name"},
+                    {
+                        "name": "nested_data",
+                        "type": {
+                            "name": "struct",
+                            "fields": [
+                                {"name": "field1", "type": {"name": "string"}},
+                                {"name": "field2", "type": {"name": "int"}},
+                            ],
+                        },
+                        "comment": None,
+                    },
+                ]
+            }
+        )
+
+        result = GetColumnsByDescribe._parse_columns_from_json(json_metadata)
+
+        assert len(result) == 3
+        assert isinstance(result[0], DatabricksColumn)
+        assert result[0].column == "id"
+        assert result[0].dtype == "bigint"
+        assert result[0].comment == "Primary key"
+
+        assert result[1].column == "name"
+        assert result[1].dtype == "string"
+        assert result[1].comment == "User name"
+
+        assert result[2].column == "nested_data"
+        assert result[2].dtype == "struct<field1: string, field2: int>"
+        assert result[2].comment is None
+
+    def test_parse_type_struct(self):
+        """Test _parse_type with struct type"""
+        type_info = {
+            "name": "struct",
+            "fields": [
+                {"name": "field1", "type": {"name": "string"}},
+                {"name": "field2", "type": {"name": "int"}},
+                {
+                    "name": "nested",
+                    "type": {
+                        "name": "struct",
+                        "fields": [{"name": "inner", "type": {"name": "double"}}],
+                    },
+                },
+            ],
+        }
+
+        result = GetColumnsByDescribe._parse_type(type_info)
+        expected = "struct<field1: string, field2: int, nested: struct<inner: double>>"
+        assert result == expected
+
+    def test_parse_type_array(self):
+        """Test _parse_type with array type"""
+        type_info = {"name": "array", "element_type": {"name": "string"}}
+
+        result = GetColumnsByDescribe._parse_type(type_info)
+        assert result == "array<string>"
+
+    def test_parse_type_array_nested(self):
+        """Test _parse_type with nested array type"""
+        type_info = {
+            "name": "array",
+            "element_type": {
+                "name": "struct",
+                "fields": [{"name": "item", "type": {"name": "int"}}],
+            },
+        }
+
+        result = GetColumnsByDescribe._parse_type(type_info)
+        assert result == "array<struct<item: int>>"
+
+    def test_parse_type_map(self):
+        """Test _parse_type with map type"""
+        type_info = {"name": "map", "key_type": {"name": "string"}, "value_type": {"name": "int"}}
+
+        result = GetColumnsByDescribe._parse_type(type_info)
+        assert result == "map<string, int>"
+
+    def test_parse_type_map_nested(self):
+        """Test _parse_type with nested map type"""
+        type_info = {
+            "name": "map",
+            "key_type": {"name": "string"},
+            "value_type": {"name": "array", "element_type": {"name": "double"}},
+        }
+
+        result = GetColumnsByDescribe._parse_type(type_info)
+        assert result == "map<string, array<double>>"
+
+    def test_parse_type_decimal_with_precision_scale(self):
+        """Test _parse_type with decimal type having precision and scale"""
+        type_info = {"name": "decimal", "precision": 10, "scale": 2}
+
+        result = GetColumnsByDescribe._parse_type(type_info)
+        assert result == "decimal(10, 2)"
+
+    def test_parse_type_decimal_with_precision_only(self):
+        """Test _parse_type with decimal type having only precision"""
+        type_info = {"name": "decimal", "precision": 10}
+
+        result = GetColumnsByDescribe._parse_type(type_info)
+        assert result == "decimal(10)"
+
+    def test_parse_type_decimal(self):
+        """Test _parse_type with decimal type without precision and scale"""
+        type_info = {"name": "decimal"}
+
+        result = GetColumnsByDescribe._parse_type(type_info)
+        assert result == "decimal"
+
+    def test_parse_type_string_with_collation(self):
+        type_info = {"name": "string", "collation": "UTF8_BINARY"}
+
+        result = GetColumnsByDescribe._parse_type(type_info)
+        assert result == "string COLLATE UTF8_BINARY"
+
+    def test_parse_type_string_without_collation(self):
+        type_info = {"name": "string"}
+
+        result = GetColumnsByDescribe._parse_type(type_info)
+        assert result == "string"
+
+    def test_parse_type_varchar(self):
+        type_info = {"name": "varchar", "length": 10}
+
+        result = GetColumnsByDescribe._parse_type(type_info)
+        # varchar is just a string in Databricks
+        assert result == "string"
+
+    def test_parse_type_char(self):
+        type_info = {"name": "char", "length": 10}
+
+        result = GetColumnsByDescribe._parse_type(type_info)
+        # char is just a string in Databricks
+        assert result == "string"
+
+    def test_parse_type_primitive_types(self):
+        """Test _parse_type with various primitive types"""
+        primitive_types = [
+            "int",
+            "bigint",
+            "smallint",
+            "tinyint",
+            "double",
+            "float",
+            "boolean",
+            "date",
+            "timestamp",
+            "binary",
+        ]
+
+        for type_name in primitive_types:
+            type_info = {"name": type_name}
+            result = GetColumnsByDescribe._parse_type(type_info)
+            assert result == type_name


### PR DESCRIPTION
<!-- Please review our pull request review process in CONTRIBUTING.md before your proceed. -->

Resolves #1083

<!---
  Include the number of the issue addressed by this PR above if applicable.

  Example:
    resolves #1234

  Please review our pull request review process in CONTRIBUTING.md before your proceed.
-->

### Description

Instead of using `DESCRIBE TABLE`, use `DESCRIBE TABLE EXTENDED <relation> AS JSON` to get full type information for columns. I wish there was a better/more sustainable solution than us having to write the JSON -> DDL translation, but looks like nothing better exists at the moment. For example I thought about using `CREATE TABLE .. USING JSON`, but looks like it can only accept a path to a file, and not the literal value which would be too complicated

### Checklist

- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
