### PR TITLE
fix: enable TestWorkflowJob functional test that was unreachable on all profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Fixes
 
 - Fix `workflow_job` Python model submission method failing with dictionary attribute error ([#1360](https://github.com/databricks/dbt-databricks/issues/1360))
+- Fix `TestWorkflowJob` functional test that was unreachable on all profiles due to incorrect skip list, wrong model fixture, and invalid `max_retries` parameter ([#1360](https://github.com/databricks/dbt-databricks/issues/1360))
 - Fix column order mismatch in microbatch and replace_where incremental strategies by using INSERT BY NAME syntax ([#1338](https://github.com/databricks/dbt-databricks/issues/1338))
 
 ## dbt-databricks 1.11.6 (Mar 10, 2026)

--- a/tests/functional/adapter/python_model/fixtures.py
+++ b/tests/functional/adapter/python_model/fixtures.py
@@ -102,6 +102,17 @@ sources:
         identifier: source
 """
 
+workflow_python_model = """
+import pandas
+
+def model(dbt, spark):
+    dbt.config(
+        materialized='table',
+    )
+    data = [[1,2]] * 10
+    return spark.createDataFrame(data, schema=['test', 'test2'])
+"""
+
 workflow_schema = """version: 2
 
 models:
@@ -110,7 +121,6 @@ models:
       submission_method: workflow_job
       user_folder_for_python: true
       python_job_config:
-        max_retries: 2
         timeout_seconds: 500
         additional_task_settings: {
           "task_key": "my_dbt_task"

--- a/tests/functional/adapter/python_model/test_python_model.py
+++ b/tests/functional/adapter/python_model/test_python_model.py
@@ -260,14 +260,14 @@ class TestComplexConfigV2(TestComplexConfig):
 
 @pytest.mark.python
 @pytest.mark.skip_profile(
-    "databricks_cluster", "databricks_uc_sql_endpoint", "databricks_uc_cluster"
+    "databricks_cluster", "databricks_uc_sql_endpoint"
 )
 class TestWorkflowJob:
     @pytest.fixture(scope="class")
     def models(self):
         return {
             "schema.yml": override_fixtures.workflow_schema,
-            "my_workflow_model.py": override_fixtures.simple_python_model,
+            "my_workflow_model.py": override_fixtures.workflow_python_model,
         }
 
     def test_workflow_run(self, project):

--- a/tests/functional/adapter/python_model/test_python_model.py
+++ b/tests/functional/adapter/python_model/test_python_model.py
@@ -259,9 +259,7 @@ class TestComplexConfigV2(TestComplexConfig):
 
 
 @pytest.mark.python
-@pytest.mark.skip_profile(
-    "databricks_cluster", "databricks_uc_sql_endpoint"
-)
+@pytest.mark.skip_profile("databricks_cluster", "databricks_uc_sql_endpoint")
 class TestWorkflowJob:
     @pytest.fixture(scope="class")
     def models(self):


### PR DESCRIPTION
## Summary

- Fix `TestWorkflowJob` functional test that was **never actually running** due to three compounding bugs:
  1. `skip_profile` listed all 3 available profiles (`databricks_cluster`, `databricks_uc_sql_endpoint`, `databricks_uc_cluster`) — test was skipped everywhere
  2. Used `simple_python_model` which hardcodes `submission_method='serverless_cluster'` in `dbt.config()`, overriding the YAML's `workflow_job` setting — test was exercising the wrong code path
  3. `workflow_schema` included `max_retries` which is not a valid `jobs.create()` parameter

resolves follow-up to #1360

### changes

- Add `workflow_python_model` fixture without `submission_method` in `dbt.config()` so the YAML schema's `submission_method: workflow_job` takes effect
- Remove `databricks_uc_cluster` from skip list so the test runs on at least one profile
- Remove invalid `max_retries` from `workflow_schema`

### checklist

- [x] i have run this code in development and it appears to resolve the stated issue
- [x] this pr includes tests, or tests are not required/relevant for this pr
- [x] i have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.

## Test plan

- [x] Verified test was SKIPPED on all 3 profiles before the fix
- [x] Verified test PASSES on `databricks_uc_cluster` profile after the fix (ran against live cluster)