### PR TITLE
fix: Ensure we access correct function properties in macros

### DIFF
--- a/dbt/include/databricks/macros/materializations/functions/scalar.sql
+++ b/dbt/include/databricks/macros/materializations/functions/scalar.sql
@@ -1,6 +1,6 @@
 {% macro databricks__scalar_function_create_replace_signature_sql(target_relation) %}
     CREATE OR REPLACE FUNCTION {{ target_relation.render() }} ({{ formatted_scalar_function_args_sql()}})
-    RETURNS {{ model.return_type.type }}
+    RETURNS {{ model.returns.data_type }}
     LANGUAGE SQL
 {% endmacro %}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
 
     "databricks-sdk>=0.41, <0.68.0",
     "databricks-sql-connector[pyarrow]>=4.1.1, <4.1.4",
-    "dbt-adapters>=1.17.0, <1.18.0",
+    "dbt-adapters>=1.17.2, <1.18.0",
     "dbt-common>=1.24.0, <1.33.0",
     "dbt-core>=1.10.1, <1.11.1",
     "dbt-spark>=1.9.0, <1.9.4",


### PR DESCRIPTION
Resolves #N/A

### Description

I made a mistake in dbt-core and dbt-adapters when initially implementing function nodes. I mis-named some properties. Unfortunately, we just caught it. The result is that we need to fix accessing some properties in dbt-databricks

### Related external PRs
* https://github.com/dbt-labs/dbt-core/pull/12065
* https://github.com/dbt-labs/dbt-adapters/pull/1366

### Checklist

- [ ] I have run this code in development and it appears to resolve the stated issue
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
