### PR TITLE
fix: materialized_view with persist_docs not updating existing comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Fixes
 
 - Truncate (128 charactesr max) and escape special characters for default query tag values
+- Fix bug where persist_docs did not update existing comments on materialized views ([#1275](https://github.com/databricks/dbt-databricks/discussions/1275))
 
 ## dbt-databricks 1.11.2 (Nov 18, 2025)
 

--- a/dbt/include/databricks/macros/adapters/persist_docs.sql
+++ b/dbt/include/databricks/macros/adapters/persist_docs.sql
@@ -43,7 +43,8 @@
 {% endmacro %}
 
 {% macro alter_relation_comment_sql(relation, description) %}
-COMMENT ON {{ relation.type.render().upper() }} {{ relation.render() }} IS '{{ description | replace("'", "\\'") }}'
+{#- ignore relation type; correct keyword is always `TABLE`: https://docs.databricks.com/aws/en/sql/language-manual/sql-ref-syntax-ddl-comment -#}
+COMMENT ON TABLE {{ relation.render() }} IS '{{ description | replace("'", "\\'") }}'
 {% endmacro %}
 
 {% macro alter_column_comments(relation, column_dict) %}

--- a/dbt/include/databricks/macros/materializations/materialized_view.sql
+++ b/dbt/include/databricks/macros/materializations/materialized_view.sql
@@ -78,6 +78,8 @@
     {% set should_revoke = should_revoke(existing_relation, full_refresh_mode=True) %}
     {% do apply_grants(target_relation, grant_config, should_revoke=should_revoke) %}
 
+    {%- do persist_docs(target_relation, model) %}
+
     {{ run_hooks(post_hooks, inside_transaction=True) }}
 
 {% endmacro %}


### PR DESCRIPTION
Resolves #1275 

### Description

See thorough writeup in https://github.com/databricks/dbt-databricks/discussions/1275#discussioncomment-15095073.

I still need to run/add integration tests - this PR would likely be a good candidate for having some.

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
