### PR TITLE
fix: replace npm dependency with bash regex in PR title linting

### DIFF
--- a/.github/workflows/ci-pr-linting.yml
+++ b/.github/workflows/ci-pr-linting.yml
@@ -15,34 +15,23 @@ jobs:
   pr-title:
     runs-on: linux-ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
-
-      - name: Setup node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
-        with:
-          node-version: 20
-      - name: Install conventional commit parser
-        shell: bash
-        run: npm install --global conventional-commits-parser@6.3.0
-
       - name: Validate PR title
         id: pr-format
         shell: bash
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
-        # language=bash
         run: |
           echo "PR title: ${PR_TITLE}"
-                    
-          # check if PR title follows conventional commits format
-          # issue on parser does not support "!" for breaking change (https://github.com/conventional-changelog/conventional-changelog/issues/648)
-          # so we override the regex to support it
-          conventionalCommitResult=$(echo "${PR_TITLE}" | conventional-commits-parser -p "^(\w*)!?(?:\(([\w\$\.\-\* ]*)\))?\: (.*)$" | jq ".[].type")
-          if [[ "${conventionalCommitResult}" != "null" ]]; then
-            echo "Conventional commit type: ${conventionalCommitResult}"
+
+          # Validate PR title follows conventional commits format
+          # Pattern: type[!][(scope)]: description
+          # Examples: feat(JIRA-123): add feature, fix!: breaking change
+          REGEX='^[a-zA-Z]+!?(\([^)]*\))?\: .+'
+          if [[ "${PR_TITLE}" =~ $REGEX ]]; then
+            echo "Valid conventional commit format"
             exit 0
           fi
-          
+
           echo "Invalid PR title"
           exit 1
 


### PR DESCRIPTION
## Summary

Replace the `conventional-commits-parser` npm package in `ci-pr-linting.yml` with a pure bash regex, eliminating the entire Node.js/npm supply chain from the CI pipeline.

## Why

The workflow installed `conventional-commits-parser@6.3.0` via `npm install --global` at CI time. While the direct package was version-pinned, its **transitive npm dependencies** use semver ranges and are resolved fresh on every CI run. This means a compromised transitive dependency (e.g., via a supply chain worm like CanisterWorm) could be silently pulled into CI without any lock file to prevent it.

The parser was used only to check whether a `type` field exists in the PR title — no other parsed fields (scope, subject, body, footer) were used. This makes the entire Node.js toolchain (actions/checkout, actions/setup-node, npm install, conventional-commits-parser, jq) replaceable with a single bash regex.

## What changed

**File:** `.github/workflows/ci-pr-linting.yml`

**Removed (3 steps + 1 action):**
- `actions/checkout` — not needed since no repo code is referenced
- `actions/setup-node` — no longer need Node.js
- `npm install --global conventional-commits-parser@6.3.0` — the dependency being eliminated

**Modified (1 step):**
- "Validate PR title" — replaced npm parser + jq pipeline with bash `[[ =~ ]]` regex match

**Kept unchanged (2 steps):**
- "Add comment to warn user" — sticky comment on failure (unchanged)
- "Delete a previous comment when the issue has been resolved" — cleanup on success (unchanged)

## Regex equivalence

Original parser regex: `^(\w*)!?(?:\(([\w\$\.\-\* ]*)\))?\: (.*)$`
Replacement bash regex: `^[a-zA-Z]+!?(\([^)]*\))?\: .+`

| Feature | Original | Replacement | Difference |
|---------|----------|-------------|------------|
| Type | `(\w*)` zero or more | `[a-zA-Z]+` one or more letters | Stricter — rejects empty or numeric-only types |
| Breaking change `!` | `!?` | `!?` | Identical |
| Optional scope | `(?:\(([\w\$\.\-\* ]*)\))?` | `(\([^)]*\))?` | Slightly more permissive on scope chars, but scope content was never validated |
| Separator | `\: ` | `\: ` | Identical |
| Description | `(.*)$` zero or more | `.+` one or more | Stricter — requires at least one char after `: ` |

Net effect: the replacement is slightly **stricter** in two beneficial ways.

## Supply chain impact

| Before | After |
|--------|-------|
| 4 GitHub Actions used | 2 GitHub Actions used |
| Node.js 20 runtime required | No additional runtime |
| npm install pulls transitive deps fresh each run | No npm dependencies |
| jq required to parse JSON output | No JSON parsing |
| postinstall scripts execute at install | No install step |

## Validation

- 17/17 regex test cases pass (9 valid titles, 8 invalid titles)
- actionlint: no new errors
- 0 unpinned action refs
- Sticky comment behavior unchanged (uses `if: failure()` / `if: success()` on job status)

## Test plan

- [ ] PR title linting workflow passes on this PR itself
- [ ] Open a test PR with invalid title — verify sticky comment appears
- [ ] Fix the title — verify sticky comment is deleted

---

JIRA: [PECOBLR-2368](https://databricks.atlassian.net/browse/PECOBLR-2368)

This pull request was AI-assisted by Isaac.

[PECOBLR-2368]: https://databricks.atlassian.net/browse/PECOBLR-2368?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ