### PR TITLE
feat: tblproperties merge behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@
 - Fix catalog names with special characters (e.g., hyphens) not being quoted in `SHOW SCHEMAS` commands, causing `INVALID_IDENTIFIER` errors ([#1325](https://github.com/databricks/dbt-databricks/issues/1325))
 - Fix liquid clustering rendering on streaming table materialization [#1330](https://github.com/databricks/dbt-databricks/pull/1330)
 
+### Under the Hood
+
+- **BREAKING:** `tblproperties` defined at different hierarchy levels (e.g. project-level and model-level) now merge additively instead of the child config completely replacing the parent.
+
 ## dbt-databricks 1.11.5 (Feb 19, 2026)
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Features
 
+- Merge `tblproperties` additively across config hierarchy levels instead of replacing parent values (thanks @canbekley!) ([#1353](https://github.com/databricks/dbt-databricks/pull/1353))
 - Add opt-in POST_PARSE invocation telemetry for eligible commands via `connection_parameters.enable_dbt_telemetry` ([#1647](https://github.com/databricks/dbt-databricks/pull/1647))
 - Add POST_RUN outcome telemetry to the opt-in invocation telemetry path ([#1648](https://github.com/databricks/dbt-databricks/pull/1648))
 

--- a/dbt/adapters/databricks/impl.py
+++ b/dbt/adapters/databricks/impl.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 from collections.abc import Iterable, Iterator
 from concurrent.futures import Future
 from contextlib import contextmanager
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from importlib import metadata
 from multiprocessing.context import SpawnContext
 from typing import TYPE_CHECKING, Any, ClassVar, Generic, NamedTuple, Optional, Union, cast
@@ -29,7 +29,7 @@ from dbt.adapters.spark.impl import (
     SparkAdapter,
 )
 from dbt_common.behavior_flags import BehaviorFlag
-from dbt_common.contracts.config.base import BaseConfig
+from dbt_common.contracts.config.base import BaseConfig, MergeBehavior
 from dbt_common.exceptions import DbtConfigError, DbtInternalError
 from dbt_common.utils import executor
 from dbt_common.utils.dict import AttrDict
@@ -177,7 +177,9 @@ class DatabricksConfig(AdapterConfig):
     merge_exclude_columns: Optional[str] = None
     databricks_tags: Optional[dict[str, str]] = None
     query_tags: Optional[str] = None
-    tblproperties: Optional[dict[str, str]] = None
+    tblproperties: Optional[dict[str, str]] = field(
+        default=None, metadata=MergeBehavior.Update.meta()
+    )
     zorder: Optional[Union[list[str], str]] = None
     unique_tmp_table_suffix: bool = False
     skip_non_matched_step: Optional[bool] = None

--- a/dbt/adapters/databricks/impl.py
+++ b/dbt/adapters/databricks/impl.py
@@ -211,7 +211,9 @@ class DatabricksConfig(AdapterConfig):
         default=None, metadata=MergeBehavior.Update.meta()
     )
     query_tags: Optional[str] = None
-    tblproperties: Optional[dict[str, str]] = None
+    tblproperties: Optional[dict[str, str]] = field(
+        default=None, metadata=MergeBehavior.Update.meta()
+    )
     zorder: Optional[Union[list[str], str]] = None
     skip_optimize: Optional[bool] = None
     unique_tmp_table_suffix: bool = False

--- a/tests/functional/adapter/tblproperties/test_set_tblproperties.py
+++ b/tests/functional/adapter/tblproperties/test_set_tblproperties.py
@@ -24,18 +24,30 @@ class TestTblproperties:
             "expected.csv": fixtures.seed_csv,
         }
 
-    def check_tblproperties(self, project, model_name: str, properties: list[str]):
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {
+            "models": {
+                "+tblproperties": {
+                    "default_property": "always",
+                    "tblproperties_to_view": "false",  # will be overwritten by model config
+                }
+            }
+        }
+
+    @staticmethod
+    def _check_tblproperties(project, model_name: str, tblproperties: dict[str, str]):
         results = util.run_sql_with_adapter(
             project.adapter,
             f"show tblproperties {project.test_schema}.{model_name}",
             fetch="all",
         )
-        tblproperties = [result[0] for result in results]
+        relation_tblproperties = {k: v for k, v in results}
 
-        for prop in properties:
-            assert prop in tblproperties
+        assert tblproperties.items() <= relation_tblproperties.items()
 
-    def check_snapshot_results(self, adapter, num_rows: int):
+    @staticmethod
+    def _check_snapshot_results(adapter, num_rows: int):
         results = util.run_sql_with_adapter(
             adapter, "select * from {database}.{schema}.my_snapshot", fetch="all"
         )
@@ -51,12 +63,16 @@ class TestTblproperties:
         util.check_relations_equal(project.adapter, ["set_tblproperties", "expected"])
         util.check_relations_equal(project.adapter, ["set_tblproperties_to_view", "expected"])
 
-        self.check_tblproperties(
+        self._check_tblproperties(
             project,
             "set_tblproperties",
-            ["delta.autoOptimize.optimizeWrite", "delta.autoOptimize.autoCompact"],
+            {"delta.autoOptimize.optimizeWrite": "true", "delta.autoOptimize.autoCompact": "true"},
         )
-        self.check_tblproperties(project, "set_tblproperties_to_view", ["tblproperties_to_view"])
+        self._check_tblproperties(
+            project,
+            "set_tblproperties_to_view",
+            {"tblproperties_to_view": "true", "default_property": "always"},
+        )
 
-        self.check_snapshot_results(project.adapter, num_rows=3)
-        self.check_tblproperties(project, "my_snapshot", ["tblproperties_to_snapshot"])
+        self._check_snapshot_results(project.adapter, num_rows=3)
+        self._check_tblproperties(project, "my_snapshot", {"tblproperties_to_snapshot": "true"})

--- a/tests/functional/adapter/tblproperties/test_set_tblproperties.py
+++ b/tests/functional/adapter/tblproperties/test_set_tblproperties.py
@@ -25,18 +25,30 @@ class TestTblproperties:
             "expected.csv": fixtures.seed_csv,
         }
 
-    def check_tblproperties(self, project, model_name: str, properties: list[str]):
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {
+            "models": {
+                "+tblproperties": {
+                    "default_property": "always",
+                    "tblproperties_to_view": "false",  # will be overwritten by model config
+                }
+            }
+        }
+
+    @staticmethod
+    def _check_tblproperties(project, model_name: str, tblproperties: dict[str, str]):
         results = util.run_sql_with_adapter(
             project.adapter,
             f"show tblproperties {project.test_schema}.{model_name}",
             fetch="all",
         )
-        tblproperties = [result[0] for result in results]
+        relation_tblproperties = {k: v for k, v in results}
 
-        for prop in properties:
-            assert prop in tblproperties
+        assert tblproperties.items() <= relation_tblproperties.items()
 
-    def check_snapshot_results(self, adapter, num_rows: int):
+    @staticmethod
+    def _check_snapshot_results(adapter, num_rows: int):
         results = util.run_sql_with_adapter(
             adapter, "select * from {database}.{schema}.my_snapshot", fetch="all"
         )
@@ -52,15 +64,19 @@ class TestTblproperties:
         util.check_relations_equal(project.adapter, ["set_tblproperties", "expected"])
         util.check_relations_equal(project.adapter, ["set_tblproperties_to_view", "expected"])
 
-        self.check_tblproperties(
+        self._check_tblproperties(
             project,
             "set_tblproperties",
-            ["delta.autoOptimize.optimizeWrite", "delta.autoOptimize.autoCompact"],
+            {"delta.autoOptimize.optimizeWrite": "true", "delta.autoOptimize.autoCompact": "true"},
         )
-        self.check_tblproperties(project, "set_tblproperties_to_view", ["tblproperties_to_view"])
+        self._check_tblproperties(
+            project,
+            "set_tblproperties_to_view",
+            {"tblproperties_to_view": "true", "default_property": "always"},
+        )
 
-        self.check_snapshot_results(project.adapter, num_rows=3)
-        self.check_tblproperties(project, "my_snapshot", ["tblproperties_to_snapshot"])
+        self._check_snapshot_results(project.adapter, num_rows=3)
+        self._check_tblproperties(project, "my_snapshot", {"tblproperties_to_snapshot": "true"})
 
 
 @pytest.mark.skip_profile("databricks_cluster")


### PR DESCRIPTION
Linked to #1340

### Description

Similar to the issue in #1340, `tblproperties` set at lower hierarchy levels currently override any tblproperty set on higher levels. This feature applies the built-in `MergeBehavior.Update` on `tblproperties`, making in merge additively, which is arguably more intuitive and user-friendly.

### Checklist

- [X] I have run this code in development and it appears to resolve the stated issue
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [X] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
