### PR TITLE
fix: Validate and autoformat query tag values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## dbt-databricks 1.11.1 (TBD)
 
+### Under the hood
+
+- Add validation for query tag value length and auto-escape special characters
+
 ## dbt-databricks 1.11.0 (Oct 29, 2025)
 
 ### Features


### PR DESCRIPTION
<!-- Please review our pull request review process in CONTRIBUTING.md before your proceed. -->

Resolves #

<!---
  Include the number of the issue addressed by this PR above if applicable.

  Example:
    resolves #1234

  Please review our pull request review process in CONTRIBUTING.md before your proceed.
-->

### Description

- Auto-escape special characters in query tag values with a warning message
- Throw error when query tag value (after applying escapes) exceeds 128 length limit

### Checklist

- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
