### PR TITLE
Fix: model-level override logic for is_cluster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Improve ANSI mode error handling for Python models and add debug instrumentation ([1157](https://github.com/databricks/dbt-databricks/pull/1157))
 - Remove external path on intermediate tables for incremental models (with Materialization V2) ([1161](https://github.com/databricks/dbt-databricks/pull/1161))
 - Fix get_columns_in_relation branching logic for streaming tables to prevent it from running `AS JSON`
+- Fix model-level compute override connection logic that was causing invalid spark configs to be set on SQL warehouses
 
 ### Under the hood
 

--- a/dbt/adapters/databricks/utils.py
+++ b/dbt/adapters/databricks/utils.py
@@ -91,9 +91,8 @@ def handle_exceptions_as_warning(op: Callable[[], None], log_gen: ExceptionToStr
 
 
 def is_cluster_http_path(http_path: str, cluster_id: Optional[str]) -> bool:
-    return (
-        cluster_id is not None
-        # Credentials field is not updated when overriding the compute at model level.
-        # This secondary check is a workaround for that case
-        or "/warehouses/" not in http_path
-    )
+    if "/warehouses/" in http_path:
+        return False
+    if "/protocolv1/" in http_path:
+        return True
+    return cluster_id is not None

--- a/tests/unit/test_connection_manager.py
+++ b/tests/unit/test_connection_manager.py
@@ -25,7 +25,7 @@ class TestDatabricksConnectionManager:
             assert connection_manager.is_cluster() is False
 
     def test_is_cluster_with_cluster_id_overrides_path(self):
-        """Test is_cluster() returns True when cluster_id is provided, regardless of path"""
+        """Test is_cluster() returns False even when cluster_id is provided"""
         # Create a minimal connection manager with mock config
         mock_config = Mock()
         connection_manager = DatabricksConnectionManager(mock_config, get_context("spawn"))
@@ -39,7 +39,7 @@ class TestDatabricksConnectionManager:
         with patch.object(
             connection_manager, "get_thread_connection", return_value=mock_connection
         ):
-            assert connection_manager.is_cluster() is True
+            assert connection_manager.is_cluster() is False
 
     def test_is_cluster_http_path_function_warehouse_path(self):
         assert is_cluster_http_path("sql/1.0/warehouses/abc123def456", None) is False
@@ -48,7 +48,7 @@ class TestDatabricksConnectionManager:
         assert is_cluster_http_path("sql/protocolv1/o/1234567890123456/", None) is True
 
     def test_is_cluster_http_path_function_cluster_id_overrides(self):
-        assert is_cluster_http_path("sql/1.0/warehouses/abc123def456", "cluster-123") is True
+        assert is_cluster_http_path("sql/1.0/warehouses/abc123def456", "cluster-123") is False
 
     @patch("dbt.adapters.databricks.connections.DatabricksHandle.from_connection_args")
     @patch("dbt.adapters.databricks.connections.SqlUtils.prepare_connection_arguments")

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -74,10 +74,10 @@ class TestDatabricksUtils:
         assert quote("table") == "`table`"
 
     def test_is_cluster_http_path_with_cluster_id(self):
-        assert is_cluster_http_path("/sql/1.0/warehouses/abc", "cluster-123") is True
+        assert is_cluster_http_path("/sql/1.0/warehouses/abc", "cluster-123") is False
 
     def test_is_cluster_http_path_without_cluster_id_and_warehouses(self):
-        assert is_cluster_http_path("/sql/1.0/endpoints/abc", None) is True
+        assert is_cluster_http_path("/sql/1.0/endpoints/abc", None) is False
 
     def test_is_cluster_http_path_without_cluster_id_and_with_warehouses(self):
         assert is_cluster_http_path("/sql/1.0/warehouses/abc", None) is False


### PR DESCRIPTION
<!-- Please review our pull request review process in CONTRIBUTING.md before your proceed. -->

Resolves #

<!---
  Include the number of the issue addressed by this PR above if applicable.

  Example:
    resolves #1234

  Please review our pull request review process in CONTRIBUTING.md before your proceed.
-->

### Description

Current logic for `is_cluster_http_path` is backwards. When original compute is a cluster and the model-level override is a SQL warehouse, it wrongly returns true. We should use `http_path` as the source of truth instead of the cluster ID. Cluster ID should only be used as a fallback if the expected keywords do not exist in the path

### Checklist

- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
