### PR TITLE
fix: ST set tags were being applied when empty

### DIFF
--- a/dbt/include/databricks/macros/relations/materialized_view/alter.sql
+++ b/dbt/include/databricks/macros/relations/materialized_view/alter.sql
@@ -37,7 +37,7 @@
             {{ return_statements.append(alter_statement) }}
         {%- endif -%}
         {%- set tags = configuration_changes.changes["tags"] -%}
-        {%- if tags -%}
+        {%- if tags and tags.set_tags and tags.set_tags != [] -%}
             {{ return_statements.append(alter_set_tags(relation, tags.set_tags)) }}
         {%- endif -%}
         {% do return(return_statements) %}

--- a/dbt/include/databricks/macros/relations/streaming_table/alter.sql
+++ b/dbt/include/databricks/macros/relations/streaming_table/alter.sql
@@ -41,7 +41,7 @@
             {{ return_statements.append(alter_statement) }}
         {%- endif -%}
         {%- set tags = configuration_changes.changes["tags"] -%}
-        {%- if tags -%}
+        {%- if tags and tags.set_tags and tags.set_tags != [] -%}
             {{ return_statements.append(alter_set_tags(relation, tags.set_tags)) }}
         {%- endif -%}
         {% do return(return_statements) %}

--- a/dbt/include/databricks/macros/relations/tags.sql
+++ b/dbt/include/databricks/macros/relations/tags.sql
@@ -21,7 +21,7 @@
   {%- if set_tags and relation.is_hive_metastore() -%}
     {{ exceptions.raise_compiler_error("Tags are only supported for Unity Catalog") }}
   {%- endif -%}
-  {%- if set_tags %}
+  {%- if set_tags and set_tags != [] %}
     {%- call statement('main') -%}
        {{ alter_set_tags(relation, set_tags) }}
     {%- endcall -%}

--- a/tests/functional/adapter/tags/test_databricks_tags.py
+++ b/tests/functional/adapter/tags/test_databricks_tags.py
@@ -6,8 +6,7 @@ from tests.functional.adapter.fixtures import MaterializationV2Mixin
 from tests.functional.adapter.tags import fixtures
 
 
-@pytest.mark.skip_profile("databricks_cluster")
-class TestTags:
+class BaseTestTags:
     materialized = "table"
 
     @pytest.fixture(scope="class")
@@ -31,7 +30,11 @@ class TestTags:
 
 
 @pytest.mark.skip_profile("databricks_cluster")
-class TestTagsUpdateViaAlter(MaterializationV2Mixin):
+class TestTableTags(BaseTestTags):
+    pass
+
+
+class BaseTestTagsUpdateViaAlter(MaterializationV2Mixin):
     materialized = "table"
 
     @pytest.fixture(scope="class")
@@ -60,12 +63,17 @@ class TestTagsUpdateViaAlter(MaterializationV2Mixin):
 
 
 @pytest.mark.skip_profile("databricks_cluster")
-class TestViewTags(TestTags):
+class TestTableTagsUpdateViaAlter(BaseTestTagsUpdateViaAlter):
+    pass
+
+
+@pytest.mark.skip_profile("databricks_cluster")
+class TestViewTags(BaseTestTags):
     materialized = "view"
 
 
 @pytest.mark.skip_profile("databricks_cluster")
-class TestViewTagsUpdateViaAlter(TestTagsUpdateViaAlter):
+class TestViewTagsUpdateViaAlter(BaseTestTagsUpdateViaAlter):
     materialized = "view"
 
     @pytest.fixture(scope="class")
@@ -79,29 +87,29 @@ class TestViewTagsUpdateViaAlter(TestTagsUpdateViaAlter):
 
 
 @pytest.mark.skip_profile("databricks_cluster")
-class TestIncrementalTags(TestTags):
+class TestIncrementalTags(BaseTestTags):
     materialized = "incremental"
 
 
 @pytest.mark.skip_profile("databricks_cluster")
-class TestIncrementalTagsUpdateViaAlter(TestTagsUpdateViaAlter):
+class TestIncrementalTagsUpdateViaAlter(BaseTestTagsUpdateViaAlter):
     materialized = "incremental"
 
 
 @pytest.mark.dlt
 @pytest.mark.skip_profile("databricks_cluster", "databricks_uc_cluster")
-class TestMaterializedViewTags(TestTags):
+class TestMaterializedViewTags(BaseTestTags):
     materialized = "materialized_view"
 
 
-@pytest.mark.skip_profile("databricks_cluster")
-class TestMaterializedViewTagsUpdateViaAlter(TestTagsUpdateViaAlter):
+@pytest.mark.skip_profile("databricks_cluster", "databricks_uc_cluster")
+class TestMaterializedViewTagsUpdateViaAlter(BaseTestTagsUpdateViaAlter):
     materialized = "materialized_view"
 
 
 @pytest.mark.dlt
 @pytest.mark.skip_profile("databricks_cluster", "databricks_uc_cluster")
-class TestStreamingTableTags(TestTags):
+class TestStreamingTableTags(BaseTestTags):
     @pytest.fixture(scope="class")
     def seeds(self):
         return {"my_seed.csv": MY_SEED}
@@ -117,7 +125,7 @@ class TestStreamingTableTags(TestTags):
         super().test_tags(project)
 
 
-@pytest.mark.skip_profile("databricks_cluster")
+@pytest.mark.skip_profile("databricks_cluster", "databricks_uc_cluster")
 class TestStreamingTableTagsUpdateViaAlter:
     @pytest.fixture(scope="class")
     def seeds(self):
@@ -147,8 +155,8 @@ class TestStreamingTableTagsUpdateViaAlter:
 
 
 @pytest.mark.python
-@pytest.mark.skip_profile("databricks_cluster")
-class TestPythonTags(TestTags):
+@pytest.mark.skip_profile("databricks_cluster", "databricks_uc_sql_endpoint")
+class TestPythonTags(BaseTestTags):
     @pytest.fixture(scope="class")
     def models(self):
         return {


### PR DESCRIPTION
### Description

I don't know how this was happening, since the code for change detection seems to not return a TagsConfig when I go into via debug, but we were calling alter with an empty set tags set, which was raising exceptions.

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
