### PR TITLE
Improve perf on schema enumeration/validation

### DIFF
--- a/dbt/adapters/databricks/impl.py
+++ b/dbt/adapters/databricks/impl.py
@@ -314,7 +314,9 @@ class DatabricksAdapter(SparkAdapter):
 
     def check_schema_exists(self, database: Optional[str], schema: str) -> bool:
         """Check if a schema exists."""
-        return schema.lower() in set(s.lower() for s in self.list_schemas(database=database))
+        return schema.lower() in set(
+            s.lower() for s in self.connections.list_schemas(database or "hive_metastore", schema)
+        )
 
     def execute(
         self,

--- a/dbt/adapters/databricks/impl.py
+++ b/dbt/adapters/databricks/impl.py
@@ -300,16 +300,7 @@ class DatabricksAdapter(SparkAdapter):
         return self.connections.compare_dbr_version(major, minor)
 
     def list_schemas(self, database: Optional[str]) -> list[str]:
-        """
-        Get a list of existing schemas in database.
-
-        If `database` is `None`, fallback to executing `show databases` because
-        `list_schemas` tries to collect schemas from all catalogs when `database` is `None`.
-        """
-        if database is not None:
-            results = self.connections.list_schemas(database=database)
-        else:
-            results = self.execute_macro(LIST_SCHEMAS_MACRO_NAME, kwargs={"database": database})
+        results = self.execute_macro(LIST_SCHEMAS_MACRO_NAME, kwargs={"database": database})
         return [row[0] for row in results]
 
     def check_schema_exists(self, database: Optional[str], schema: str) -> bool:


### PR DESCRIPTION
Resolves #1166 

<!---
  Include the number of the issue addressed by this PR above if applicable.

  Example:
    resolves #1234

  Please review our pull request review process in CONTRIBUTING.md before your proceed.
-->

### Description

Apparently we've had a performance regression for a while due to switching to GetSchemas over using show schemas for everything.  Prior to 1.9, you could get the show schema behavior if you were on HMS but didn't specify a database.  Unclear why GetSchema's performance is poor, but even in my non-HMS testing, show schemas is faster.

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
