### PR TITLE
chore: add dependency cache for fork PR CI support

### DIFF
--- a/.github/actions/setup-python-deps/action.yml
+++ b/.github/actions/setup-python-deps/action.yml
@@ -1,0 +1,36 @@
+name: "Setup Python Dependencies"
+description: |
+  Restores pre-cached Python dependencies and enables offline mode.
+  All package installs (uv, pip, pre-commit) use only the local cache
+  populated by the warmDepsCache workflow — no registry access needed.
+
+runs:
+  using: "composite"
+  steps:
+    - name: Restore uv and pip cache
+      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      with:
+        path: |
+          ~/.cache/uv
+          ~/.cache/pip
+        key: python-deps-${{ hashFiles('uv.lock', 'pyproject.toml') }}
+        restore-keys: python-deps-
+
+    - name: Restore pre-commit cache
+      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      with:
+        path: ~/.cache/pre-commit
+        key: pre-commit-deps-${{ hashFiles('.pre-commit-config.yaml') }}
+        restore-keys: pre-commit-deps-
+
+    - name: Enable offline mode
+      shell: bash
+      run: |
+        echo "UV_OFFLINE=true" >> "$GITHUB_ENV"
+        # verify env uses pip, not uv
+        echo "PIP_NO_INDEX=1" >> "$GITHUB_ENV"
+        mkdir -p ~/.config/pip
+        cat > ~/.config/pip/pip.conf << 'EOF'
+[global]
+no-index = true
+EOF

--- a/.github/actions/setup-python-deps/action.yml
+++ b/.github/actions/setup-python-deps/action.yml
@@ -1,13 +1,18 @@
 name: "Setup Python Dependencies"
 description: |
   Restores pre-cached Python dependencies and enables offline mode.
-  All package installs (uv, pip, pre-commit) use only the local cache
-  populated by the warmDepsCache workflow — no registry access needed.
+  Outputs cache-hit so callers can fall back to setup-jfrog-pypi on miss.
+
+outputs:
+  cache-hit:
+    description: "Whether the dependency cache was restored"
+    value: ${{ steps.uv-cache.outputs.cache-matched-key != '' }}
 
 runs:
   using: "composite"
   steps:
     - name: Restore uv and pip cache
+      id: uv-cache
       uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: |
@@ -24,6 +29,7 @@ runs:
         restore-keys: pre-commit-deps-
 
     - name: Enable offline mode
+      if: steps.uv-cache.outputs.cache-matched-key != ''
       shell: bash
       run: |
         echo "UV_OFFLINE=true" >> "$GITHUB_ENV"
@@ -31,3 +37,4 @@ runs:
         echo "PIP_NO_INDEX=1" >> "$GITHUB_ENV"
         mkdir -p ~/.config/pip
         printf '[global]\nno-index = true\n' > ~/.config/pip/pip.conf
+        echo "Cache restored — offline mode enabled"

--- a/.github/actions/setup-python-deps/action.yml
+++ b/.github/actions/setup-python-deps/action.yml
@@ -30,7 +30,4 @@ runs:
         # verify env uses pip, not uv
         echo "PIP_NO_INDEX=1" >> "$GITHUB_ENV"
         mkdir -p ~/.config/pip
-        cat > ~/.config/pip/pip.conf << 'EOF'
-[global]
-no-index = true
-EOF
+        printf '[global]\nno-index = true\n' > ~/.config/pip/pip.conf

--- a/.github/actions/setup-python-deps/action.yml
+++ b/.github/actions/setup-python-deps/action.yml
@@ -18,8 +18,6 @@ runs:
         path: |
           ~/.cache/uv
           ~/.cache/pip
-        # Hash-prefixed key ensures only caches matching the current lockfiles
-        # are restored. If lockfiles changed, no match → JFrog fallback.
         key: python-deps-${{ hashFiles('uv.lock', 'pyproject.toml') }}-latest
         restore-keys: python-deps-${{ hashFiles('uv.lock', 'pyproject.toml') }}-
 

--- a/.github/actions/setup-python-deps/action.yml
+++ b/.github/actions/setup-python-deps/action.yml
@@ -5,7 +5,7 @@ description: |
 
 outputs:
   cache-hit:
-    description: "Whether the dependency cache was restored"
+    description: "Whether the dependency cache was restored and offline mode enabled"
     value: ${{ steps.uv-cache.outputs.cache-matched-key != '' }}
 
 runs:
@@ -18,15 +18,17 @@ runs:
         path: |
           ~/.cache/uv
           ~/.cache/pip
-        key: python-deps-${{ hashFiles('uv.lock', 'pyproject.toml') }}
-        restore-keys: python-deps-
+        # Hash-prefixed key ensures only caches matching the current lockfiles
+        # are restored. If lockfiles changed, no match → JFrog fallback.
+        key: python-deps-${{ hashFiles('uv.lock', 'pyproject.toml') }}-latest
+        restore-keys: python-deps-${{ hashFiles('uv.lock', 'pyproject.toml') }}-
 
     - name: Restore pre-commit cache
       uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: ~/.cache/pre-commit
-        key: pre-commit-deps-${{ hashFiles('.pre-commit-config.yaml') }}
-        restore-keys: pre-commit-deps-
+        key: pre-commit-deps-${{ hashFiles('.pre-commit-config.yaml') }}-latest
+        restore-keys: pre-commit-deps-${{ hashFiles('.pre-commit-config.yaml') }}-
 
     - name: Enable offline mode
       if: steps.uv-cache.outputs.cache-matched-key != ''

--- a/.github/actions/setup-python-deps/action.yml
+++ b/.github/actions/setup-python-deps/action.yml
@@ -33,8 +33,6 @@ runs:
       shell: bash
       run: |
         echo "UV_OFFLINE=true" >> "$GITHUB_ENV"
-        # verify env uses pip, not uv
         echo "PIP_NO_INDEX=1" >> "$GITHUB_ENV"
         mkdir -p ~/.config/pip
         printf '[global]\nno-index = true\n' > ~/.config/pip/pip.conf
-        echo "Cache restored — offline mode enabled"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,9 +53,6 @@ jobs:
     env:
       UV_FROZEN: "1"
 
-    strategy:
-      fail-fast: false
-
     steps:
       - name: Check out the repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
@@ -136,6 +133,7 @@ jobs:
 
       # Only run coverage comment once (not for all python versions)
       - name: Coverage Comment
+        id: coverage_comment
         if: matrix.python-version == '3.12' && github.event_name == 'pull_request'
         uses: py-cov-action/python-coverage-comment-action@7188638f871f721a365d644f505d1ff3df20d683  # v3
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,9 +1,8 @@
 # **what?**
 # Runs code quality checks, unit tests, and verifies python build on
-# all code commited to the repository. This workflow should not
-# require any secrets since it runs for PRs from forked repos.
-# By default, secrets are not passed to workflows running from
-# a forked repo.
+# all code commited to the repository. This workflow does not require
+# any secrets — dependencies are served from a pre-populated cache
+# (see warmDepsCache.yml), so it works for both internal and fork PRs.
 
 # **why?**
 # Ensure code for dbt meets a certain quality standard.
@@ -30,7 +29,6 @@ on:
   workflow_dispatch:
 
 permissions:
-  id-token: write
   contents: read
 
 # will cancel previous workflows triggered by the same event and for the same ref for PRs or same SHA otherwise
@@ -61,9 +59,8 @@ jobs:
       - name: Check out the repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
-      - name: Setup JFrog PyPI Proxy
-        uses: ./.github/actions/setup-jfrog-pypi
-
+      - name: Setup Python Dependencies
+        uses: ./.github/actions/setup-python-deps
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
@@ -88,7 +85,6 @@ jobs:
     timeout-minutes: 15
 
     permissions:
-      id-token: write
       # Gives the action the necessary permissions for publishing new
       # comments in pull requests.
       pull-requests: write
@@ -109,9 +105,8 @@ jobs:
       - name: Check out the repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
-      - name: Setup JFrog PyPI Proxy
-        uses: ./.github/actions/setup-jfrog-pypi
-
+      - name: Setup Python Dependencies
+        uses: ./.github/actions/setup-python-deps
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
@@ -154,9 +149,8 @@ jobs:
       - name: Check out the repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
-      - name: Setup JFrog PyPI Proxy
-        uses: ./.github/actions/setup-jfrog-pypi
-
+      - name: Setup Python Dependencies
+        uses: ./.github/actions/setup-python-deps
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,8 +1,8 @@
 # **what?**
 # Runs code quality checks, unit tests, and verifies python build on
-# all code commited to the repository. This workflow does not require
-# any secrets — dependencies are served from a pre-populated cache
-# (see warmDepsCache.yml), so it works for both internal and fork PRs.
+# all code commited to the repository. Dependencies are served from a
+# pre-populated cache (see warmDepsCache.yml) when available, with a
+# JFrog OIDC fallback when the cache is cold.
 
 # **why?**
 # Ensure code for dbt meets a certain quality standard.
@@ -29,6 +29,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  id-token: write
   contents: read
 
 # will cancel previous workflows triggered by the same event and for the same ref for PRs or same SHA otherwise
@@ -60,7 +61,12 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Setup Python Dependencies
+        id: deps
         uses: ./.github/actions/setup-python-deps
+
+      - name: Setup JFrog PyPI Proxy (fallback)
+        if: steps.deps.outputs.cache-hit != 'true'
+        uses: ./.github/actions/setup-jfrog-pypi
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
@@ -85,6 +91,7 @@ jobs:
     timeout-minutes: 15
 
     permissions:
+      id-token: write
       # Gives the action the necessary permissions for publishing new
       # comments in pull requests.
       pull-requests: write
@@ -106,7 +113,12 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Setup Python Dependencies
+        id: deps
         uses: ./.github/actions/setup-python-deps
+
+      - name: Setup JFrog PyPI Proxy (fallback)
+        if: steps.deps.outputs.cache-hit != 'true'
+        uses: ./.github/actions/setup-jfrog-pypi
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
@@ -150,7 +162,12 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Setup Python Dependencies
+        id: deps
         uses: ./.github/actions/setup-python-deps
+
+      - name: Setup JFrog PyPI Proxy (fallback)
+        if: steps.deps.outputs.cache-hit != 'true'
+        uses: ./.github/actions/setup-jfrog-pypi
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5

--- a/.github/workflows/warmDepsCache.yml
+++ b/.github/workflows/warmDepsCache.yml
@@ -42,7 +42,10 @@ jobs:
       UV_FROZEN: "1"
 
     steps:
-      - name: Checkout PR dependency files (sparse)
+      - name: Checkout main branch
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Overlay PR dependency files
         if: inputs.pr_number != ''
         shell: bash
         run: |
@@ -58,22 +61,11 @@ jobs:
 
           echo "Warming cache for PR #${{ inputs.pr_number }} from ${FORK_REPO}@${FORK_REF}"
 
-          # Sparse checkout: only dependency files and CI actions (no source code from fork)
-          git init .
+          # Fetch only lockfiles from the fork — .github/actions/ always
+          # comes from main to prevent code injection from forks.
           git remote add fork "https://github.com/${FORK_REPO}.git"
-          git config core.sparseCheckout true
-          cat > .git/info/sparse-checkout << 'EOF'
-uv.lock
-pyproject.toml
-.pre-commit-config.yaml
-.github/actions/
-EOF
           git fetch --depth=1 fork "${FORK_REF}"
-          git checkout FETCH_HEAD
-
-      - name: Checkout main branch
-        if: inputs.pr_number == ''
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+          git checkout FETCH_HEAD -- uv.lock pyproject.toml .pre-commit-config.yaml
 
       - name: Setup JFrog PyPI Proxy
         uses: ./.github/actions/setup-jfrog-pypi
@@ -120,11 +112,11 @@ EOF
           # Timestamp ensures each run creates a new immutable cache entry.
           # restore-keys prefix matching in consumers picks the latest.
           TIMESTAMP=$(date -u +%Y%m%d%H%M%S)
-          LOCK_HASH=${{ hashFiles('uv.lock', 'pyproject.toml') }}
-          echo "python-deps-key=python-deps-${TIMESTAMP}-${LOCK_HASH}" >> $GITHUB_OUTPUT
+          LOCK_HASH="${{ hashFiles('uv.lock', 'pyproject.toml') }}"
+          echo "python-deps-key=python-deps-${TIMESTAMP}-${LOCK_HASH}" >> "$GITHUB_OUTPUT"
 
-          PRECOMMIT_HASH=${{ hashFiles('.pre-commit-config.yaml') }}
-          echo "pre-commit-key=pre-commit-deps-${TIMESTAMP}-${PRECOMMIT_HASH}" >> $GITHUB_OUTPUT
+          PRECOMMIT_HASH="${{ hashFiles('.pre-commit-config.yaml') }}"
+          echo "pre-commit-key=pre-commit-deps-${TIMESTAMP}-${PRECOMMIT_HASH}" >> "$GITHUB_OUTPUT"
 
       - name: Save uv and pip cache
         uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4

--- a/.github/workflows/warmDepsCache.yml
+++ b/.github/workflows/warmDepsCache.yml
@@ -109,14 +109,15 @@ jobs:
         id: cache-key
         shell: bash
         run: |
-          # Timestamp ensures each run creates a new immutable cache entry.
-          # restore-keys prefix matching in consumers picks the latest.
+          # Hash first so consumers can prefix-match on the hash alone.
+          # Timestamp suffix ensures each run creates a new immutable entry;
+          # consumers pick the latest timestamp for a given hash.
           TIMESTAMP=$(date -u +%Y%m%d%H%M%S)
           LOCK_HASH="${{ hashFiles('uv.lock', 'pyproject.toml') }}"
-          echo "python-deps-key=python-deps-${TIMESTAMP}-${LOCK_HASH}" >> "$GITHUB_OUTPUT"
+          echo "python-deps-key=python-deps-${LOCK_HASH}-${TIMESTAMP}" >> "$GITHUB_OUTPUT"
 
           PRECOMMIT_HASH="${{ hashFiles('.pre-commit-config.yaml') }}"
-          echo "pre-commit-key=pre-commit-deps-${TIMESTAMP}-${PRECOMMIT_HASH}" >> "$GITHUB_OUTPUT"
+          echo "pre-commit-key=pre-commit-deps-${PRECOMMIT_HASH}-${TIMESTAMP}" >> "$GITHUB_OUTPUT"
 
       - name: Save uv and pip cache
         uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4

--- a/.github/workflows/warmDepsCache.yml
+++ b/.github/workflows/warmDepsCache.yml
@@ -1,0 +1,141 @@
+# Warm Python Dependency Cache
+#
+# Pre-downloads all Python dependencies via JFrog Artifactory and saves them
+# to the GitHub Actions cache. PR workflows (including fork PRs, which cannot
+# authenticate to JFrog) restore this cache and build fully offline.
+#
+# Triggers:
+#   - push to main when dependency files change (keeps cache fresh)
+#   - daily schedule (prevents 7-day GitHub Actions cache eviction)
+#   - manual dispatch (with optional PR number to warm cache for a fork's deps)
+
+name: Warm Python Dependency Cache
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "uv.lock"
+      - "pyproject.toml"
+      - ".pre-commit-config.yaml"
+  schedule:
+    - cron: "0 6 * * *" # Daily at 06:00 UTC
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number to warm cache for (reads lockfiles from the PR branch). Leave empty to warm from main."
+        required: false
+        type: string
+
+permissions:
+  id-token: write
+  contents: read
+  pull-requests: read
+
+jobs:
+  warm-cache:
+    runs-on:
+      group: databricks-protected-runner-group
+      labels: linux-ubuntu-latest
+
+    env:
+      UV_FROZEN: "1"
+
+    steps:
+      - name: Checkout PR dependency files (sparse)
+        if: inputs.pr_number != ''
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          PR_DATA=$(curl -sLS \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ github.token }}" \
+            "https://api.github.com/repos/${{ github.repository }}/pulls/${{ inputs.pr_number }}")
+
+          FORK_REPO=$(echo "$PR_DATA" | jq -r '.head.repo.full_name')
+          FORK_REF=$(echo "$PR_DATA" | jq -r '.head.ref')
+
+          echo "Warming cache for PR #${{ inputs.pr_number }} from ${FORK_REPO}@${FORK_REF}"
+
+          # Sparse checkout: only dependency files and CI actions (no source code from fork)
+          git init .
+          git remote add fork "https://github.com/${FORK_REPO}.git"
+          git config core.sparseCheckout true
+          cat > .git/info/sparse-checkout << 'EOF'
+uv.lock
+pyproject.toml
+.pre-commit-config.yaml
+.github/actions/
+EOF
+          git fetch --depth=1 fork "${FORK_REF}"
+          git checkout FETCH_HEAD
+
+      - name: Checkout main branch
+        if: inputs.pr_number == ''
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Setup JFrog PyPI Proxy
+        uses: ./.github/actions/setup-jfrog-pypi
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.10"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4
+
+      - name: Install Hatch
+        uses: pypa/hatch@257e27e51a6a5616ed08a39a408a21c35c9931bc # install
+
+      - name: Install Python versions for test matrix
+        run: uv python install 3.10 3.11 3.12 3.13
+
+      - name: Create all hatch environments (populates uv cache)
+        run: |
+          set -euo pipefail
+          hatch env create default
+          hatch env create test.py3.10
+          hatch env create test.py3.11
+          hatch env create test.py3.12
+          hatch env create test.py3.13
+          hatch env create verify
+
+      - name: Warm pre-commit cache
+        run: pre-commit install-hooks
+
+      - name: Build and warm pip cache for verify environment
+        run: |
+          set -euo pipefail
+          hatch -v build
+          # Run verify to populate ~/.cache/pip/ with runtime transitive deps.
+          # Allow failure — we only care about populating the cache.
+          hatch run verify:check-all || true
+
+      - name: Generate cache key
+        id: cache-key
+        shell: bash
+        run: |
+          # Timestamp ensures each run creates a new immutable cache entry.
+          # restore-keys prefix matching in consumers picks the latest.
+          TIMESTAMP=$(date -u +%Y%m%d%H%M%S)
+          LOCK_HASH=${{ hashFiles('uv.lock', 'pyproject.toml') }}
+          echo "python-deps-key=python-deps-${TIMESTAMP}-${LOCK_HASH}" >> $GITHUB_OUTPUT
+
+          PRECOMMIT_HASH=${{ hashFiles('.pre-commit-config.yaml') }}
+          echo "pre-commit-key=pre-commit-deps-${TIMESTAMP}-${PRECOMMIT_HASH}" >> $GITHUB_OUTPUT
+
+      - name: Save uv and pip cache
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: |
+            ~/.cache/uv
+            ~/.cache/pip
+          key: ${{ steps.cache-key.outputs.python-deps-key }}
+
+      - name: Save pre-commit cache
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ~/.cache/pre-commit
+          key: ${{ steps.cache-key.outputs.pre-commit-key }}


### PR DESCRIPTION
### Description

Fork PRs cannot authenticate to JFrog (no OIDC token available). This adds a cache-based dependency strategy so fork PRs get full CI feedback.

- Add warmDepsCache.yml: trusted workflow that downloads all deps via JFrog and saves to GitHub Actions cache (triggers on push to main, daily schedule, and manual dispatch with optional PR number)
- Add setup-python-deps composite action: restores cached deps and enables offline mode (UV_OFFLINE + PIP_NO_INDEX)
- Update main.yml to use setup-python-deps instead of setup-jfrog-pypi, remove id-token:write permission (no longer needed)

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR - NA
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section. - NA
