### PR TITLE
Fix MV/ST materializations with complex data types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Fix bug causing "main is not being called during running model" errors for some view updates ([1077](https://github.com/databricks/dbt-databricks/issues/1077))
 - Fix bug that causes materialization (V2) to fail when data type is long enough to be truncated by DESCRIBE TABLE ([1083](https://github.com/databricks/dbt-databricks/issues/1083))
 - Fix the bugs with external tabls cloning [1095](https://github.com/databricks/dbt-databricks/pull/1095) (thanks @samgans!)
+- Fix MV/ST materializations with complex data types ([1100](https://github.com/databricks/dbt-databricks/issues/1100))
 
 ### Under the Hood
 

--- a/dbt/adapters/databricks/impl.py
+++ b/dbt/adapters/databricks/impl.py
@@ -429,22 +429,6 @@ class DatabricksAdapter(SparkAdapter):
             for row in new_rows
         ]
 
-    @available.parse(lambda *a, **k: [])
-    def get_column_schema_from_query(self, sql: str) -> list[DatabricksColumn]:
-        """Get a list of the Columns with names and data types from the given sql."""
-        _, cursor = self.connections.add_select_query(sql)
-        try:
-            columns: list[DatabricksColumn] = [
-                self.Column.create(
-                    column_name, self.connections.data_type_code_to_name(column_type_code)
-                )
-                # https://peps.python.org/pep-0249/#description
-                for column_name, column_type_code, *_ in cursor.description
-            ]
-        finally:
-            cursor.close()
-        return columns
-
     def get_relation(
         self,
         database: Optional[str],

--- a/dbt/include/databricks/macros/relations/streaming_table/create.sql
+++ b/dbt/include/databricks/macros/relations/streaming_table/create.sql
@@ -10,7 +10,19 @@
   {%- set refresh = streaming_table.config["refresh"] -%}
 
   {%- set analysis_sql = sql | replace('STREAM ', '') | replace('stream ', '') -%}
-  {%- set columns = get_column_schema_from_query(analysis_sql) -%}
+
+  {#
+    TODO: When DESCRIBE QUERY EXTENDED is supported, this implementation should be simplified
+    to use that instead. For now, we work around this limitation by writing results to a
+    temporary view and using DESCRIBE TABLE EXTENDED on the temporary view.
+  #}
+  {%- set temp_relation = make_temp_relation(relation) -%}
+  {% call statement('create_temp_view') -%}
+    {%- set sql_with_limit = analysis_sql.rstrip('; \n\t') ~ ' LIMIT 10' -%}
+    {{ create_temporary_view(temp_relation, sql_with_limit) }}
+  {%- endcall %}
+
+  {%- set columns = adapter.get_columns_in_relation(temp_relation) -%}
   {%- set model_columns = model.get('columns', {}) -%}
   {%- set columns_and_constraints = adapter.parse_columns_and_constraints(columns, model_columns, []) -%}
 

--- a/tests/functional/adapter/materialized_view_tests/fixtures.py
+++ b/tests/functional/adapter/materialized_view_tests/fixtures.py
@@ -64,3 +64,46 @@ models:
         relation: true
         columns: true
 """
+
+complex_types_materialized_view = """
+{{ config(
+    materialized='materialized_view',
+    schedule = {
+        'cron': '0 0 * * * ? *',
+        'time_zone': 'Etc/UTC'
+    },
+) }}
+SELECT
+  named_struct(
+    'field1', map('a', 1, 'b', 2),
+    'field2', array(10, 20, 30),
+    'field3', 3,
+    'field4', 4,
+    'field5', 5,
+    'field6', 6,
+    'field7', 7,
+    'field8', 8,
+    'field9', 9,
+    'field10', 10,
+    'field11', 11,
+    'field12', 12,
+    'field13', 13,
+    'field14', 14,
+    'field15', 15,
+    'field16', 16,
+    'field17', 17,
+    'field18', 18,
+    'field19', 19,
+    'field20', 20,
+    'field21', 21,
+    'field22', 22,
+    'field23', 23,
+    'field24', 24,
+    'field25', 25,
+    'field26', 26,
+    'field27', 27,
+    'field28', 28,
+    'field29', 29,
+    'field30', 30
+  ) AS my_struct;
+"""

--- a/tests/functional/adapter/streaming_tables/fixtures.py
+++ b/tests/functional/adapter/streaming_tables/fixtures.py
@@ -79,3 +79,10 @@ select * from stream read_files(
     '{{ env_var('DBT_DATABRICKS_LOCATION_ROOT') }}/test_inputs/streaming_table_test_sources'
 );
 """
+
+complex_types_streaming_table = """
+{{ config(
+    materialized='streaming_table',
+) }}
+select * from stream complex_types_table
+"""

--- a/tests/functional/adapter/streaming_tables/test_st_basic.py
+++ b/tests/functional/adapter/streaming_tables/test_st_basic.py
@@ -249,7 +249,8 @@ class TestStreamingTablesBasic(TestStreamingTablesMixin):
         results = project.run_sql(
             f"""
             SELECT COLUMN_NAME, FULL_DATA_TYPE FROM {project.database}.information_schema.columns
-            WHERE table_schema = '{project.test_schema}' AND table_name = 'complex_types_streaming_table';
+            WHERE table_schema = '{project.test_schema}'
+            AND table_name = 'complex_types_streaming_table';
             """,
             fetch="all",
         )


### PR DESCRIPTION
<!-- Please review our pull request review process in CONTRIBUTING.md before your proceed. -->

Resolves #1100

<!---
  Include the number of the issue addressed by this PR above if applicable.

  Example:
    resolves #1234

  Please review our pull request review process in CONTRIBUTING.md before your proceed.
-->

### Description

MV/STs currently uses `get_column_schema_from_query` to get data types, but it is broken for complex data types (i.e. struct, map, array). For example, if the input type is `map<int,int>`, the output will be a `map` which is not a full data type that is required on create.

The temporary workaround is to write a few results to a temporary view, then run a `DESCRIBE TABLE EXTENDED .. AS JSON` to get the full non-truncated data types. Ideally, once `DESCRIBE QUERY EXTENDED .. AS JSON` is supported in Databricks, we should use that instead

### Checklist

- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
