### PR TITLE
Simplify connection management to align with base adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Fixes
 - Do not use `DESCRIBE TABLE EXTENDED .. AS JSON` for STs when DBR version < 17.1. Do not use at all for MVs (not yet supported)
 
+### Under the Hood
+- Simplify connection management to align with base adapter. Connections are no longer cached per-thread
+
 ## dbt-databricks 1.10.6 (July 30, 2025)
 
 ### Fixes
@@ -29,7 +32,6 @@
 ### Under the Hood
 
 - Dropping primary key constraints in incremental runs now trigger cascading deletes (i.e. foreign key constraints referencing it will also be dropped)
-- Simplify connection management to align with base adapter. Connections are no longer cached per-thread
 
 ## dbt-databricks 1.10.4 (June 24, 2025)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,12 @@
 ## dbt-databricks 1.10.8 (TBD)
 
+### Under the Hood
+- Simplify connection management to align with base adapter. Connections are no longer cached per-thread
+
 ## dbt-databricks 1.10.7 (July 31, 2025)
 
 ### Fixes
 - Do not use `DESCRIBE TABLE EXTENDED .. AS JSON` for STs when DBR version < 17.1. Do not use at all for MVs (not yet supported)
-
-### Under the Hood
-- Simplify connection management to align with base adapter. Connections are no longer cached per-thread
 
 ## dbt-databricks 1.10.6 (July 30, 2025)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 ### Under the Hood
 
 - Dropping primary key constraints in incremental runs now trigger cascading deletes (i.e. foreign key constraints referencing it will also be dropped)
+- Simplify connection management to align with base adapter. Connections are no longer cached per-thread
 
 ## dbt-databricks 1.10.4 (June 24, 2025)
 

--- a/dbt/adapters/databricks/connections.py
+++ b/dbt/adapters/databricks/connections.py
@@ -1,4 +1,3 @@
-import re
 import time
 from collections.abc import Callable, Iterator
 from contextlib import contextmanager
@@ -32,7 +31,6 @@ from dbt.adapters.databricks.credentials import (
 from dbt.adapters.databricks.events.connection_events import (
     ConnectionCreate,
     ConnectionCreateError,
-    ConnectionReset,
 )
 from dbt.adapters.databricks.events.other_events import QueryError
 from dbt.adapters.databricks.handle import CursorWrapper, DatabricksHandle, SqlUtils
@@ -50,12 +48,6 @@ from dbt.adapters.spark.connections import SparkConnectionManager
 
 if TYPE_CHECKING:
     from agate import Table
-
-
-mv_refresh_regex = re.compile(r"refresh\s+materialized\s+view\s+([`\w.]+)", re.IGNORECASE)
-st_refresh_regex = re.compile(
-    r"create\s+or\s+refresh\s+streaming\s+table\s+([`\w.]+)", re.IGNORECASE
-)
 
 
 DATABRICKS_QUERY_COMMENT = f"""
@@ -130,11 +122,6 @@ class DatabricksDBTConnection(Connection):
             f"DatabricksDBTConnection(session-id={self.session_id}, "
             f"name={self.name}, language={self.language})"
         )
-
-    def _reset_handle(self, open: Callable[[Connection], Connection]) -> None:
-        self.handle = LazyHandle(open)
-        self.session_id = None
-        logger.debug(ConnectionReset(str(self)))
 
 
 class DatabricksConnectionManager(SparkConnectionManager):

--- a/dbt/adapters/databricks/connections.py
+++ b/dbt/adapters/databricks/connections.py
@@ -108,6 +108,7 @@ class DatabricksMacroQueryStringSetter(MacroQueryStringSetter):
 @dataclass(init=False)
 class DatabricksDBTConnection(Connection):
     http_path: str = ""
+    thread_identifier: tuple[int, int] = (0, 0)
 
     # If the connection is being used for a model we want to track the model language.
     # We do this because we need special handling for python models.  Python models will
@@ -218,6 +219,7 @@ class DatabricksConnectionManager(SparkConnectionManager):
         )
         creds = cast(DatabricksCredentials, self.profile.credentials)
         conn.http_path = QueryConfigUtils.get_http_path(query_header_context, creds)
+        conn.thread_identifier = cast(tuple[int, int], self.get_thread_identifier())
         conn.language = query_header_context.language
 
         conn.handle = LazyHandle(self.open)

--- a/tests/unit/test_query_config.py
+++ b/tests/unit/test_query_config.py
@@ -3,7 +3,6 @@ from unittest.mock import Mock
 import pytest
 from dbt_common.exceptions import DbtRuntimeError
 
-from dbt.adapters.databricks import connections
 from dbt.adapters.databricks.connections import QueryConfigUtils, QueryContextWrapper
 
 
@@ -53,42 +52,3 @@ class TestQueryConfigUtils:
         context = QueryContextWrapper(compute_name="foo", relation_name="a_relation")
         creds.compute = {"foo": {"http_path": "alternate_path"}}
         assert "alternate_path" == QueryConfigUtils.get_http_path(context, creds)
-
-    def test_get_max_idle__no_config(self, creds):
-        time = QueryConfigUtils.get_max_idle_time(QueryContextWrapper(), creds)
-        assert connections.DEFAULT_MAX_IDLE_TIME == time
-
-    def test_get_max_idle__no_matching_compute(self, creds):
-        time = QueryConfigUtils.get_max_idle_time(QueryContextWrapper(compute_name="foo"), creds)
-        assert connections.DEFAULT_MAX_IDLE_TIME == time
-
-    def test_get_max_idle__compute_without_details(self, creds):
-        creds.compute = {"foo": {}}
-        time = QueryConfigUtils.get_max_idle_time(QueryContextWrapper(compute_name="foo"), creds)
-        assert connections.DEFAULT_MAX_IDLE_TIME == time
-
-    def test_get_max_idle__creds_but_no_context(self, creds):
-        creds.connect_max_idle = 77
-        time = QueryConfigUtils.get_max_idle_time(QueryContextWrapper(), creds)
-        assert 77 == time
-
-    def test_get_max_idle__matching_compute_no_value(self, creds):
-        creds.connect_max_idle = 77
-        creds.compute = {"foo": {}}
-        time = QueryConfigUtils.get_max_idle_time(QueryContextWrapper(compute_name="foo"), creds)
-        assert 77 == time
-
-    def test_get_max_idle__matching_compute(self, creds):
-        creds.compute = {"foo": {"connect_max_idle": "88"}}
-        creds.connect_max_idle = 77
-        time = QueryConfigUtils.get_max_idle_time(QueryContextWrapper(compute_name="foo"), creds)
-        assert 88 == time
-
-    def test_get_max_idle__invalid_config(self, creds):
-        creds.compute = {"foo": {"connect_max_idle": "bar"}}
-
-        with pytest.raises(DbtRuntimeError) as info:
-            QueryConfigUtils.get_max_idle_time(QueryContextWrapper(compute_name="foo"), creds)
-        assert (
-            "bar is not a valid value for connect_max_idle. Must be a number of seconds."
-        ) in str(info.value)


### PR DESCRIPTION
<!-- Please review our pull request review process in CONTRIBUTING.md before your proceed. -->

Resolves #

<!---
  Include the number of the issue addressed by this PR above if applicable.

  Example:
    resolves #1234

  Please review our pull request review process in CONTRIBUTING.md before your proceed.
-->

### Description

Most of our custom connection management logic is to facilitate per-thread caching of connections (e.g. determine when it is safe to reuse a connection). This optimization has proven to be insignificant to overall execution time, so we are moving back to a simpler model that aligns with dbt core's base connection management. This PR cleans up all of the caching logic

### Checklist

- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
