### PR TITLE
fix(streaming_table): resolve schema inference error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
   - Improved efficiency of column tags and comments change detection to use case-insensitive comparison
 - Use backtick quoting for everything to avoid errors with special characters ([1186](https://github.com/databricks/dbt-databricks/pull/1186))
 - Ensure column compare always uses lower case names (since Databricks stores internally as lower case) ([1190](https://github.com/databricks/dbt-databricks/pull/1190))
+- Fix incompatible schema error during streaming table creation ([1235](https://github.com/databricks/dbt-databricks/issues/1235))
 
 ### Under the Hood
 
@@ -36,9 +37,6 @@
 - Use atomic `CREATE OR REPLACE` instead of DROP + CREATE for managed Iceberg tables
 
 ## dbt-databricks 1.10.15 (TBD)
-### Fixes
-
-- Fix incompatible schema error during streaming table creation ([1235](https://github.com/databricks/dbt-databricks/issues/1235))
 
 ## dbt-databricks 1.10.14 (October 22, 2025)
 

--- a/dbt/include/databricks/macros/relations/streaming_table/create.sql
+++ b/dbt/include/databricks/macros/relations/streaming_table/create.sql
@@ -18,8 +18,8 @@
   #}
   {%- set temp_relation = make_temp_relation(relation) -%}
   {% call statement('create_temp_view') -%}
-    {%- set sql_with_limit = analysis_sql.rstrip('; \n\t') -%}
-    {{ create_temporary_view(temp_relation, sql_with_limit) }}
+    {%- set view_sql = analysis_sql.rstrip('; \n\t') -%}
+    {{ create_temporary_view(temp_relation, view_sql) }}
   {%- endcall %}
 
   {%- set columns = adapter.get_columns_in_relation(temp_relation) -%}


### PR DESCRIPTION
Resolves ([1235](https://github.com/databricks/dbt-databricks/issues/1235))

### Description

Removing the limit in `create_temp_view` fixes schema inference issues when the underlying file structures are inconsistent between files. Based on my tests, removing the limit does not negatively affect table creation performance.

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
