### PR TITLE
fix: Add retry logic for transient API errors in Python model execution

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,6 +90,8 @@ hatch run pytest path/to/test_file.py::TestClass::test_method -v
 - **Unity Catalog Cluster** (`databricks_uc_cluster`): Modern UC features
 - **SQL Warehouse** (`databricks_uc_sql_endpoint`): Serverless compute
 
+**Important**: Test environment credentials are automatically loaded from `test.env` file by pytest (via `python-dotenv` plugin). You do NOT need to manually source this file - pytest reads it automatically when running tests.
+
 ### Writing Tests
 
 #### Unit Test Example

--- a/dbt/adapters/databricks/python_models/python_submissions.py
+++ b/dbt/adapters/databricks/python_models/python_submissions.py
@@ -400,7 +400,8 @@ class PythonNotebookSubmitter(PythonSubmitter):
                 # Poll for completion
                 self.api_client.job_runs.poll_for_completion(run_id)
 
-                # Success - break out of retry loop
+                # Success - clean up tracker and break out of retry loop
+                self.tracker.remove_run_id(run_id)
                 break
 
             except Exception as e:

--- a/dbt/adapters/databricks/python_models/python_submissions.py
+++ b/dbt/adapters/databricks/python_models/python_submissions.py
@@ -404,7 +404,7 @@ class PythonNotebookSubmitter(PythonSubmitter):
                 break
 
             except Exception as e:
-                # Clean up tracker for this attempt
+                # Clean up tracker for this attempt before retrying
                 if run_id:
                     self.tracker.remove_run_id(run_id)
 
@@ -426,17 +426,6 @@ class PythonNotebookSubmitter(PythonSubmitter):
                             f"Final error: {str(e)[:500]}"
                         )
                     raise
-            finally:
-                # Ensure tracker cleanup on success
-                if run_id and attempt < MAX_JOB_RETRIES:
-                    # Only remove if we're going to retry (already removed in except block)
-                    pass
-                elif run_id:
-                    # Final cleanup on last attempt
-                    try:
-                        self.tracker.remove_run_id(run_id)
-                    except Exception:
-                        pass  # Best effort cleanup
 
 
 class JobClusterPythonJobHelper(BaseDatabricksHelper):

--- a/dbt/adapters/databricks/python_models/python_submissions.py
+++ b/dbt/adapters/databricks/python_models/python_submissions.py
@@ -362,31 +362,81 @@ class PythonNotebookSubmitter(PythonSubmitter):
     def submit(self, compiled_code: str) -> None:
         logger.debug("Submitting Python model using the Job Run API.")
 
+        import time
+
+        from dbt.adapters.databricks.api_client import (
+            JOB_RETRY_BASE_DELAY,
+            MAX_JOB_RETRIES,
+            is_retryable_job_failure,
+        )
+
         file_path = self.uploader.upload(compiled_code)
         job_config = self.config_compiler.compile(file_path)
 
-        run_id = self.api_client.job_runs.submit(
-            job_config.run_name, job_config.job_spec, **job_config.additional_job_config
-        )
-        self.tracker.insert_run_id(run_id)
+        # Retry the entire submit + poll flow for transient INTERNAL_ERROR failures
 
-        try:
-            if "access_control_list" in job_config.job_spec:
-                try:
-                    job_id = self.api_client.job_runs.get_job_id_from_run_id(run_id)
-                    logger.debug(f"Setting permissions on job: {job_id}")
-                    self.api_client.workflow_permissions.patch(
-                        job_id, job_config.job_spec["access_control_list"]
-                    )
-                except Exception as e:
-                    logger.error(f"Failed to set permissions on job {run_id}: {str(e)}")
-                    raise DbtRuntimeError(
-                        f"Failed to set permissions on job: run_id={run_id}, error: {str(e)}"
-                    )
+        for attempt in range(MAX_JOB_RETRIES + 1):
+            run_id = None
+            try:
+                run_id = self.api_client.job_runs.submit(
+                    job_config.run_name, job_config.job_spec, **job_config.additional_job_config
+                )
+                self.tracker.insert_run_id(run_id)
 
-            self.api_client.job_runs.poll_for_completion(run_id)
-        finally:
-            self.tracker.remove_run_id(run_id)
+                # Set permissions if needed
+                if "access_control_list" in job_config.job_spec:
+                    try:
+                        job_id = self.api_client.job_runs.get_job_id_from_run_id(run_id)
+                        logger.debug(f"Setting permissions on job: {job_id}")
+                        self.api_client.workflow_permissions.patch(
+                            job_id, job_config.job_spec["access_control_list"]
+                        )
+                    except Exception as e:
+                        logger.error(f"Failed to set permissions on job {run_id}: {str(e)}")
+                        raise DbtRuntimeError(
+                            f"Failed to set permissions on job: run_id={run_id}, error: {str(e)}"
+                        )
+
+                # Poll for completion
+                self.api_client.job_runs.poll_for_completion(run_id)
+
+                # Success - break out of retry loop
+                break
+
+            except Exception as e:
+                # Clean up tracker for this attempt
+                if run_id:
+                    self.tracker.remove_run_id(run_id)
+
+                # Check if we should retry
+                if is_retryable_job_failure(e) and attempt < MAX_JOB_RETRIES:
+                    retry_delay = JOB_RETRY_BASE_DELAY * (2**attempt)
+                    logger.warning(
+                        f"Python model job failed with transient error "
+                        f"(attempt {attempt + 1}/{MAX_JOB_RETRIES + 1}): {str(e)[:200]}. "
+                        f"Retrying in {retry_delay} seconds..."
+                    )
+                    time.sleep(retry_delay)
+                    continue
+                else:
+                    # Non-retryable or max retries exceeded
+                    if attempt >= MAX_JOB_RETRIES:
+                        logger.error(
+                            f"Python model job failed after {MAX_JOB_RETRIES + 1} attempts. "
+                            f"Final error: {str(e)[:500]}"
+                        )
+                    raise
+            finally:
+                # Ensure tracker cleanup on success
+                if run_id and attempt < MAX_JOB_RETRIES:
+                    # Only remove if we're going to retry (already removed in except block)
+                    pass
+                elif run_id:
+                    # Final cleanup on last attempt
+                    try:
+                        self.tracker.remove_run_id(run_id)
+                    except Exception:
+                        pass  # Best effort cleanup
 
 
 class JobClusterPythonJobHelper(BaseDatabricksHelper):

--- a/tests/unit/api_client/test_retry_logic.py
+++ b/tests/unit/api_client/test_retry_logic.py
@@ -1,0 +1,72 @@
+from dbt.adapters.databricks.api_client import is_retryable_api_error
+
+
+class TestRetryLogic:
+    """Test the retry logic helper functions."""
+
+    def test_is_retryable_api_error__timeout_errors(self):
+        """Test that timeout errors are detected as retryable."""
+        assert is_retryable_api_error(Exception("Request timed out"))
+        assert is_retryable_api_error(Exception("Connection timeout"))
+        assert is_retryable_api_error(Exception("Operation timeout"))
+
+    def test_is_retryable_api_error__connection_errors(self):
+        """Test that connection errors are detected as retryable."""
+        assert is_retryable_api_error(Exception("Connection refused"))
+        assert is_retryable_api_error(Exception("Connection error"))
+        assert is_retryable_api_error(Exception("Connection reset"))
+
+    def test_is_retryable_api_error__rate_limiting(self):
+        """Test that rate limiting errors are detected as retryable."""
+        assert is_retryable_api_error(Exception("Rate limit exceeded"))
+        assert is_retryable_api_error(Exception("Too many requests"))
+        assert is_retryable_api_error(Exception("Throttle limit reached"))
+
+    def test_is_retryable_api_error__server_errors(self):
+        """Test that temporary server errors are detected as retryable."""
+        assert is_retryable_api_error(Exception("503 Service Unavailable"))
+        assert is_retryable_api_error(Exception("502 Bad Gateway"))
+        assert is_retryable_api_error(Exception("504 Gateway Timeout"))
+        assert is_retryable_api_error(Exception("Temporarily unavailable"))
+        assert is_retryable_api_error(Exception("Resource exhausted"))
+        assert is_retryable_api_error(Exception("Deadline exceeded"))
+
+    def test_is_retryable_api_error__non_retryable(self):
+        """Test that non-retryable errors are correctly identified."""
+        assert not is_retryable_api_error(Exception("Invalid credentials"))
+        assert not is_retryable_api_error(Exception("Not found"))
+        assert not is_retryable_api_error(Exception("Permission denied"))
+        assert not is_retryable_api_error(Exception("Invalid request"))
+        assert not is_retryable_api_error(Exception("Validation error"))
+
+    def test_is_retryable_api_error__case_insensitive(self):
+        """Test that error detection is case-insensitive."""
+        assert is_retryable_api_error(Exception("TIMEOUT"))
+        assert is_retryable_api_error(Exception("Timeout"))
+        assert is_retryable_api_error(Exception("RATE LIMIT"))
+        assert is_retryable_api_error(Exception("Rate Limit"))
+
+    def test_is_retryable_api_error__programming_errors_not_retried(self):
+        """Test that programming errors are never retried."""
+        assert not is_retryable_api_error(
+            AttributeError("'NoneType' object has no attribute 'foo'")
+        )
+        assert not is_retryable_api_error(TypeError("expected str, got int"))
+        assert not is_retryable_api_error(ValueError("invalid literal for int()"))
+        assert not is_retryable_api_error(KeyError("key not found"))
+        assert not is_retryable_api_error(KeyboardInterrupt())
+
+    def test_is_retryable_api_error__specific_transient_errors(self):
+        """Test specific transient error patterns that should be retried."""
+        # HTTP status codes
+        assert is_retryable_api_error(Exception("HTTP 429: Too Many Requests"))
+        assert is_retryable_api_error(Exception("502 Bad Gateway"))
+        assert is_retryable_api_error(Exception("Service returned 503"))
+
+        # Connection issues
+        assert is_retryable_api_error(Exception("Connection reset by peer"))
+        assert is_retryable_api_error(Exception("Connection refused"))
+
+        # Resource issues
+        assert is_retryable_api_error(Exception("Resource exhausted"))
+        assert is_retryable_api_error(Exception("Deadline exceeded while processing"))

--- a/tests/unit/api_client/test_workspace_api.py
+++ b/tests/unit/api_client/test_workspace_api.py
@@ -35,7 +35,7 @@ class TestWorkspaceApi:
 
     def test_upload_notebook__exception(self, api, workspace_client):
         workspace_client.workspace.import_.side_effect = Exception("API Error")
-        with pytest.raises(Exception, match="Error creating python notebook"):
+        with pytest.raises(Exception, match="Error uploading python notebook"):
             api.upload_notebook("path", "code")
 
     def test_upload_notebook__success(self, api, workspace_client):


### PR DESCRIPTION
This change improves the robustness of Python model execution by adding retry logic with exponential backoff for operations that may encounter transient failures such as rate limiting, network issues, or temporary service unavailability.

This addresses intermittent test failures seen in CI/CD when multiple tests run concurrently and hit rate limits or temporary API issues.  Really hoping this works.

### Checklist

- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
