### PR TITLE
Adjust order of dbt dependency installation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,12 +64,12 @@ check-sdist = [
 
 [tool.hatch.envs.default]
 pre-install-commands = [
-    "pip install git+https://github.com/dbt-labs/dbt-adapters.git#subdirectory=dbt-adapters",
+    "pip install git+https://github.com/dbt-labs/dbt-common.git",
+    "pip install git+https://github.com/dbt-labs/dbt-adapters.git@main#subdirectory=dbt-adapters",
     "pip install git+https://github.com/dbt-labs/dbt-adapters.git@main#subdirectory=dbt-tests-adapter",
+    "pip install git+https://github.com/dbt-labs/dbt-core.git@main#subdirectory=core",
 ]
 dependencies = [
-    "dbt_common @ git+https://github.com/dbt-labs/dbt-common.git",
-    "dbt-core @ git+https://github.com/dbt-labs/dbt-core.git@main#subdirectory=core",
     "dbt-spark @ git+https://github.com/dbt-labs/dbt-adapters.git#subdirectory=dbt-spark",
     "pytest",
     "pytest-xdist",


### PR DESCRIPTION
<!-- Please review our pull request review process in CONTRIBUTING.md before your proceed. -->

Resolves #

<!---
  Include the number of the issue addressed by this PR above if applicable.

  Example:
    resolves #1234

  Please review our pull request review process in CONTRIBUTING.md before your proceed.
-->

### Description

Protobuf version was updated by our dbt dependencies:
- https://github.com/dbt-labs/dbt-adapters/pull/1259
- https://github.com/dbt-labs/dbt-common/pull/300
- https://github.com/dbt-labs/dbt-core/pull/11916

This broke our CI because pip is installing published pypi versions of transitive dependencies. The fix is to install dependencies in order, starting from leaf nodes

### Checklist

- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
