### PR TITLE
fix: pin click dependency version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
+    "click>=8.2.0, <9.0.0",
     "databricks-sdk>=0.41, <0.68.0",
     "databricks-sql-connector[pyarrow]>=4.1.1, <4.1.4",
     "dbt-adapters>=1.17.2, <1.18.0",


### PR DESCRIPTION
<!-- Please review our pull request review process in CONTRIBUTING.md before your proceed. -->

Resolves #

<!---
  Include the number of the issue addressed by this PR above if applicable.

  Example:
    resolves #1234

  Please review our pull request review process in CONTRIBUTING.md before your proceed.
-->

### Description

Problem:
- `dbt-databricks==1.11.1` introduced a new minimum version for `dbt-core>=1.11.0b4`
- It seems like `dbt-core>=1.11.0b4` has a new dependency on `click>=8.2.0`
- When I manually install `click==8.1.0`, it works with `dbt-databricks==1.10.15` and `dbt-databricks==1.11.0`. It does NOT work with `dbt-databricks==1.11.1`

Fix:
- Pin minimum version for click to force correct version on dbt-databricks install (for whatever, the version pin for click in dbt-core is not being respected)

### Checklist

- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
