### PR TITLE
fix: prevent duplicate alias in --empty mode for inline ref/source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Fixes
 
 - Fix column order mismatch in microbatch and replace_where incremental strategies by using INSERT BY NAME syntax ([#1338](https://github.com/databricks/dbt-databricks/issues/1338))
+- Fix `dbt run --empty` failing with inline `ref()` / `source()` aliases ([dbt-labs/dbt-adapters#660](https://github.com/dbt-labs/dbt-adapters/issues/660))
 
 ## dbt-databricks 1.11.6 (Mar 10, 2026)
 

--- a/dbt/adapters/databricks/relation.py
+++ b/dbt/adapters/databricks/relation.py
@@ -72,6 +72,7 @@ class DatabricksRelation(BaseRelation):
     quote_policy: Policy = field(default_factory=lambda: DatabricksQuotePolicy())
     include_policy: Policy = field(default_factory=lambda: DatabricksIncludePolicy())
     quote_character: str = "`"
+    require_alias: bool = False
     is_delta: Optional[bool] = None
     create_constraints: list[TypedConstraint] = field(default_factory=list)
     alter_constraints: list[TypedConstraint] = field(default_factory=list)

--- a/tests/functional/adapter/empty/test_empty.py
+++ b/tests/functional/adapter/empty/test_empty.py
@@ -1,0 +1,9 @@
+from dbt.tests.adapter.empty.test_empty import BaseTestEmpty, BaseTestEmptyInlineSourceRef
+
+
+class TestDatabricksEmpty(BaseTestEmpty):
+    pass
+
+
+class TestDatabricksEmptyInlineSourceRef(BaseTestEmptyInlineSourceRef):
+    pass

--- a/tests/unit/test_relation.py
+++ b/tests/unit/test_relation.py
@@ -368,3 +368,16 @@ class TestConstraints:
         relation.add_constraint(custom_constraint)
         relation.add_constraint(pk_constraint)
         assert relation.render_constraints_for_create() == "a > 1, PRIMARY KEY (a)"
+
+
+class TestDatabricksRenderLimited:
+    def test_render_limited_with_empty_no_alias(self):
+        relation = DatabricksRelation.create(
+            database="test_catalog",
+            schema="test_schema",
+            identifier="test_model",
+            limit=0,
+        )
+        result = relation.render_limited()
+        expected = "(select * from `test_catalog`.`test_schema`.`test_model` where false limit 0)"
+        assert result == expected


### PR DESCRIPTION
## Summary

- Sets `require_alias: bool = False` on `DatabricksRelation`, preventing `render_limited()` from injecting a `_dbt_limit_subq_*` alias that conflicts with user-provided `AS` aliases when running `dbt run --empty`
- Adds conformance tests for `--empty` mode (`BaseTestEmpty` and `BaseTestEmptyInlineSourceRef`)
- Adds a unit test verifying `render_limited()` output has no trailing subquery alias

## Context

When `dbt run --empty` is used, dbt wraps `ref()` and `source()` in a zero-row subquery. `BaseRelation` defaults to `require_alias=True`, which appends an auto-generated alias (`_dbt_limit_subq_{table}`). If the user also has an `AS` alias in their SQL (e.g. `{{ ref('orders') }} AS orders`), the two aliases conflict and produce invalid SQL.

Databricks SQL does not require subquery aliases, so `require_alias` should be `False`.

Resolves dbt-labs/dbt-adapters#660 for Databricks.

## Test plan

- [x] Unit test: `test_render_limited_with_empty_no_alias` — asserts `render_limited()` produces no trailing alias with `limit=0`
- [x] Functional test: `TestDatabricksEmptyInlineSourceRef` — end-to-end against live cluster, `dbt run --empty` with inline source alias
- [x] Functional test: `TestDatabricksEmpty` — general `--empty` conformance
- [x] All 721 existing unit tests pass (0 regressions)