### PR TITLE
fix(relation_configs): bug #1130 when view_definition is empty

### DIFF
--- a/dbt/adapters/databricks/relation_configs/query.py
+++ b/dbt/adapters/databricks/relation_configs/query.py
@@ -28,7 +28,7 @@ class QueryProcessor(DatabricksComponentProcessor[QueryConfig]):
     @classmethod
     def from_relation_results(cls, result: RelationResults) -> QueryConfig:
         view_definition = result["information_schema.views"]["view_definition"].strip()
-        if view_definition[0] == "(" and view_definition[-1] == ")":
+        if view_definition and view_definition[0] == "(" and view_definition[-1] == ")":
             view_definition = view_definition[1:-1]
         return QueryConfig(query=SqlUtils.clean_sql(view_definition))
 


### PR DESCRIPTION
Resolves #1130

### Description

Avoids error `string index out of range` if `view_definition` is empty (e.g. if existing materialized view was created from a [`dlt`](https://pypi.org/project/dlt/) pipeline).

### Checklist

- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
