### PR TITLE
Add column tag support for views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## dbt-databricks 1.10.9 (TBD)
 
+### Features
+- Support column tags for views using `ALTER TABLE`
+
 ## dbt-databricks 1.10.8 (August 4, 2025)
 
 ### Features

--- a/dbt/adapters/databricks/relation_configs/view.py
+++ b/dbt/adapters/databricks/relation_configs/view.py
@@ -8,6 +8,7 @@ from dbt.adapters.databricks.relation_configs.base import (
     DatabricksRelationConfigBase,
 )
 from dbt.adapters.databricks.relation_configs.column_comments import ColumnCommentsProcessor
+from dbt.adapters.databricks.relation_configs.column_tags import ColumnTagsProcessor
 from dbt.adapters.databricks.relation_configs.comment import CommentProcessor
 from dbt.adapters.databricks.relation_configs.query import QueryProcessor
 from dbt.adapters.databricks.relation_configs.tags import TagsProcessor
@@ -21,6 +22,7 @@ class ViewConfig(DatabricksRelationConfigBase):
         QueryProcessor,
         CommentProcessor,
         ColumnCommentsProcessor,
+        ColumnTagsProcessor,
     ]
 
     def get_changeset(self, existing: Self) -> Optional[DatabricksRelationChangeSet]:

--- a/dbt/include/databricks/macros/materializations/view.sql
+++ b/dbt/include/databricks/macros/materializations/view.sql
@@ -31,6 +31,10 @@
         {{ get_create_view_as_sql(target_relation, sql) }}
       {%- endcall %}
       {{ apply_tags(target_relation, tags) }}
+      {% set column_tags = adapter.get_column_tags_from_model(config.model) %}
+      {% if column_tags and column_tags.set_column_tags %}
+        {{ apply_column_tags(target_relation, column_tags) }}
+      {% endif %}
     {% endif %}
     {% set should_revoke = should_revoke(exists_as_view, full_refresh_mode=True) %}
     {% do apply_grants(target_relation, grant_config, should_revoke=True) %}
@@ -57,6 +61,11 @@
 
     {%- do apply_tags(target_relation, tags) -%}
 
+    {% set column_tags = adapter.get_column_tags_from_model(config.model) %}
+    {% if column_tags and column_tags.set_column_tags %}
+      {{ apply_column_tags(target_relation, column_tags) }}
+    {% endif %}
+
     {{ run_hooks(post_hooks) }}
   {% endif %}
 
@@ -69,6 +78,11 @@
   {% set tags = config.get('databricks_tags') %}
   {{ execute_multiple_statements(get_replace_sql(existing_relation, target_relation, sql)) }}
   {%- do apply_tags(target_relation, tags) -%}
+  
+  {% set column_tags = adapter.get_column_tags_from_model(config.model) %}
+  {% if column_tags and column_tags.set_column_tags %}
+    {{ apply_column_tags(target_relation, column_tags) }}
+  {% endif %}
 {% endmacro %}
 
 {% macro relation_should_be_altered(existing_relation) %}

--- a/dbt/include/databricks/macros/relations/components/column_tags.sql
+++ b/dbt/include/databricks/macros/relations/components/column_tags.sql
@@ -34,7 +34,12 @@
 {%- endmacro -%}
 
 {% macro alter_set_column_tags(relation, column, tags) -%}
-  ALTER {{ relation.type | replace('_', ' ') }} {{ relation.render() }}
+  {# ALTER VIEW does not support setting column tags, but ALTER TABLE works for views #}
+  {%- if relation.type == 'view' -%}
+    ALTER TABLE {{ relation.render() }}
+  {%- else -%}
+    ALTER {{ relation.type | replace('_', ' ') }} {{ relation.render() }}
+  {%- endif -%}
   ALTER COLUMN `{{ column }}`
   SET TAGS (
     {%- for tag_name, tag_value in tags.items() -%}

--- a/dbt/include/databricks/macros/relations/view/create.sql
+++ b/dbt/include/databricks/macros/relations/view/create.sql
@@ -2,9 +2,6 @@
   {% if column_mask_exists() %}
     {% do exceptions.raise_compiler_error("Column masks are not supported for views.") %}
   {% endif %}
-  {% if column_tags_exist() %}
-    {% do exceptions.raise_compiler_error("Column tags are not supported for views.") %}
-  {% endif %}
   {{ log("Creating view " ~ relation) }}
   create or replace view {{ relation.render() }}
   {%- if config.persist_column_docs() -%}

--- a/tests/functional/adapter/column_tags/fixtures.py
+++ b/tests/functional/adapter/column_tags/fixtures.py
@@ -2,7 +2,7 @@ base_model_sql = """
 select 1 as id, 'abc123' as account_number
 """
 
-model_with_column_tags = """
+initial_column_tag_model = """
 version: 2
 models:
   - name: base_model
@@ -10,6 +10,22 @@ models:
         materialized: table
     columns:
       - name: id
+      - name: account_number
+        databricks_tags:
+          pii: "true"
+          sensitive: "true"
+"""
+
+updated_column_tag_model = """
+version: 2
+models:
+  - name: base_model
+    config:
+        materialized: table
+    columns:
+      - name: id
+        databricks_tags:
+          pii: "false"
       - name: account_number
         databricks_tags:
           pii: "true"


### PR DESCRIPTION
<!-- Please review our pull request review process in CONTRIBUTING.md before your proceed. -->

Resolves #

<!---
  Include the number of the issue addressed by this PR above if applicable.

  Example:
    resolves #1234

  Please review our pull request review process in CONTRIBUTING.md before your proceed.
-->

### Description

Previously, we did not add column tag support for views because `ALTER VIEW` does not support it. However, it turns out that `ALTER TABLE` works on views for setting column tags. This PR adds the missing column tag support for views and updates column tag functional tests to add coverage for updated column tag configs between runs

### Checklist

- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
