### PR TITLE
feat: Add tagging methods to snapshot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fix issue causing MV/STs to always trigger as having their config changed ([1181](http://github.com/databricks/dbt-databricks/pull/1181))
 - Fix pydantic v2 deprecation warning "Valid config keys have changed in V2" (thanks @Korijn!) ([1194](https://github.com/databricks/dbt-databricks/pull/1194))
+- Fix snapshots not applying databricks_tags config ([1192](https://github.com/databricks/dbt-databricks/pull/1192))
 
 ## dbt-databricks 1.10.12 (September 8, 2025)
 

--- a/dbt/include/databricks/macros/materializations/snapshot.sql
+++ b/dbt/include/databricks/macros/materializations/snapshot.sql
@@ -5,6 +5,7 @@
   {%- set unique_key = config.get('unique_key') %}
   {%- set file_format = config.get('file_format', 'delta') -%}
   {%- set grant_config = config.get('grants') -%}
+  {%- set tags = config.get('databricks_tags') -%}
 
   {% set target_relation_exists, target_relation = databricks__get_or_create_relation(
           database=model.database,
@@ -100,6 +101,11 @@
   {% endcall %}
 
   {% set should_revoke = should_revoke(target_relation_exists, full_refresh_mode=False) %}
+  
+  {%- if tags -%}
+    {%- do apply_tags(target_relation, tags) -%}
+  {%- endif -%}
+
   {% do apply_grants(target_relation, grant_config, should_revoke=should_revoke) %}
 
   {% do persist_docs(target_relation, model) %}


### PR DESCRIPTION
<!-- Please review our pull request review process in CONTRIBUTING.md before your proceed. -->

Resolves #1187 

<!---
  Include the number of the issue addressed by this PR above if applicable.

  Example:
    resolves #1234

  Please review our pull request review process in CONTRIBUTING.md before your proceed.
-->

### Description

Add checking the `databricks_tags` config on snapshots and also apply them. With this change, the following snapshot definition:

```yaml
# models/snapshots.yml
snapshots:
  - name: yet_another_snap
    relation: ref('foo')
    config:
      strategy: check
      check_cols: all
      unique_key: id
      databricks_tags:
        some_key: some_value
```

Results in the tag being applied, e.g:

```sh
$ dbt snapshot
...
03:31:23  On snapshot.analytics.yet_another_snap: /* {"app": "dbt", "dbt_version": "1.10.11", "dbt_databricks_version": "1.10.12", "databricks_sql_connector_version": "4.0.5", "profile_name": "all", "target_name": "db", "node_id": "snapshot.analytics.yet_another_snap"} */

      merge into `dev`.`dbt_jyeo_prod`.`yet_another_snap` as DBT_INTERNAL_DEST
    
      using `yet_another_snap__dbt_tmp` as DBT_INTERNAL_SOURCE
    
    on DBT_INTERNAL_SOURCE.dbt_scd_id = DBT_INTERNAL_DEST.dbt_scd_id
    when matched
     
       and DBT_INTERNAL_DEST.dbt_valid_to is null
     
     and DBT_INTERNAL_SOURCE.dbt_change_type in ('update', 'delete')
        then update
        set dbt_valid_to = DBT_INTERNAL_SOURCE.dbt_valid_to

    when not matched
     and DBT_INTERNAL_SOURCE.dbt_change_type = 'insert'
        then insert *
    ;

  
03:31:23  Databricks adapter: Cursor(session-id=01f099c0-197e-13b4-a02e-59b9c166a0cd, command-id=01f099c0-1c49-1cc0-9c79-34ee79b10d49) - Closing
03:31:26  SQL status: OK in 2.530 seconds
03:31:26  Databricks adapter: Cursor(session-id=01f099c0-197e-13b4-a02e-59b9c166a0cd, command-id=01f099c0-1c80-1c98-b0a1-941bd19f6f85) - Closing
03:31:26  Applying tags to relation {'some_key': 'some_value'}
03:31:26  Writing runtime sql for node "snapshot.analytics.yet_another_snap"
03:31:26  Using databricks connection "snapshot.analytics.yet_another_snap"
03:31:26  On snapshot.analytics.yet_another_snap: /* {"app": "dbt", "dbt_version": "1.10.11", "dbt_databricks_version": "1.10.12", "databricks_sql_connector_version": "4.0.5", "profile_name": "all", "target_name": "db", "node_id": "snapshot.analytics.yet_another_snap"} */
ALTER table `dev`.`dbt_jyeo_prod`.`yet_another_snap` SET TAGS (
    'some_key' = 'some_value'
  )
03:31:26  SQL status: OK in 0.540 seconds
03:31:26  Databricks adapter: Cursor(session-id=01f099c0-197e-13b4-a02e-59b9c166a0cd, command-id=01f099c0-1e01-1877-a38d-036b87e44c45) - Closing
03:31:26  Applying DROP to: `yet_another_snap__dbt_tmp`
03:31:26  Using databricks connection "snapshot.analytics.yet_another_snap"
03:31:26  On snapshot.analytics.yet_another_snap: /* {"app": "dbt", "dbt_version": "1.10.11", "dbt_databricks_version": "1.10.12", "databricks_sql_connector_version": "4.0.5", "profile_name": "all", "target_name": "db", "node_id": "snapshot.analytics.yet_another_snap"} */
DROP VIEW IF EXISTS `yet_another_snap__dbt_tmp`
03:31:27  SQL status: OK in 0.470 seconds
03:31:27  Databricks adapter: Cursor(session-id=01f099c0-197e-13b4-a02e-59b9c166a0cd, command-id=01f099c0-1e57-1f95-b68b-45ebe2eccfbb) - Closing
03:31:27  On snapshot.analytics.yet_another_snap: Close
03:31:27  Databricks adapter: Connection(session-id=01f099c0-197e-13b4-a02e-59b9c166a0cd) - Closing
03:31:27  1 of 1 OK snapshotted dbt_jyeo_prod.yet_another_snap ........................... [OK in 9.54s]
```

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
