### PR TITLE
Create standardize_column.sql

### DIFF
--- a/dbt/include/databricks/macros/get_custom_name/standardize_column.sql
+++ b/dbt/include/databricks/macros/get_custom_name/standardize_column.sql
@@ -1,0 +1,20 @@
+-- macros/standardize_column.sql
+
+{% macro standardize_column(column_name, to_lower=true, strip_whitespace=true, remove_special_chars=false) %}
+    {%- set expr = column_name -%}
+
+    {%- if strip_whitespace %}
+        {%- set expr = "trim(" ~ expr ~ ")" -%}
+    {%- endif %}
+
+    {%- if to_lower %}
+        {%- set expr = "lower(" ~ expr ~ ")" -%}
+    {%- endif %}
+
+    {%- if remove_special_chars %}
+        -- Replace non-alphanumeric characters with underscore
+        {%- set expr = "regexp_replace(" ~ expr ~ ", '[^a-zA-Z0-9]', '_')" -%}
+    {%- endif %}
+
+    {{ expr }}
+{% endmacro %}


### PR DESCRIPTION
This macro provides a flexible way to standardize column values in dbt models. It applies common text cleaning transformations such as trimming whitespace, converting to lowercase, and optionally removing special characters. Trim whitespace: Removes leading and trailing spaces.

Convert to lowercase: Ensures consistent casing for text values.

Remove special characters (optional): Replaces non‑alphanumeric characters with underscores using regexp_replace.

Configurable flags: Each transformation can be toggled with macro arguments.

<!-- Please review our pull request review process in CONTRIBUTING.md before your proceed. -->

Resolves #

<!---
  Include the number of the issue addressed by this PR above if applicable.

  Example:
    resolves #1234

  Please review our pull request review process in CONTRIBUTING.md before your proceed.
-->

### Description

<!--- Describe the Pull Request here -->

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
