### PR TITLE
Add fallback logic for known error types for AS JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## dbt-databricks 1.10.8 (TBD)
 
 ### Fixes
-- Add fallback logic for known error types for `DESCRIBE TABLE EXTENDED .. AS JSON` for better reliability
+- Add fallback logic for known error types for `DESCRIBE TABLE EXTENDED .. AS JSON` for better reliability ([1128](https://github.com/databricks/dbt-databricks/issues/1128))
 
 ## dbt-databricks 1.10.7 (July 31, 2025)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## dbt-databricks 1.10.8 (TBD)
 
+### Fixes
+- Add fallback logic for known error types for `DESCRIBE TABLE EXTENDED .. AS JSON` for better reliability
+
 ## dbt-databricks 1.10.7 (July 31, 2025)
 
 ### Fixes

--- a/dbt/adapters/databricks/behaviors/columns.py
+++ b/dbt/adapters/databricks/behaviors/columns.py
@@ -1,5 +1,6 @@
 from abc import ABC, abstractmethod
 
+from dbt_common.exceptions import DbtDatabaseError
 from dbt_common.utils.dict import AttrDict
 
 from dbt.adapters.databricks.column import DatabricksColumn
@@ -37,13 +38,20 @@ class GetColumnsByDescribe(GetColumnsBehavior):
             rows = cls._get_columns_with_comments(adapter, relation, "get_columns_comments")
             return cls._parse_columns(rows)
         else:
-            result = cls._get_columns_with_comments(
-                adapter, relation, "get_columns_comments_as_json"
-            )
-            if not result:
-                return []
-            json_metadata = result[0]["json_metadata"]
-            return DatabricksColumn.from_json_metadata(json_metadata)
+            try:
+                result = cls._get_columns_with_comments(
+                    adapter, relation, "get_columns_comments_as_json"
+                )
+                if not result:
+                    return []
+                json_metadata = result[0]["json_metadata"]
+                return DatabricksColumn.from_json_metadata(json_metadata)
+            except DbtDatabaseError as ex:
+                # Fall back to legacy logic if the error is due to AS JSON not being supported
+                # for the current runtime or relation type (e.g. foreign table)
+                if "PARSE_SYNTAX_ERROR" in ex.msg or "UNSUPPORTED_FEATURE" in ex.msg:
+                    return cls.get_columns_in_relation(adapter, relation, True)
+                raise ex
 
     @classmethod
     def _parse_columns(cls, rows: list[AttrDict]) -> list[DatabricksColumn]:


### PR DESCRIPTION
<!-- Please review our pull request review process in CONTRIBUTING.md before your proceed. -->

Resolves #1128

<!---
  Include the number of the issue addressed by this PR above if applicable.

  Example:
    resolves #1234

  Please review our pull request review process in CONTRIBUTING.md before your proceed.
-->

### Description

It looks like the branching logic does not cover all the possible failure scenarios of `AS JSON`. From manual testing and bug reports, it looks like
1. `PARSE_SYNTAX_ERROR` is thrown when DBR version does not support it
2. `UNSUPPORTED_FEATURE` is thrown when DBR version supports it, but relation type does not (e.g. foreign table, materialized views)

Instead of trying to guess all the edge cases where `AS JSON` is unsupported, add a try-catch to fallback to the legacy macro when the error message contains one of these errors

### Checklist

- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
