### PR TITLE
chore: restrict dependabot to security updates only

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,15 +1,17 @@
 version: 2
 updates:
-  # Python dependencies
+  # Python dependencies — security updates only
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+    open-pull-requests-limit: 0
     rebase-strategy: "disabled"
 
-  # GitHub Actions — auto-update SHA pins
+  # GitHub Actions — security updates only
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 0
     rebase-strategy: "disabled"


### PR DESCRIPTION
## Summary
- Sets `open-pull-requests-limit: 0` on both pip and github-actions ecosystems, which disables routine version-bump PRs while still allowing security update PRs (they bypass this limit)
- Changes pip scanning interval from daily to weekly since it only matters for security scanning cadence now

## Context
Closed 9 open dependabot PRs that were all routine version bumps with no security motivation. This config change prevents future noise.