### PR TITLE
chore: remove temporary pull_request trigger from warmDepsCache

### DIFF
--- a/.github/workflows/warmDepsCache.yml
+++ b/.github/workflows/warmDepsCache.yml
@@ -18,7 +18,6 @@ on:
       - "uv.lock"
       - "pyproject.toml"
       - ".pre-commit-config.yaml"
-  pull_request: # TEMPORARY: remove after testing
   schedule:
     - cron: "0 6 * * *" # Daily at 06:00 UTC
   workflow_dispatch:


### PR DESCRIPTION
## Summary
- Remove the temporary `pull_request` trigger that was added to `warmDepsCache.yml` for testing
- The cache warmer should only run on push to main, daily schedule, and manual dispatch

## Test plan
- [ ] Verify warmDepsCache no longer triggers on PRs