### PR TITLE
fix: track tblproperties managed by dbt (#1314)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Fixes
 
 - Fix foreign-key on an incremental table to a primary key on a non-incremental table being lost after incremental run
+- Track tblproperties which are managed by dbt, rather than relying on ignore list
 
 ### Under the Hood
 

--- a/tests/functional/adapter/materialized_view_tests/test_changes.py
+++ b/tests/functional/adapter/materialized_view_tests/test_changes.py
@@ -19,7 +19,9 @@ from tests.functional.adapter.materialized_view_tests import fixtures
 
 def _check_tblproperties(tblproperties: TblPropertiesConfig, expected: dict):
     final_tblproperties = {
-        k: v for k, v in tblproperties.tblproperties.items() if k not in tblproperties.ignore_list
+        k: v
+        for k, v in tblproperties.tblproperties.items()
+        if k not in ["dbt.tblproperties.managedKeys"]
     }
     assert final_tblproperties == expected
 
@@ -58,7 +60,7 @@ class MaterializedViewChangesMixin(MaterializedViewChanges):
     def change_config_via_replace(project, materialized_view):
         initial_model = util.get_model_file(project, materialized_view)
         new_model = (
-            initial_model.replace("partition_by='id',", "")
+            initial_model.replace("partition_by='id',", "partition_by='value',")
             .replace("select *", "select id, value")
             .replace("'key': 'value'", "'other': 'other'")
         )
@@ -69,7 +71,7 @@ class MaterializedViewChangesMixin(MaterializedViewChanges):
         with util.get_connection(project.adapter):
             results = project.adapter.get_relation_config(materialized_view)
         assert isinstance(results, MaterializedViewConfig)
-        assert results.config["partition_by"].partition_by == []
+        assert results.config["partition_by"].partition_by == ["value"]
         assert results.config["query"].query.startswith("select id, value")
         _check_tblproperties(results.config["tblproperties"], {"other": "other"})
 

--- a/tests/functional/adapter/streaming_tables/test_st_changes.py
+++ b/tests/functional/adapter/streaming_tables/test_st_changes.py
@@ -18,7 +18,9 @@ from tests.functional.adapter.streaming_tables import fixtures
 
 def _check_tblproperties(tblproperties: TblPropertiesConfig, expected: dict):
     final_tblproperties = {
-        k: v for k, v in tblproperties.tblproperties.items() if k not in tblproperties.ignore_list
+        k: v
+        for k, v in tblproperties.tblproperties.items()
+        if k not in ["dbt.tblproperties.managedKeys"]
     }
     assert final_tblproperties == expected
 

--- a/tests/functional/adapter/views/test_views.py
+++ b/tests/functional/adapter/views/test_views.py
@@ -71,7 +71,8 @@ class BaseUpdateTblProperties(BaseUpdateView):
             "show tblproperties {database}.{schema}.initial_view",
             fetch="all",
         )
-        assert results[0][1] == "value2"
+        row = [r for r in results if r[0] == "key"][0]
+        assert row[1] == "value2"
 
 
 class BaseUpdateColumnComments(BaseUpdateView):

--- a/tests/unit/relation_configs/test_incremental_config.py
+++ b/tests/unit/relation_configs/test_incremental_config.py
@@ -39,6 +39,7 @@ class TestIncrementalConfig:
                     ["clusterByAuto", "true"],
                     ["clusteringColumns", '[["col1"],[""a""]]'],
                     ["delta.constraints.check_name_length", "LENGTH (name) >= 1"],
+                    ["dbt.tblproperties.managedKeys", "prop,delta.constraints.check_name_length"],
                 ],
                 column_names=["key", "value"],
             ),
@@ -99,6 +100,7 @@ class TestIncrementalConfig:
                     tblproperties={
                         "prop": "f1",
                         "delta.constraints.check_name_length": "LENGTH (name) >= 1",
+                        "dbt.tblproperties.managedKeys": "prop,delta.constraints.check_name_length",
                     }
                 ),
                 "liquid_clustering": LiquidClusteringConfig(

--- a/tests/unit/relation_configs/test_materialized_view_config.py
+++ b/tests/unit/relation_configs/test_materialized_view_config.py
@@ -37,7 +37,12 @@ class TestMaterializedViewConfig:
                 ["select * from foo", "other"], ["view_definition", "comment"]
             ),
             "show_tblproperties": Table(
-                rows=[["prop", "1"], ["other", "other"]], column_names=["key", "value"]
+                rows=[
+                    ["prop", "1"],
+                    ["other", "other"],
+                    ["dbt.tblproperties.managedKeys", "other,prop"],
+                ],
+                column_names=["key", "value"],
             ),
             "information_schema.tags": Table(
                 rows=[["a", "b"], ["c", "d"]], column_names=["tag_name", "tag_value"]
@@ -51,7 +56,13 @@ class TestMaterializedViewConfig:
                 "partition_by": PartitionedByConfig(partition_by=["col_a", "col_b"]),
                 "liquid_clustering": LiquidClusteringConfig(),
                 "comment": CommentConfig(comment="This is the table comment"),
-                "tblproperties": TblPropertiesConfig(tblproperties={"prop": "1", "other": "other"}),
+                "tblproperties": TblPropertiesConfig(
+                    tblproperties={
+                        "prop": "1",
+                        "other": "other",
+                        "dbt.tblproperties.managedKeys": "other,prop",
+                    }
+                ),
                 "refresh": RefreshConfig(),
                 "query": QueryConfig(query="select * from foo"),
                 "tags": TagsConfig(set_tags={"a": "b", "c": "d"}),
@@ -79,7 +90,13 @@ class TestMaterializedViewConfig:
                 "partition_by": PartitionedByConfig(partition_by=["col_a", "col_b"]),
                 "liquid_clustering": LiquidClusteringConfig(),
                 "comment": CommentConfig(comment="This is the table comment", persist=True),
-                "tblproperties": TblPropertiesConfig(tblproperties={"prop": "1", "other": "other"}),
+                "tblproperties": TblPropertiesConfig(
+                    tblproperties={
+                        "prop": "1",
+                        "other": "other",
+                        "dbt.tblproperties.managedKeys": "other,prop",
+                    }
+                ),
                 "refresh": RefreshConfig(),
                 "query": QueryConfig(query="select * from foo"),
                 "tags": TagsConfig(set_tags={"a": "b", "c": "d"}),

--- a/tests/unit/relation_configs/test_streaming_table_config.py
+++ b/tests/unit/relation_configs/test_streaming_table_config.py
@@ -30,7 +30,9 @@ class TestStreamingTableConfig:
                     ["View Text", "select * from foo", None],
                 ],
             ),
-            "show_tblproperties": fixtures.gen_tblproperties([["prop", "1"], ["other", "other"]]),
+            "show_tblproperties": fixtures.gen_tblproperties(
+                [["prop", "1"], ["other", "other"], ["dbt.tblproperties.managedKeys", "other,prop"]]
+            ),
             "information_schema.tags": Table(
                 rows=[["a", "b"], ["c", "d"]], column_names=["tag_name", "tag_value"]
             ),
@@ -43,7 +45,13 @@ class TestStreamingTableConfig:
                 "partition_by": PartitionedByConfig(partition_by=["col_a", "col_b"]),
                 "liquid_clustering": LiquidClusteringConfig(),
                 "comment": CommentConfig(comment="This is the table comment"),
-                "tblproperties": TblPropertiesConfig(tblproperties={"prop": "1", "other": "other"}),
+                "tblproperties": TblPropertiesConfig(
+                    tblproperties={
+                        "prop": "1",
+                        "other": "other",
+                        "dbt.tblproperties.managedKeys": "other,prop",
+                    }
+                ),
                 "refresh": RefreshConfig(),
                 "tags": TagsConfig(set_tags={"a": "b", "c": "d"}),
                 "query": QueryConfig(query="select * from foo"),
@@ -71,7 +79,13 @@ class TestStreamingTableConfig:
                 "partition_by": PartitionedByConfig(partition_by=["col_a", "col_b"]),
                 "liquid_clustering": LiquidClusteringConfig(),
                 "comment": CommentConfig(comment="This is the table comment", persist=False),
-                "tblproperties": TblPropertiesConfig(tblproperties={"prop": "1", "other": "other"}),
+                "tblproperties": TblPropertiesConfig(
+                    tblproperties={
+                        "prop": "1",
+                        "other": "other",
+                        "dbt.tblproperties.managedKeys": "other,prop",
+                    }
+                ),
                 "refresh": RefreshConfig(),
                 "tags": TagsConfig(set_tags={"a": "b", "c": "d"}),
                 "query": QueryConfig(query="select * from foo"),

--- a/tests/unit/relation_configs/test_tblproperties.py
+++ b/tests/unit/relation_configs/test_tblproperties.py
@@ -89,11 +89,13 @@ class TestTblPropertiesProcessor:
                 "custom_prop": "value",
                 "delta.enableIcebergCompatV2": "true",
                 "delta.universalFormat.enabledFormats": constants.ICEBERG_TABLE_FORMAT,
-                "dbt.tblproperties.managedKeys": ",".join([
-                    "custom_prop",
-                    "delta.enableIcebergCompatV2",
-                    "delta.universalFormat.enabledFormats",
-                ])
+                "dbt.tblproperties.managedKeys": ",".join(
+                    [
+                        "custom_prop",
+                        "delta.enableIcebergCompatV2",
+                        "delta.universalFormat.enabledFormats",
+                    ]
+                ),
             }
         )
 

--- a/tests/unit/relation_configs/test_tblproperties.py
+++ b/tests/unit/relation_configs/test_tblproperties.py
@@ -19,16 +19,30 @@ class TestTblPropertiesProcessor:
         assert spec == TblPropertiesConfig(tblproperties={})
 
     def test_from_results__single(self):
-        results = {"show_tblproperties": fixtures.gen_tblproperties([["prop", "f1"]])}
+        results = {
+            "show_tblproperties": fixtures.gen_tblproperties(
+                [["prop", "f1"], ["dbt.tblproperties.managedKeys", "prop"]]
+            )
+        }
         spec = TblPropertiesProcessor.from_relation_results(results)
-        assert spec == TblPropertiesConfig(tblproperties={"prop": "f1"})
+        assert spec == TblPropertiesConfig(
+            tblproperties={"prop": "f1", "dbt.tblproperties.managedKeys": "prop"}
+        )
 
     def test_from_results__multiple(self):
         results = {
-            "show_tblproperties": fixtures.gen_tblproperties([["prop", "1"], ["other", "other"]])
+            "show_tblproperties": fixtures.gen_tblproperties(
+                [["prop", "1"], ["other", "other"], ["dbt.tblproperties.managedKeys", "other,prop"]]
+            )
         }
         spec = TblPropertiesProcessor.from_relation_results(results)
-        assert spec == TblPropertiesConfig(tblproperties={"prop": "1", "other": "other"})
+        assert spec == TblPropertiesConfig(
+            tblproperties={
+                "prop": "1",
+                "other": "other",
+                "dbt.tblproperties.managedKeys": "other,prop",
+            }
+        )
 
     def test_from_model_node__without_tblproperties(self):
         model = Mock()
@@ -42,7 +56,9 @@ class TestTblPropertiesProcessor:
             "tblproperties": {"prop": 1},
         }
         spec = TblPropertiesProcessor.from_relation_config(model)
-        assert spec == TblPropertiesConfig(tblproperties={"prop": "1"})
+        assert spec == TblPropertiesConfig(
+            tblproperties={"prop": "1", "dbt.tblproperties.managedKeys": "prop"}
+        )
 
     def test_from_model_node__with_empty_tblproperties(self):
         model = Mock()
@@ -73,6 +89,7 @@ class TestTblPropertiesProcessor:
                 "custom_prop": "value",
                 "delta.enableIcebergCompatV2": "true",
                 "delta.universalFormat.enabledFormats": constants.ICEBERG_TABLE_FORMAT,
+                "dbt.tblproperties.managedKeys": "custom_prop,delta.enableIcebergCompatV2,delta.universalFormat.enabledFormats",
             }
         )
 
@@ -85,7 +102,9 @@ class TestTblPropertiesProcessor:
         }
         spec = TblPropertiesProcessor.from_relation_config(model)
         # Should only have the custom property, NOT the UniForm properties
-        assert spec == TblPropertiesConfig(tblproperties={"custom_prop": "value"})
+        assert spec == TblPropertiesConfig(
+            tblproperties={"custom_prop": "value", "dbt.tblproperties.managedKeys": "custom_prop"}
+        )
 
     def test_from_model_node__with_iceberg_no_flag_no_properties(self):
         GlobalState.set_use_managed_iceberg(None)

--- a/tests/unit/relation_configs/test_tblproperties.py
+++ b/tests/unit/relation_configs/test_tblproperties.py
@@ -89,7 +89,11 @@ class TestTblPropertiesProcessor:
                 "custom_prop": "value",
                 "delta.enableIcebergCompatV2": "true",
                 "delta.universalFormat.enabledFormats": constants.ICEBERG_TABLE_FORMAT,
-                "dbt.tblproperties.managedKeys": "custom_prop,delta.enableIcebergCompatV2,delta.universalFormat.enabledFormats",
+                "dbt.tblproperties.managedKeys": ",".join([
+                    "custom_prop",
+                    "delta.enableIcebergCompatV2",
+                    "delta.universalFormat.enabledFormats",
+                ])
             }
         )
 


### PR DESCRIPTION
<!-- Please review our pull request review process in CONTRIBUTING.md before your proceed. -->

Resolves #1314

<!---
  Include the number of the issue addressed by this PR above if applicable.

  Example:
    resolves #1234

  Please review our pull request review process in CONTRIBUTING.md before your proceed.
-->

### Description

Rather than relying on an ever changing list of tblproperty keys to ignore, track (in a tblproperty) which keys have been set in the model, and are therefore being managed by dbt.

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
