### PR TITLE
chore: Add DBT_DATABRICKS_PROFILE env var for test profile selection

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -829,13 +829,19 @@ For debugging, use your IDE's test runner rather than pytest directly:
 3. **Use "Python: Debug Tests"** configuration for detailed debugging
 
 **Switching Test Environments:**
-To test against different Databricks environments during IDE debugging, modify the default profile in `tests/conftest.py`:
 
-```python
-def pytest_addoption(parser):
-    parser.addoption("--profile", action="store", default="databricks_cluster", type=str)
-    # Change default to: "databricks_uc_cluster" or "databricks_uc_sql_endpoint"
+For **CLI testing**, use the hatch commands which specify the correct profile:
+```bash
+hatch run cluster-e2e        # Tests with databricks_cluster
+hatch run uc-cluster-e2e     # Tests with databricks_uc_cluster  
+hatch run sqlw-e2e           # Tests with databricks_uc_sql_endpoint
 ```
+
+For **IDE test runners** (VS Code, PyCharm, etc.), you can override the default test profile by adding to your `test.env` file:
+```bash
+DBT_DATABRICKS_PROFILE=databricks_cluster  # or databricks_uc_cluster, databricks_uc_sql_endpoint
+```
+Note: The default is `databricks_uc_sql_endpoint` if not specified.
 
 ### Log Analysis
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import os
 import pytest
 
 from tests.profiles import get_databricks_cluster_target
@@ -6,7 +7,9 @@ pytest_plugins = ["dbt.tests.fixtures.project"]
 
 
 def pytest_addoption(parser):
-    parser.addoption("--profile", action="store", default="databricks_cluster", type=str)
+    # Use DBT_DATABRICKS_PROFILE env var if set, otherwise default to databricks_uc_sql_endpoint
+    default_profile = os.environ.get("DBT_DATABRICKS_PROFILE", "databricks_uc_sql_endpoint")
+    parser.addoption("--profile", action="store", default=default_profile, type=str)
 
 
 # Using @pytest.mark.skip_profile('databricks_cluster') uses the 'skip_by_adapter_type'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import os
+
 import pytest
 
 from tests.profiles import get_databricks_cluster_target


### PR DESCRIPTION
### Description

- Allow overriding default test profile via DBT_DATABRICKS_PROFILE environment variable
- Change default test profile from databricks_cluster to databricks_uc_sql_endpoint
- Update testing documentation to explain profile selection for CLI vs IDE testing
- Maintains backward compatibility with existing --profile flag and hatch commands
