### PR TITLE
chore: Tighten version range for higher risk dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 ]
 dependencies = [
     "databricks-sdk>=0.41, <0.48.0",
-    "databricks-sql-connector[pyarrow]>=4.0.0, <4.1.0",
+    "databricks-sql-connector[pyarrow]>=4.0.0, <4.0.6",
     "dbt-adapters>=1.16.0, <1.16.5",
     "dbt-common>=1.24.0, <1.29.0",
     "dbt-core>=1.10.1, <1.10.10",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,11 +23,11 @@ classifiers = [
 ]
 dependencies = [
     "databricks-sdk>=0.41, <0.48.0",
-    "databricks-sql-connector[pyarrow]>=4.0.0, <5.0.0",
-    "dbt-adapters>=1.16.0, <2.0",
-    "dbt-common>=1.24.0, <2.0",
-    "dbt-core>=1.10.1, <2.0",
-    "dbt-spark>=1.9.0, <2.0",
+    "databricks-sql-connector[pyarrow]>=4.0.0, <4.1.0",
+    "dbt-adapters>=1.16.0, <1.16.5",
+    "dbt-common>=1.24.0, <1.29.0",
+    "dbt-core>=1.10.1, <1.10.10",
+    "dbt-spark>=1.9.0, <1.9.4",
     "keyring>=23.13.0",
     "pydantic>=1.10.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
-    "databricks-sdk>=0.41, <0.48.0",
+    "databricks-sdk>=0.41, <0.64.0",
     "databricks-sql-connector[pyarrow]>=4.0.0, <4.0.6",
     "dbt-adapters>=1.16.0, <1.16.5",
     "dbt-common>=1.24.0, <1.29.0",


### PR DESCRIPTION
<!-- Please review our pull request review process in CONTRIBUTING.md before your proceed. -->

Resolves #

<!---
  Include the number of the issue addressed by this PR above if applicable.

  Example:
    resolves #1234

  Please review our pull request review process in CONTRIBUTING.md before your proceed.
-->

### Description

Tighten versions for some upstream dependencies that have broken us in the past. For dbt packages, pin patch version as they frequently contain significant changes. The only exception is `dbt-common` which rarely has patch versions (https://pypi.org/project/dbt-common/#history), so just pinning minor version for that

### Checklist

- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
