### PR TITLE
fix: dependency cache bugs for fork PR CI

### DIFF
--- a/.github/actions/setup-python-deps/action.yml
+++ b/.github/actions/setup-python-deps/action.yml
@@ -18,6 +18,7 @@ runs:
         path: |
           ~/.cache/uv
           ~/.cache/pip
+          ~/.cache/pip-wheelhouse
         key: python-deps-${{ hashFiles('uv.lock', 'pyproject.toml') }}-latest
         restore-keys: python-deps-${{ hashFiles('uv.lock', 'pyproject.toml') }}-
 
@@ -33,11 +34,6 @@ runs:
       shell: bash
       run: |
         echo "UV_OFFLINE=true" >> "$GITHUB_ENV"
-        # uv cache is index-URL-scoped. The warmer downloads via JFrog, so
-        # cache entries are keyed by JFrog's URL hash. Set the same URL here
-        # (without credentials — offline mode never contacts it, only uses
-        # the hash to find the right cache bucket).
         echo "UV_INDEX_URL=https://databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple" >> "$GITHUB_ENV"
         echo "PIP_NO_INDEX=1" >> "$GITHUB_ENV"
-        mkdir -p ~/.config/pip
-        printf '[global]\nno-index = true\n' > ~/.config/pip/pip.conf
+        echo "PIP_FIND_LINKS=$HOME/.cache/pip-wheelhouse" >> "$GITHUB_ENV"

--- a/.github/actions/setup-python-deps/action.yml
+++ b/.github/actions/setup-python-deps/action.yml
@@ -33,6 +33,11 @@ runs:
       shell: bash
       run: |
         echo "UV_OFFLINE=true" >> "$GITHUB_ENV"
+        # uv cache is index-URL-scoped. The warmer downloads via JFrog, so
+        # cache entries are keyed by JFrog's URL hash. Set the same URL here
+        # (without credentials — offline mode never contacts it, only uses
+        # the hash to find the right cache bucket).
+        echo "UV_INDEX_URL=https://databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple" >> "$GITHUB_ENV"
         echo "PIP_NO_INDEX=1" >> "$GITHUB_ENV"
         mkdir -p ~/.config/pip
         printf '[global]\nno-index = true\n' > ~/.config/pip/pip.conf

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -80,14 +80,24 @@ jobs:
 
       - name: Debug pre-commit cache
         run: |
-          echo "=== PRE_COMMIT_HOME ==="
-          echo "${PRE_COMMIT_HOME:-not set (default: ~/.cache/pre-commit)}"
-          echo "=== ~/.cache/pre-commit contents ==="
-          ls -la ~/.cache/pre-commit/ 2>/dev/null || echo "directory not found"
           echo "=== db.db repos ==="
-          sqlite3 ~/.cache/pre-commit/db.db "SELECT * FROM repos;" 2>/dev/null || echo "no db.db or no sqlite3"
-          echo "=== repo dirs ==="
-          ls -la ~/.cache/pre-commit/repo*/ 2>/dev/null | head -20
+          sqlite3 ~/.cache/pre-commit/db.db "SELECT * FROM repos;" 2>/dev/null || echo "no db.db or sqlite3"
+          echo ""
+          # Find the ruff-pre-commit repo dir from db.db
+          RUFF_DIR=$(sqlite3 ~/.cache/pre-commit/db.db "SELECT path FROM repos WHERE repo LIKE '%ruff%';" 2>/dev/null)
+          echo "=== Ruff hook dir: $RUFF_DIR ==="
+          ls -la "$RUFF_DIR/" 2>/dev/null | head -10
+          echo "=== Ruff venv contents ==="
+          ls -la "$RUFF_DIR/py_env-python3.10/" 2>/dev/null | head -10
+          echo "=== pyvenv.cfg ==="
+          cat "$RUFF_DIR/py_env-python3.10/pyvenv.cfg" 2>/dev/null
+          echo "=== Python binary check ==="
+          ls -la "$RUFF_DIR/py_env-python3.10/bin/python"* 2>/dev/null
+          file "$RUFF_DIR/py_env-python3.10/bin/python" 2>/dev/null
+          echo "=== Can the venv python run? ==="
+          "$RUFF_DIR/py_env-python3.10/bin/python" --version 2>&1 || echo "FAILED"
+          echo "=== Installed packages in venv ==="
+          "$RUFF_DIR/py_env-python3.10/bin/pip" list 2>&1 | head -10 || echo "pip list failed"
 
       - name: Run Code Quality
         run: hatch -v run code-quality

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,7 +52,6 @@ jobs:
 
     env:
       UV_FROZEN: "1"
-      UV_CACHE_DIR: /home/runner/.cache/uv
 
     steps:
       - name: Check out the repository
@@ -73,6 +72,8 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a  # v4
+        with:
+          cache-local-path: ~/.cache/uv
 
       - name: Install Hatch
         uses: pypa/hatch@257e27e51a6a5616ed08a39a408a21c35c9931bc  # install
@@ -100,7 +101,6 @@ jobs:
 
     env:
       UV_FROZEN: "1"
-      UV_CACHE_DIR: /home/runner/.cache/uv
 
     strategy:
       fail-fast: false
@@ -126,6 +126,8 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a  # v4
+        with:
+          cache-local-path: ~/.cache/uv
 
       - name: Install Hatch
         uses: pypa/hatch@257e27e51a6a5616ed08a39a408a21c35c9931bc  # install
@@ -156,7 +158,6 @@ jobs:
 
     env:
       UV_FROZEN: "1"
-      UV_CACHE_DIR: /home/runner/.cache/uv
 
     steps:
       - name: Check out the repository
@@ -177,6 +178,8 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a  # v4
+        with:
+          cache-local-path: ~/.cache/uv
 
       - name: Install Hatch
         uses: pypa/hatch@257e27e51a6a5616ed08a39a408a21c35c9931bc  # install

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -78,6 +78,17 @@ jobs:
       - name: Install Hatch
         uses: pypa/hatch@257e27e51a6a5616ed08a39a408a21c35c9931bc  # install
 
+      - name: Debug pre-commit cache
+        run: |
+          echo "=== PRE_COMMIT_HOME ==="
+          echo "${PRE_COMMIT_HOME:-not set (default: ~/.cache/pre-commit)}"
+          echo "=== ~/.cache/pre-commit contents ==="
+          ls -la ~/.cache/pre-commit/ 2>/dev/null || echo "directory not found"
+          echo "=== db.db repos ==="
+          sqlite3 ~/.cache/pre-commit/db.db "SELECT * FROM repos;" 2>/dev/null || echo "no db.db or no sqlite3"
+          echo "=== repo dirs ==="
+          ls -la ~/.cache/pre-commit/repo*/ 2>/dev/null | head -20
+
       - name: Run Code Quality
         run: hatch -v run code-quality
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -78,27 +78,6 @@ jobs:
       - name: Install Hatch
         uses: pypa/hatch@257e27e51a6a5616ed08a39a408a21c35c9931bc  # install
 
-      - name: Debug pre-commit cache
-        run: |
-          echo "=== db.db repos ==="
-          sqlite3 ~/.cache/pre-commit/db.db "SELECT * FROM repos;" 2>/dev/null || echo "no db.db or sqlite3"
-          echo ""
-          # Find the ruff-pre-commit repo dir from db.db
-          RUFF_DIR=$(sqlite3 ~/.cache/pre-commit/db.db "SELECT path FROM repos WHERE repo LIKE '%ruff%';" 2>/dev/null)
-          echo "=== Ruff hook dir: $RUFF_DIR ==="
-          ls -la "$RUFF_DIR/" 2>/dev/null | head -10
-          echo "=== Ruff venv contents ==="
-          ls -la "$RUFF_DIR/py_env-python3.10/" 2>/dev/null | head -10
-          echo "=== pyvenv.cfg ==="
-          cat "$RUFF_DIR/py_env-python3.10/pyvenv.cfg" 2>/dev/null
-          echo "=== Python binary check ==="
-          ls -la "$RUFF_DIR/py_env-python3.10/bin/python"* 2>/dev/null
-          file "$RUFF_DIR/py_env-python3.10/bin/python" 2>/dev/null
-          echo "=== Can the venv python run? ==="
-          "$RUFF_DIR/py_env-python3.10/bin/python" --version 2>&1 || echo "FAILED"
-          echo "=== Installed packages in venv ==="
-          "$RUFF_DIR/py_env-python3.10/bin/pip" list 2>&1 | head -10 || echo "pip list failed"
-
       - name: Run Code Quality
         run: hatch -v run code-quality
 

--- a/.github/workflows/warmDepsCache.yml
+++ b/.github/workflows/warmDepsCache.yml
@@ -62,8 +62,6 @@ jobs:
 
           echo "Warming cache for PR #${{ inputs.pr_number }} from ${FORK_REPO}@${FORK_REF}"
 
-          # Fetch only lockfiles from the fork — .github/actions/ always
-          # comes from main to prevent code injection from forks.
           git remote add fork "https://github.com/${FORK_REPO}.git"
           git fetch --depth=1 fork "${FORK_REF}"
           git checkout FETCH_HEAD -- uv.lock pyproject.toml .pre-commit-config.yaml
@@ -84,30 +82,43 @@ jobs:
       - name: Install Hatch
         uses: pypa/hatch@257e27e51a6a5616ed08a39a408a21c35c9931bc # install
 
+      - name: Install Python versions for test matrix
+        run: uv python install 3.11 3.12 3.13
+
       - name: Create hatch environments (populates uv cache)
         run: |
           set -euo pipefail
           hatch env create default
+          hatch env create test.py3.10
+          hatch env create test.py3.11
+          hatch env create test.py3.12
+          hatch env create test.py3.13
           hatch env create verify
 
       - name: Warm pre-commit cache
         run: hatch run pre-commit install-hooks
 
-      - name: Build and warm pip cache for verify environment
+      - name: Create pip wheelhouse
         run: |
           set -euo pipefail
-          hatch -v build
-          # Run verify to populate ~/.cache/pip/ with runtime transitive deps.
-          # Allow failure — we only care about populating the cache.
-          hatch run verify:check-all || true
+          mkdir -p ~/.cache/pip-wheelhouse
+          hatch run pip download --dest ~/.cache/pip-wheelhouse \
+            setuptools wheel twine check-wheel-contents
+          hatch run pip download --dest ~/.cache/pip-wheelhouse \
+            $(hatch run python -c "
+          import tomllib
+          with open('pyproject.toml', 'rb') as f:
+              data = tomllib.load(f)
+          print(' '.join(data['project']['dependencies']))
+          ")
+
+      - name: Build package
+        run: hatch -v build
 
       - name: Generate cache key
         id: cache-key
         shell: bash
         run: |
-          # Hash first so consumers can prefix-match on the hash alone.
-          # Timestamp suffix ensures each run creates a new immutable entry;
-          # consumers pick the latest timestamp for a given hash.
           TIMESTAMP=$(date -u +%Y%m%d%H%M%S)
           LOCK_HASH="${{ hashFiles('uv.lock', 'pyproject.toml') }}"
           echo "python-deps-key=python-deps-${LOCK_HASH}-${TIMESTAMP}" >> "$GITHUB_OUTPUT"
@@ -121,6 +132,7 @@ jobs:
           path: |
             ~/.cache/uv
             ~/.cache/pip
+            ~/.cache/pip-wheelhouse
           key: ${{ steps.cache-key.outputs.python-deps-key }}
 
       - name: Save pre-commit cache

--- a/.github/workflows/warmDepsCache.yml
+++ b/.github/workflows/warmDepsCache.yml
@@ -18,7 +18,6 @@ on:
       - "uv.lock"
       - "pyproject.toml"
       - ".pre-commit-config.yaml"
-  pull_request: # TEMPORARY: remove after testing
   schedule:
     - cron: "0 6 * * *" # Daily at 06:00 UTC
   workflow_dispatch:

--- a/.github/workflows/warmDepsCache.yml
+++ b/.github/workflows/warmDepsCache.yml
@@ -102,15 +102,17 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p ~/.cache/pip-wheelhouse
-          hatch run pip download --dest ~/.cache/pip-wheelhouse \
-            setuptools wheel twine check-wheel-contents
-          hatch run pip download --dest ~/.cache/pip-wheelhouse \
-            $(hatch run python -c "
-          import tomllib
+          DEPS=$(hatch run python -c "
+          try:
+              import tomllib
+          except ImportError:
+              import tomli as tomllib
           with open('pyproject.toml', 'rb') as f:
               data = tomllib.load(f)
           print(' '.join(data['project']['dependencies']))
           ")
+          hatch run pip download --dest ~/.cache/pip-wheelhouse \
+            setuptools wheel twine check-wheel-contents $DEPS
 
       - name: Build package
         run: hatch -v build

--- a/.github/workflows/warmDepsCache.yml
+++ b/.github/workflows/warmDepsCache.yml
@@ -88,6 +88,13 @@ jobs:
       - name: Install Python versions for test matrix
         run: uv python install 3.10 3.11 3.12 3.13
 
+      - name: Cache build system dependencies
+        run: |
+          # pypa/hatch@install bundles hatchling, so hatch env create reuses
+          # it instead of downloading via uv. Force hatchling into the uv
+          # cache so offline builds with build isolation work on consumers.
+          uv pip install --system --reinstall hatchling
+
       - name: Create all hatch environments (populates uv cache)
         run: |
           set -euo pipefail

--- a/.github/workflows/warmDepsCache.yml
+++ b/.github/workflows/warmDepsCache.yml
@@ -89,10 +89,11 @@ jobs:
 
       - name: Cache build system dependencies
         run: |
-          # pypa/hatch@install bundles hatchling, so hatch env create reuses
-          # it instead of downloading via uv. Force hatchling into the uv
-          # cache so offline builds with build isolation work on consumers.
-          uv pip install --system --reinstall hatchling
+          # Trigger uv's build isolation to cache hatchling and its deps
+          # through the exact same code path consumers use. uv pip install
+          # uses a different cache resolution than build isolation.
+          uv build --wheel --out-dir /tmp/warmup-build
+          rm -rf /tmp/warmup-build
 
       - name: Create all hatch environments (populates uv cache)
         run: |

--- a/.github/workflows/warmDepsCache.yml
+++ b/.github/workflows/warmDepsCache.yml
@@ -87,14 +87,6 @@ jobs:
       - name: Install Python versions for test matrix
         run: uv python install 3.10 3.11 3.12 3.13
 
-      - name: Cache build system dependencies
-        run: |
-          # Trigger uv's build isolation to cache hatchling and its deps
-          # through the exact same code path consumers use. uv pip install
-          # uses a different cache resolution than build isolation.
-          uv build --wheel --out-dir /tmp/warmup-build
-          rm -rf /tmp/warmup-build
-
       - name: Create all hatch environments (populates uv cache)
         run: |
           set -euo pipefail

--- a/.github/workflows/warmDepsCache.yml
+++ b/.github/workflows/warmDepsCache.yml
@@ -84,17 +84,10 @@ jobs:
       - name: Install Hatch
         uses: pypa/hatch@257e27e51a6a5616ed08a39a408a21c35c9931bc # install
 
-      - name: Install Python versions for test matrix
-        run: uv python install 3.10 3.11 3.12 3.13
-
-      - name: Create all hatch environments (populates uv cache)
+      - name: Create hatch environments (populates uv cache)
         run: |
           set -euo pipefail
           hatch env create default
-          hatch env create test.py3.10
-          hatch env create test.py3.11
-          hatch env create test.py3.12
-          hatch env create test.py3.13
           hatch env create verify
 
       - name: Warm pre-commit cache

--- a/.github/workflows/warmDepsCache.yml
+++ b/.github/workflows/warmDepsCache.yml
@@ -41,9 +41,6 @@ jobs:
 
     env:
       UV_FROZEN: "1"
-      # Pin cache dir so setup-uv doesn't override it to a temp path.
-      # Must match the path in setup-python-deps/action.yml cache restore.
-      UV_CACHE_DIR: /home/runner/.cache/uv
 
     steps:
       - name: Checkout main branch
@@ -81,6 +78,8 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4
+        with:
+          cache-local-path: ~/.cache/uv
 
       - name: Install Hatch
         uses: pypa/hatch@257e27e51a6a5616ed08a39a408a21c35c9931bc # install

--- a/.github/workflows/warmDepsCache.yml
+++ b/.github/workflows/warmDepsCache.yml
@@ -102,17 +102,19 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p ~/.cache/pip-wheelhouse
-          DEPS=$(hatch run python -c "
+          hatch run python -c "
           try:
               import tomllib
           except ImportError:
               import tomli as tomllib
           with open('pyproject.toml', 'rb') as f:
               data = tomllib.load(f)
-          print(' '.join(data['project']['dependencies']))
-          ")
+          for dep in data['project']['dependencies']:
+              print(dep)
+          " > /tmp/runtime-deps.txt
           hatch run pip download --dest ~/.cache/pip-wheelhouse \
-            setuptools wheel twine check-wheel-contents $DEPS
+            setuptools wheel twine check-wheel-contents \
+            -r /tmp/runtime-deps.txt
 
       - name: Build package
         run: hatch -v build


### PR DESCRIPTION
## Summary

Fixes issues preventing the dependency cache (#1386) from working on fork PRs:

- **uv cache path**: `setup-uv` overrode the cache dir to a temp path. Use `cache-local-path` to pin it.
- **uv offline lookups**: cache is scoped by index URL hash. Set `UV_INDEX_URL` to match the warmer's JFrog URL.
- **Pre-commit broken symlinks**: warmer's Python path differed from consumer's. Use `setup-python` in warmer.
- **pip offline**: `PIP_NO_INDEX` blocks all index access. Create a pip wheelhouse and use `PIP_FIND_LINKS`.
- **Version-specific wheels**: create test envs for all matrix versions in the warmer.
- Misc: removed no-op `strategy.fail-fast`, added missing `id: coverage_comment`.

## Test plan
- [x] `warm-cache` job succeeds on this PR
- [x] All `main.yml` jobs pass offline