### PR TITLE
fix: warm cache pre-commit and uv cache path bugs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,6 +52,7 @@ jobs:
 
     env:
       UV_FROZEN: "1"
+      UV_CACHE_DIR: /home/runner/.cache/uv
 
     steps:
       - name: Check out the repository
@@ -99,6 +100,7 @@ jobs:
 
     env:
       UV_FROZEN: "1"
+      UV_CACHE_DIR: /home/runner/.cache/uv
 
     strategy:
       fail-fast: false
@@ -154,6 +156,7 @@ jobs:
 
     env:
       UV_FROZEN: "1"
+      UV_CACHE_DIR: /home/runner/.cache/uv
 
     steps:
       - name: Check out the repository

--- a/.github/workflows/warmDepsCache.yml
+++ b/.github/workflows/warmDepsCache.yml
@@ -40,6 +40,9 @@ jobs:
 
     env:
       UV_FROZEN: "1"
+      # Pin cache dir so setup-uv doesn't override it to a temp path.
+      # Must match the path in setup-python-deps/action.yml cache restore.
+      UV_CACHE_DIR: /home/runner/.cache/uv
 
     steps:
       - name: Checkout main branch
@@ -95,7 +98,7 @@ jobs:
           hatch env create verify
 
       - name: Warm pre-commit cache
-        run: pre-commit install-hooks
+        run: hatch run pre-commit install-hooks
 
       - name: Build and warm pip cache for verify environment
         run: |

--- a/.github/workflows/warmDepsCache.yml
+++ b/.github/workflows/warmDepsCache.yml
@@ -18,6 +18,7 @@ on:
       - "uv.lock"
       - "pyproject.toml"
       - ".pre-commit-config.yaml"
+  pull_request: # TEMPORARY: remove after testing
   schedule:
     - cron: "0 6 * * *" # Daily at 06:00 UTC
   workflow_dispatch:


### PR DESCRIPTION
## Summary
- Fix `pre-commit: command not found` in warmDepsCache — pre-commit is inside hatch's default env, use `hatch run pre-commit install-hooks`
- Fix UV cache path mismatch — `setup-uv` overrides `UV_CACHE_DIR` to a temp path, but cache save/restore uses `~/.cache/uv`. Pin `UV_CACHE_DIR: /home/runner/.cache/uv` in job env so `setup-uv` respects it and paths align.

## Test plan
> Note: I had done a temp change to trigger `warmDepsCache` on the PR for testing
- [x] Verify warmDepsCache run succeeds [Ref](https://github.com/databricks/dbt-databricks/actions/runs/24276657026/job/70891669261?pr=1389)
- [x] Verify that we have correct artifacts uploaded - confirmed using github API
- [x] All existing tests pass 