### PR TITLE
Fix incompatible schema errors when streaming table source schema evolves

### DIFF
--- a/dbt/include/databricks/macros/relations/streaming_table/create.sql
+++ b/dbt/include/databricks/macros/relations/streaming_table/create.sql
@@ -9,26 +9,7 @@
   {%- set comment = streaming_table.config["comment"].comment -%}
   {%- set refresh = streaming_table.config["refresh"] -%}
 
-  {%- set analysis_sql = sql | replace('STREAM ', '') | replace('stream ', '') -%}
-
-  {#
-    TODO: When DESCRIBE QUERY EXTENDED is supported, this implementation should be simplified
-    to use that instead. For now, we work around this limitation by writing results to a
-    temporary view and using DESCRIBE TABLE EXTENDED on the temporary view.
-  #}
-  {%- set temp_relation = make_temp_relation(relation) -%}
-  {% call statement('create_temp_view') -%}
-    {%- set view_sql = analysis_sql.rstrip('; \n\t') -%}
-    {{ create_temporary_view(temp_relation, view_sql) }}
-  {%- endcall %}
-
-  {%- set columns = adapter.get_columns_in_relation(temp_relation) -%}
-  {%- set model_columns = model.get('columns', {}) -%}
-  {%- set columns_and_constraints = adapter.parse_columns_and_constraints(columns, model_columns, []) -%}
-
-  {#-- We don't enrich the relation with model constraints because they are not supported for streaming tables --#}
   CREATE STREAMING TABLE {{ relation.render() }}
-    {{ get_column_and_constraints_sql(relation, columns_and_constraints[0]) }}
     {{ get_create_sql_partition_by(partition_by) }}
     {{ liquid_clustered_cols() }}
     {{ get_create_sql_comment(comment) }}


### PR DESCRIPTION
<!-- Please review our pull request review process in CONTRIBUTING.md before your proceed. -->

Resolves #1303

<!---
  Include the number of the issue addressed by this PR above if applicable.

  Example:
    resolves #1234

  Please review our pull request review process in CONTRIBUTING.md before your proceed.
-->

### Description

The temporary view was intended to enrich the streaming table with constraints, but the implementation was incorrect, so the constraints never worked (as noted in the comment).

Creating the temporary view and using it to create the streaming tabl caused incompatible schema errors when the source schema evolved and significantly slowed down model creation, leading to unnecessary compute costs.

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
