### PR TITLE
Fix AS JSON branching logic for MV/STs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## dbt-databricks 1.10.7 (TBD)
 
 ### Fixes
-- Do not use `DESCRIBE TABLE EXTENDED .. AS JSON` for MV/STs when DBR version < 17.1
+- Do not use `DESCRIBE TABLE EXTENDED .. AS JSON` for STs when DBR version < 17.1. Do not use at all for MVs (not yet supported)
 
 ## dbt-databricks 1.10.6 (July 30, 2025)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## dbt-databricks 1.10.7 (TBD)
 
+### Fixes
+- Do not use `DESCRIBE TABLE EXTENDED .. AS JSON` for MV/STs when DBR version < 17.1
+
 ## dbt-databricks 1.10.6 (July 30, 2025)
 
 ### Fixes

--- a/dbt/adapters/databricks/impl.py
+++ b/dbt/adapters/databricks/impl.py
@@ -481,7 +481,15 @@ class DatabricksAdapter(SparkAdapter):
         self, relation: DatabricksRelation
     ) -> list[DatabricksColumn]:
         # Use legacy macros for hive metastore or DBR versions older than 16.2
-        use_legacy_logic = relation.is_hive_metastore() or self.compare_dbr_version(16, 2) < 0
+        use_legacy_logic = (
+            relation.is_hive_metastore()
+            or self.compare_dbr_version(16, 2) < 0
+            or (
+                relation.type
+                in (DatabricksRelationType.StreamingTable, DatabricksRelationType.MaterializedView)
+                and self.compare_dbr_version(17, 1) < 0
+            )
+        )
         return self.get_column_behavior.get_columns_in_relation(self, relation, use_legacy_logic)
 
     def _get_updated_relation(

--- a/dbt/adapters/databricks/impl.py
+++ b/dbt/adapters/databricks/impl.py
@@ -484,9 +484,9 @@ class DatabricksAdapter(SparkAdapter):
         use_legacy_logic = (
             relation.is_hive_metastore()
             or self.compare_dbr_version(16, 2) < 0
+            or relation.type == DatabricksRelationType.MaterializedView
             or (
-                relation.type
-                in (DatabricksRelationType.StreamingTable, DatabricksRelationType.MaterializedView)
+                relation.type == DatabricksRelationType.StreamingTable
                 and self.compare_dbr_version(17, 1) < 0
             )
         )

--- a/tests/unit/test_adapter.py
+++ b/tests/unit/test_adapter.py
@@ -1094,3 +1094,60 @@ class TestGetColumnsByDbrVersion(DatabricksAdapterBase):
             assert result[0].column == "col1"
             assert result[0].dtype == "string"
             assert result[0].comment == "comment1"
+
+    @patch(
+        "dbt.adapters.databricks.behaviors.columns.GetColumnsByDescribe._get_columns_with_comments"
+    )
+    def test_get_columns_streaming_table_legacy_logic(
+        self, mock_get_columns, adapter, unity_relation
+    ):
+        streaming_relation = DatabricksRelation.create(
+            database=unity_relation.database,
+            schema=unity_relation.schema,
+            identifier=unity_relation.identifier,
+            type=DatabricksRelation.StreamingTable,
+        )
+        # Return value less than 0 means version is older than 17.1
+        with patch.object(adapter, "compare_dbr_version", return_value=-1):
+            mock_get_columns.return_value = [
+                {"col_name": "stream_col", "data_type": "int", "comment": "streaming col"},
+            ]
+            result = adapter.get_columns_in_relation(streaming_relation)
+            mock_get_columns.assert_called_with(adapter, streaming_relation, "get_columns_comments")
+            assert len(result) == 1
+            assert result[0].column == "stream_col"
+            assert result[0].dtype == "int"
+            assert result[0].comment == "streaming col"
+
+    @patch(
+        "dbt.adapters.databricks.behaviors.columns.GetColumnsByDescribe._get_columns_with_comments"
+    )
+    def test_get_columns_streaming_table_new_logic(self, mock_get_columns, adapter, unity_relation):
+        streaming_relation = DatabricksRelation.create(
+            database=unity_relation.database,
+            schema=unity_relation.schema,
+            identifier=unity_relation.identifier,
+            type=DatabricksRelation.StreamingTable,
+        )
+        # Return value 0 means version is 17.1
+        with patch.object(adapter, "compare_dbr_version", return_value=0):
+            json_data = """
+                {
+                  "columns": [
+                    {
+                      "name": "stream_col",
+                      "type": {"name": "int"},
+                      "comment": "streaming col"
+                    }
+                  ]
+                }
+                """
+            mock_get_columns.return_value = [{"json_metadata": json_data}]
+            result = adapter.get_columns_in_relation(streaming_relation)
+            mock_get_columns.assert_called_with(
+                adapter, streaming_relation, "get_columns_comments_as_json"
+            )
+            assert len(result) == 1
+            assert result[0].column == "stream_col"
+            assert result[0].dtype == "int"
+            assert result[0].comment == "streaming col"


### PR DESCRIPTION
<!-- Please review our pull request review process in CONTRIBUTING.md before your proceed. -->

Resolves #

<!---
  Include the number of the issue addressed by this PR above if applicable.

  Example:
    resolves #1234

  Please review our pull request review process in CONTRIBUTING.md before your proceed.
-->

### Description

Current support for `DESCRIBE TABLE EXTENDED .. AS JSON`:
- Streaming tables: DBR 17.1+
- Materialized views: Not supported
- All other relation types: DBR 16.2+

Fix the macro branching logic to reflect this

### Checklist

- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
