### PR TITLE
Ensure we can append with parquet, and delegate to DBSQL for possible errors

### DIFF
--- a/dbt/include/databricks/macros/adapters/columns.sql
+++ b/dbt/include/databricks/macros/adapters/columns.sql
@@ -30,16 +30,10 @@ WHERE
 
 {% macro databricks__alter_relation_add_remove_columns(relation, add_columns, remove_columns) %}
   {% if remove_columns %}
-    {% if not relation.is_delta %}
-      {{ exceptions.raise_compiler_error('Delta format required for dropping columns from tables') }}
-    {% endif %}
     {{ run_query_as(drop_columns_sql(relation, remove_columns), 'alter_relation_remove_columns', fetch_result=False) }}
   {% endif %}
 
   {% if add_columns %}
-    {% if not relation.is_delta %}
-      {{ exceptions.raise_compiler_error('Delta format required for dropping columns from tables') }}
-    {% endif %}
     {{ run_query_as(add_columns_sql(relation, add_columns), 'alter_relation_add_columns', fetch_result=False) }}
   {% endif %}
 {% endmacro %}


### PR DESCRIPTION
Resolves #1098 

### Description
We should leave it up to DBSQL to decide when append/delete columns is allowed rather than short circuit, so that things like parquet column append can work.

### Checklist

- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
