### PR TITLE
chore: Modify integration workflow to simplify running external PRs

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,6 +1,15 @@
+# Integration Tests for dbt-databricks
+#
+# This workflow runs integration tests that require Databricks secrets.
+#
+# Uses pull_request_target to run on PRs from forks with access to secrets.
+# Repository settings require owner approval before external PRs can run workflows,
+# providing a security gate while maintaining automatic execution after approval.
 name: Integration Tests
 on:
-  pull_request:
+  pull_request_target:
+    # Runs in the context of the target repo (databricks) with access to secrets
+    # but can checkout code from the forked PR
     paths-ignore:
       - "**.MD"
       - "**.md"
@@ -27,6 +36,11 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+        with:
+          # Checkout the PR head commit to test the forked code
+          ref: ${{ github.event.pull_request.head.sha }}
+          # Fetch enough history for PR testing
+          fetch-depth: 0
 
       - name: Set up python
         id: setup-python
@@ -67,6 +81,11 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+        with:
+          # Checkout the PR head commit to test the forked code
+          ref: ${{ github.event.pull_request.head.sha }}
+          # Fetch enough history for PR testing
+          fetch-depth: 0
 
       - name: Set up python
         id: setup-python
@@ -104,6 +123,11 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+        with:
+          # Checkout the PR head commit to test the forked code
+          ref: ${{ github.event.pull_request.head.sha }}
+          # Fetch enough history for PR testing
+          fetch-depth: 0
 
       - name: Set up python
         id: setup-python

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -2,14 +2,19 @@
 #
 # This workflow runs integration tests that require Databricks secrets.
 #
-# Uses pull_request_target to run on PRs from forks with access to secrets.
-# Repository settings require owner approval before external PRs can run workflows,
-# providing a security gate while maintaining automatic execution after approval.
+# For testing external contributions (PRs from forks):
+# 1. Go to Actions tab -> Integration Tests -> Run workflow
+# 2. Enter the PR number in the 'pr_number' field
+# 3. Click "Run workflow"
+#
+# This approach is secure because:
+# - The workflow runs in the databricks repository context (access to secrets)
+# - The code to test is explicitly specified by maintainers
+# - No automatic execution of untrusted code with secrets
 name: Integration Tests
 on:
-  pull_request_target:
-    # Runs in the context of the target repo (databricks) with access to secrets
-    # but can checkout code from the forked PR
+  pull_request:
+    # Run on PRs to the same repository (internal contributors)
     paths-ignore:
       - "**.MD"
       - "**.md"
@@ -17,6 +22,18 @@ on:
       - "tests/unit/**"
       - ".github/workflows/main.yml"
       - ".github/workflows/stale.yml"
+
+  workflow_dispatch:
+    # Manual triggering for external contributions and ad-hoc testing
+    inputs:
+      pr_number:
+        description: "PR number to test (for external contributions)"
+        required: false
+        type: string
+      git_ref:
+        description: "Git ref (branch/tag/commit) to test"
+        required: false
+        type: string
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -26,6 +43,8 @@ jobs:
   run-uc-cluster-e2e-tests:
     runs-on: ubuntu-latest
     environment: azure-prod
+    # Only run on internal PRs or manual dispatch - skip external forks to avoid secret access failures
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
     env:
       DBT_DATABRICKS_HOST_NAME: ${{ secrets.DATABRICKS_HOST }}
       DBT_DATABRICKS_CLIENT_ID: ${{ secrets.TEST_PECO_SP_ID }}
@@ -37,8 +56,11 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
         with:
-          # Checkout the PR head commit to test the forked code
-          ref: ${{ github.event.pull_request.head.sha }}
+          # For pull_request: checkout the PR head commit
+          # For workflow_dispatch with pr_number: checkout that PR's head
+          # For workflow_dispatch with git_ref: checkout that ref
+          # Otherwise: checkout current branch
+          ref: ${{ github.event.pull_request.head.sha || (github.event.inputs.pr_number && format('refs/pull/{0}/head', github.event.inputs.pr_number)) || github.event.inputs.git_ref || github.ref }}
           # Fetch enough history for PR testing
           fetch-depth: 0
 
@@ -70,6 +92,8 @@ jobs:
   run-sqlwarehouse-e2e-tests:
     runs-on: ubuntu-latest
     environment: azure-prod
+    # Only run on internal PRs or manual dispatch - skip external forks to avoid secret access failures
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
     env:
       DBT_DATABRICKS_HOST_NAME: ${{ secrets.DATABRICKS_HOST }}
       DBT_DATABRICKS_CLIENT_ID: ${{ secrets.TEST_PECO_SP_ID }}
@@ -82,8 +106,11 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
         with:
-          # Checkout the PR head commit to test the forked code
-          ref: ${{ github.event.pull_request.head.sha }}
+          # For pull_request: checkout the PR head commit
+          # For workflow_dispatch with pr_number: checkout that PR's head
+          # For workflow_dispatch with git_ref: checkout that ref
+          # Otherwise: checkout current branch
+          ref: ${{ github.event.pull_request.head.sha || (github.event.inputs.pr_number && format('refs/pull/{0}/head', github.event.inputs.pr_number)) || github.event.inputs.git_ref || github.ref }}
           # Fetch enough history for PR testing
           fetch-depth: 0
 
@@ -115,6 +142,8 @@ jobs:
   run-cluster-e2e-tests:
     runs-on: ubuntu-latest
     environment: azure-prod
+    # Only run on internal PRs or manual dispatch - skip external forks to avoid secret access failures
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
     env:
       DBT_DATABRICKS_HOST_NAME: ${{ secrets.DATABRICKS_HOST }}
       DBT_DATABRICKS_TOKEN: ${{ secrets.DATABRICKS_TOKEN }}
@@ -124,8 +153,11 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
         with:
-          # Checkout the PR head commit to test the forked code
-          ref: ${{ github.event.pull_request.head.sha }}
+          # For pull_request: checkout the PR head commit
+          # For workflow_dispatch with pr_number: checkout that PR's head
+          # For workflow_dispatch with git_ref: checkout that ref
+          # Otherwise: checkout current branch
+          ref: ${{ github.event.pull_request.head.sha || (github.event.inputs.pr_number && format('refs/pull/{0}/head', github.event.inputs.pr_number)) || github.event.inputs.git_ref || github.ref }}
           # Fetch enough history for PR testing
           fetch-depth: 0
 


### PR DESCRIPTION
### Description

According to Cursor, these are the changes we need such that user PRs can run our integration tests in our target, but only after approval.

### Checklist

- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
