### PR TITLE
chore: migrate to hardened GHA runners and add JFrog PyPI proxy

### DIFF
--- a/.github/actions/setup-jfrog-pypi/action.yml
+++ b/.github/actions/setup-jfrog-pypi/action.yml
@@ -29,3 +29,20 @@ runs:
 
         echo "JFROG_ACCESS_TOKEN=${ACCESS_TOKEN}" >> "$GITHUB_ENV"
         echo "JFrog OIDC token obtained successfully"
+
+    - name: Configure pip and uv to use JFrog PyPI proxy
+      shell: bash
+      run: |
+        set -euo pipefail
+        JFROG_PYPI_URL="https://gha-service-account:${JFROG_ACCESS_TOKEN}@databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple"
+        echo "PIP_INDEX_URL=${JFROG_PYPI_URL}" >> "$GITHUB_ENV"
+        echo "UV_INDEX_URL=${JFROG_PYPI_URL}" >> "$GITHUB_ENV"
+
+        # Write pip.conf so subprocesses (hatch, pre-commit, virtualenv) also use JFrog
+        mkdir -p ~/.config/pip
+        cat > ~/.config/pip/pip.conf << EOF
+        [global]
+        index-url = ${JFROG_PYPI_URL}
+        EOF
+
+        echo "pip and uv configured to use JFrog registry"

--- a/.github/actions/setup-jfrog-pypi/action.yml
+++ b/.github/actions/setup-jfrog-pypi/action.yml
@@ -1,0 +1,31 @@
+name: "Setup JFrog PyPI Proxy"
+description: "Authenticate with JFrog via OIDC and configure uv to use JFrog as PyPI proxy"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Get JFrog OIDC token
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        # Get GitHub OIDC ID token
+        ID_TOKEN=$(curl -sLS \
+          -H "User-Agent: actions/oidc-client" \
+          -H "Authorization: Bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+          "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=jfrog-github" | jq .value | tr -d '"')
+        echo "::add-mask::${ID_TOKEN}"
+
+        # Exchange for JFrog access token
+        ACCESS_TOKEN=$(curl -sLS -XPOST -H "Content-Type: application/json" \
+          "https://databricks.jfrog.io/access/api/v1/oidc/token" \
+          -d "{\"grant_type\": \"urn:ietf:params:oauth:grant-type:token-exchange\", \"subject_token_type\":\"urn:ietf:params:oauth:token-type:id_token\", \"subject_token\": \"${ID_TOKEN}\", \"provider_name\": \"github-actions\"}" | jq .access_token | tr -d '"')
+        echo "::add-mask::${ACCESS_TOKEN}"
+
+        if [ -z "$ACCESS_TOKEN" ] || [ "$ACCESS_TOKEN" = "null" ]; then
+          echo "FAIL: Could not extract JFrog access token"
+          exit 1
+        fi
+
+        echo "JFROG_ACCESS_TOKEN=${ACCESS_TOKEN}" >> "$GITHUB_ENV"
+        echo "JFrog OIDC token obtained successfully"

--- a/.github/workflows/ci-pr-linting.yml
+++ b/.github/workflows/ci-pr-linting.yml
@@ -14,8 +14,8 @@ on:
 jobs:
   pr-title:
     runs-on:
-      group: databricks-protected-runner-group-hardened-optin
-      labels: linux-ubuntu-latest-hardened
+      group: databricks-protected-runner-group
+      labels: linux-ubuntu-latest
     steps:
       - name: Validate PR title
         id: pr-format

--- a/.github/workflows/ci-pr-linting.yml
+++ b/.github/workflows/ci-pr-linting.yml
@@ -13,7 +13,9 @@ on:
 
 jobs:
   pr-title:
-    runs-on: linux-ubuntu-latest
+    runs-on:
+      group: databricks-protected-runner-group-hardened-optin
+      labels: linux-ubuntu-latest-hardened
     steps:
       - name: Validate PR title
         id: pr-format

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -10,7 +10,9 @@ on:
 jobs:
   test:
     name: Run tests & display coverage
-    runs-on: linux-ubuntu-latest
+    runs-on:
+      group: databricks-protected-runner-group-hardened-optin
+      labels: linux-ubuntu-latest-hardened
     if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
     permissions:
       # Gives the action the necessary permissions for publishing new

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -11,8 +11,8 @@ jobs:
   test:
     name: Run tests & display coverage
     runs-on:
-      group: databricks-protected-runner-group-hardened-optin
-      labels: linux-ubuntu-latest-hardened
+      group: databricks-protected-runner-group
+      labels: linux-ubuntu-latest
     if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
     permissions:
       # Gives the action the necessary permissions for publishing new

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -35,13 +35,19 @@ on:
         required: false
         type: string
 
+permissions:
+  id-token: write
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
   run-uc-cluster-e2e-tests:
-    runs-on: ubuntu-latest
+    runs-on:
+      group: databricks-protected-runner-group-hardened-optin
+      labels: linux-ubuntu-latest-hardened
     environment: azure-prod
     # Only run on internal PRs or manual dispatch - skip external forks to avoid secret access failures
     if: github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
@@ -64,6 +70,15 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || (github.event.inputs.pr_number && format('refs/pull/{0}/head', github.event.inputs.pr_number)) || github.event.inputs.git_ref || github.ref }}
           # Fetch enough history for PR testing
           fetch-depth: 0
+
+      - name: Setup JFrog PyPI Proxy
+        uses: ./.github/actions/setup-jfrog-pypi
+
+      - name: Configure uv
+        run: |
+          set -euo pipefail
+          echo "UV_INDEX_URL=https://gha-service-account:${JFROG_ACCESS_TOKEN}@databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple" >> "$GITHUB_ENV"
+          echo "uv configured to use JFrog registry"
 
       - name: Set up python
         id: setup-python
@@ -94,7 +109,9 @@ jobs:
           retention-days: 5
 
   run-sqlwarehouse-e2e-tests:
-    runs-on: ubuntu-latest
+    runs-on:
+      group: databricks-protected-runner-group-hardened-optin
+      labels: linux-ubuntu-latest-hardened
     environment: azure-prod
     # Only run on internal PRs or manual dispatch - skip external forks to avoid secret access failures
     if: github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
@@ -118,6 +135,15 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || (github.event.inputs.pr_number && format('refs/pull/{0}/head', github.event.inputs.pr_number)) || github.event.inputs.git_ref || github.ref }}
           # Fetch enough history for PR testing
           fetch-depth: 0
+
+      - name: Setup JFrog PyPI Proxy
+        uses: ./.github/actions/setup-jfrog-pypi
+
+      - name: Configure uv
+        run: |
+          set -euo pipefail
+          echo "UV_INDEX_URL=https://gha-service-account:${JFROG_ACCESS_TOKEN}@databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple" >> "$GITHUB_ENV"
+          echo "uv configured to use JFrog registry"
 
       - name: Set up python
         id: setup-python
@@ -148,7 +174,9 @@ jobs:
           retention-days: 5
 
   run-cluster-e2e-tests:
-    runs-on: ubuntu-latest
+    runs-on:
+      group: databricks-protected-runner-group-hardened-optin
+      labels: linux-ubuntu-latest-hardened
     environment: azure-prod
     # Only run on internal PRs or manual dispatch - skip external forks to avoid secret access failures
     if: github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
@@ -170,6 +198,15 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || (github.event.inputs.pr_number && format('refs/pull/{0}/head', github.event.inputs.pr_number)) || github.event.inputs.git_ref || github.ref }}
           # Fetch enough history for PR testing
           fetch-depth: 0
+
+      - name: Setup JFrog PyPI Proxy
+        uses: ./.github/actions/setup-jfrog-pypi
+
+      - name: Configure uv
+        run: |
+          set -euo pipefail
+          echo "UV_INDEX_URL=https://gha-service-account:${JFROG_ACCESS_TOKEN}@databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple" >> "$GITHUB_ENV"
+          echo "uv configured to use JFrog registry"
 
       - name: Set up python
         id: setup-python

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -74,12 +74,6 @@ jobs:
       - name: Setup JFrog PyPI Proxy
         uses: ./.github/actions/setup-jfrog-pypi
 
-      - name: Configure pip and uv
-        run: |
-          set -euo pipefail
-          echo "PIP_INDEX_URL=https://gha-service-account:${JFROG_ACCESS_TOKEN}@databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple" >> "$GITHUB_ENV"
-          echo "UV_INDEX_URL=https://gha-service-account:${JFROG_ACCESS_TOKEN}@databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple" >> "$GITHUB_ENV"
-          echo "pip and uv configured to use JFrog registry"
 
       - name: Set up python
         id: setup-python
@@ -140,12 +134,6 @@ jobs:
       - name: Setup JFrog PyPI Proxy
         uses: ./.github/actions/setup-jfrog-pypi
 
-      - name: Configure pip and uv
-        run: |
-          set -euo pipefail
-          echo "PIP_INDEX_URL=https://gha-service-account:${JFROG_ACCESS_TOKEN}@databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple" >> "$GITHUB_ENV"
-          echo "UV_INDEX_URL=https://gha-service-account:${JFROG_ACCESS_TOKEN}@databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple" >> "$GITHUB_ENV"
-          echo "pip and uv configured to use JFrog registry"
 
       - name: Set up python
         id: setup-python
@@ -204,12 +192,6 @@ jobs:
       - name: Setup JFrog PyPI Proxy
         uses: ./.github/actions/setup-jfrog-pypi
 
-      - name: Configure pip and uv
-        run: |
-          set -euo pipefail
-          echo "PIP_INDEX_URL=https://gha-service-account:${JFROG_ACCESS_TOKEN}@databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple" >> "$GITHUB_ENV"
-          echo "UV_INDEX_URL=https://gha-service-account:${JFROG_ACCESS_TOKEN}@databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple" >> "$GITHUB_ENV"
-          echo "pip and uv configured to use JFrog registry"
 
       - name: Set up python
         id: setup-python

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -74,11 +74,12 @@ jobs:
       - name: Setup JFrog PyPI Proxy
         uses: ./.github/actions/setup-jfrog-pypi
 
-      - name: Configure uv
+      - name: Configure pip and uv
         run: |
           set -euo pipefail
+          echo "PIP_INDEX_URL=https://gha-service-account:${JFROG_ACCESS_TOKEN}@databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple" >> "$GITHUB_ENV"
           echo "UV_INDEX_URL=https://gha-service-account:${JFROG_ACCESS_TOKEN}@databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple" >> "$GITHUB_ENV"
-          echo "uv configured to use JFrog registry"
+          echo "pip and uv configured to use JFrog registry"
 
       - name: Set up python
         id: setup-python
@@ -139,11 +140,12 @@ jobs:
       - name: Setup JFrog PyPI Proxy
         uses: ./.github/actions/setup-jfrog-pypi
 
-      - name: Configure uv
+      - name: Configure pip and uv
         run: |
           set -euo pipefail
+          echo "PIP_INDEX_URL=https://gha-service-account:${JFROG_ACCESS_TOKEN}@databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple" >> "$GITHUB_ENV"
           echo "UV_INDEX_URL=https://gha-service-account:${JFROG_ACCESS_TOKEN}@databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple" >> "$GITHUB_ENV"
-          echo "uv configured to use JFrog registry"
+          echo "pip and uv configured to use JFrog registry"
 
       - name: Set up python
         id: setup-python
@@ -202,11 +204,12 @@ jobs:
       - name: Setup JFrog PyPI Proxy
         uses: ./.github/actions/setup-jfrog-pypi
 
-      - name: Configure uv
+      - name: Configure pip and uv
         run: |
           set -euo pipefail
+          echo "PIP_INDEX_URL=https://gha-service-account:${JFROG_ACCESS_TOKEN}@databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple" >> "$GITHUB_ENV"
           echo "UV_INDEX_URL=https://gha-service-account:${JFROG_ACCESS_TOKEN}@databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple" >> "$GITHUB_ENV"
-          echo "uv configured to use JFrog registry"
+          echo "pip and uv configured to use JFrog registry"
 
       - name: Set up python
         id: setup-python

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -46,8 +46,8 @@ concurrency:
 jobs:
   run-uc-cluster-e2e-tests:
     runs-on:
-      group: databricks-protected-runner-group-hardened-optin
-      labels: linux-ubuntu-latest-hardened
+      group: databricks-protected-runner-group
+      labels: linux-ubuntu-latest
     environment: azure-prod
     # Only run on internal PRs or manual dispatch - skip external forks to avoid secret access failures
     if: github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
@@ -110,8 +110,8 @@ jobs:
 
   run-sqlwarehouse-e2e-tests:
     runs-on:
-      group: databricks-protected-runner-group-hardened-optin
-      labels: linux-ubuntu-latest-hardened
+      group: databricks-protected-runner-group
+      labels: linux-ubuntu-latest
     environment: azure-prod
     # Only run on internal PRs or manual dispatch - skip external forks to avoid secret access failures
     if: github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
@@ -175,8 +175,8 @@ jobs:
 
   run-cluster-e2e-tests:
     runs-on:
-      group: databricks-protected-runner-group-hardened-optin
-      labels: linux-ubuntu-latest-hardened
+      group: databricks-protected-runner-group
+      labels: linux-ubuntu-latest
     environment: azure-prod
     # Only run on internal PRs or manual dispatch - skip external forks to avoid secret access failures
     if: github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,11 +64,12 @@ jobs:
       - name: Setup JFrog PyPI Proxy
         uses: ./.github/actions/setup-jfrog-pypi
 
-      - name: Configure uv
+      - name: Configure pip and uv
         run: |
           set -euo pipefail
+          echo "PIP_INDEX_URL=https://gha-service-account:${JFROG_ACCESS_TOKEN}@databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple" >> "$GITHUB_ENV"
           echo "UV_INDEX_URL=https://gha-service-account:${JFROG_ACCESS_TOKEN}@databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple" >> "$GITHUB_ENV"
-          echo "uv configured to use JFrog registry"
+          echo "pip and uv configured to use JFrog registry"
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
@@ -117,11 +118,12 @@ jobs:
       - name: Setup JFrog PyPI Proxy
         uses: ./.github/actions/setup-jfrog-pypi
 
-      - name: Configure uv
+      - name: Configure pip and uv
         run: |
           set -euo pipefail
+          echo "PIP_INDEX_URL=https://gha-service-account:${JFROG_ACCESS_TOKEN}@databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple" >> "$GITHUB_ENV"
           echo "UV_INDEX_URL=https://gha-service-account:${JFROG_ACCESS_TOKEN}@databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple" >> "$GITHUB_ENV"
-          echo "uv configured to use JFrog registry"
+          echo "pip and uv configured to use JFrog registry"
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
@@ -167,11 +169,12 @@ jobs:
       - name: Setup JFrog PyPI Proxy
         uses: ./.github/actions/setup-jfrog-pypi
 
-      - name: Configure uv
+      - name: Configure pip and uv
         run: |
           set -euo pipefail
+          echo "PIP_INDEX_URL=https://gha-service-account:${JFROG_ACCESS_TOKEN}@databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple" >> "$GITHUB_ENV"
           echo "UV_INDEX_URL=https://gha-service-account:${JFROG_ACCESS_TOKEN}@databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple" >> "$GITHUB_ENV"
-          echo "uv configured to use JFrog registry"
+          echo "pip and uv configured to use JFrog registry"
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,9 @@ on:
       - "**.md"
   workflow_dispatch:
 
-permissions: read-all
+permissions:
+  id-token: write
+  contents: read
 
 # will cancel previous workflows triggered by the same event and for the same ref for PRs or same SHA otherwise
 concurrency:
@@ -44,7 +46,9 @@ jobs:
   code-quality:
     name: Code Quality
 
-    runs-on: linux-ubuntu-latest
+    runs-on:
+      group: databricks-protected-runner-group-hardened-optin
+      labels: linux-ubuntu-latest-hardened
     timeout-minutes: 10
 
     env:
@@ -56,6 +60,15 @@ jobs:
     steps:
       - name: Check out the repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+      - name: Setup JFrog PyPI Proxy
+        uses: ./.github/actions/setup-jfrog-pypi
+
+      - name: Configure uv
+        run: |
+          set -euo pipefail
+          echo "UV_INDEX_URL=https://gha-service-account:${JFROG_ACCESS_TOKEN}@databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple" >> "$GITHUB_ENV"
+          echo "uv configured to use JFrog registry"
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
@@ -74,10 +87,13 @@ jobs:
   unit:
     name: unit test / python ${{ matrix.python-version }}
 
-    runs-on: linux-ubuntu-latest
+    runs-on:
+      group: databricks-protected-runner-group-hardened-optin
+      labels: linux-ubuntu-latest-hardened
     timeout-minutes: 15
 
     permissions:
+      id-token: write
       # Gives the action the necessary permissions for publishing new
       # comments in pull requests.
       pull-requests: write
@@ -97,6 +113,15 @@ jobs:
     steps:
       - name: Check out the repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+      - name: Setup JFrog PyPI Proxy
+        uses: ./.github/actions/setup-jfrog-pypi
+
+      - name: Configure uv
+        run: |
+          set -euo pipefail
+          echo "UV_INDEX_URL=https://gha-service-account:${JFROG_ACCESS_TOKEN}@databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple" >> "$GITHUB_ENV"
+          echo "uv configured to use JFrog registry"
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
@@ -128,7 +153,9 @@ jobs:
 
   build:
     name: Build and Verify Packages
-    runs-on: linux-ubuntu-latest
+    runs-on:
+      group: databricks-protected-runner-group-hardened-optin
+      labels: linux-ubuntu-latest-hardened
 
     env:
       UV_FROZEN: "1"
@@ -136,6 +163,15 @@ jobs:
     steps:
       - name: Check out the repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+      - name: Setup JFrog PyPI Proxy
+        uses: ./.github/actions/setup-jfrog-pypi
+
+      - name: Configure uv
+        run: |
+          set -euo pipefail
+          echo "UV_INDEX_URL=https://gha-service-account:${JFROG_ACCESS_TOKEN}@databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple" >> "$GITHUB_ENV"
+          echo "uv configured to use JFrog registry"
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,12 +64,6 @@ jobs:
       - name: Setup JFrog PyPI Proxy
         uses: ./.github/actions/setup-jfrog-pypi
 
-      - name: Configure pip and uv
-        run: |
-          set -euo pipefail
-          echo "PIP_INDEX_URL=https://gha-service-account:${JFROG_ACCESS_TOKEN}@databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple" >> "$GITHUB_ENV"
-          echo "UV_INDEX_URL=https://gha-service-account:${JFROG_ACCESS_TOKEN}@databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple" >> "$GITHUB_ENV"
-          echo "pip and uv configured to use JFrog registry"
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
@@ -118,12 +112,6 @@ jobs:
       - name: Setup JFrog PyPI Proxy
         uses: ./.github/actions/setup-jfrog-pypi
 
-      - name: Configure pip and uv
-        run: |
-          set -euo pipefail
-          echo "PIP_INDEX_URL=https://gha-service-account:${JFROG_ACCESS_TOKEN}@databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple" >> "$GITHUB_ENV"
-          echo "UV_INDEX_URL=https://gha-service-account:${JFROG_ACCESS_TOKEN}@databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple" >> "$GITHUB_ENV"
-          echo "pip and uv configured to use JFrog registry"
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
@@ -169,12 +157,6 @@ jobs:
       - name: Setup JFrog PyPI Proxy
         uses: ./.github/actions/setup-jfrog-pypi
 
-      - name: Configure pip and uv
-        run: |
-          set -euo pipefail
-          echo "PIP_INDEX_URL=https://gha-service-account:${JFROG_ACCESS_TOKEN}@databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple" >> "$GITHUB_ENV"
-          echo "UV_INDEX_URL=https://gha-service-account:${JFROG_ACCESS_TOKEN}@databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple" >> "$GITHUB_ENV"
-          echo "pip and uv configured to use JFrog registry"
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,8 +47,8 @@ jobs:
     name: Code Quality
 
     runs-on:
-      group: databricks-protected-runner-group-hardened-optin
-      labels: linux-ubuntu-latest-hardened
+      group: databricks-protected-runner-group
+      labels: linux-ubuntu-latest
     timeout-minutes: 10
 
     env:
@@ -88,8 +88,8 @@ jobs:
     name: unit test / python ${{ matrix.python-version }}
 
     runs-on:
-      group: databricks-protected-runner-group-hardened-optin
-      labels: linux-ubuntu-latest-hardened
+      group: databricks-protected-runner-group
+      labels: linux-ubuntu-latest
     timeout-minutes: 15
 
     permissions:
@@ -154,8 +154,8 @@ jobs:
   build:
     name: Build and Verify Packages
     runs-on:
-      group: databricks-protected-runner-group-hardened-optin
-      labels: linux-ubuntu-latest-hardened
+      group: databricks-protected-runner-group
+      labels: linux-ubuntu-latest
 
     env:
       UV_FROZEN: "1"

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -5,8 +5,8 @@ on:
 jobs:
   stale:
     runs-on:
-      group: databricks-protected-runner-group-hardened-optin
-      labels: linux-ubuntu-latest-hardened
+      group: databricks-protected-runner-group
+      labels: linux-ubuntu-latest
     steps:
       # pinned at v4 (https://github.com/actions/stale/releases/tag/v4.0.0)
       - uses: actions/stale@cdf15f641adb27a71842045a94023bef6945e3aa

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -4,7 +4,9 @@ on:
     - cron: "30 1 * * *"
 jobs:
   stale:
-    runs-on: ubuntu-latest
+    runs-on:
+      group: databricks-protected-runner-group-hardened-optin
+      labels: linux-ubuntu-latest-hardened
     steps:
       # pinned at v4 (https://github.com/actions/stale/releases/tag/v4.0.0)
       - uses: actions/stale@cdf15f641adb27a71842045a94023bef6945e3aa


### PR DESCRIPTION
Switch all workflows to databricks-protected-runner-group-hardened-optin with linux-ubuntu-latest-hardened labels. Add JFrog OIDC authentication via a reusable composite action and configure uv to use JFrog as PyPI proxy for workflows that install Python packages.

Successful workflow runs 
- Tests and Code Checks: http://github.com/databricks/dbt-databricks/actions/runs/24123367171
- Integration tests: https://github.com/databricks/dbt-databricks/actions/runs/24123353498/job/70382173173 
