### PR TITLE
perf: allow V1 incremental path to skip config change metadata queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Under the Hood
 
 - **BREAKING:** `databricks_tags` defined at different hierarchy levels (e.g. project-level and model-level) now merge additively instead of the child config completely replacing the parent.
+- Allow V1 incremental path to skip unnecessary metadata queries by respecting `incremental_apply_config_changes` config flag, matching V2 behavior ([#1402](https://github.com/databricks/dbt-databricks/issues/1402))
 
 ## dbt-databricks 1.11.8 (TBD)
 

--- a/dbt/include/databricks/macros/materializations/incremental/incremental.sql
+++ b/dbt/include/databricks/macros/materializations/incremental/incremental.sql
@@ -171,7 +171,6 @@
         --#}
       {%- endif -%}
       {{ process_config_changes(target_relation) }}
-      {% do persist_docs(target_relation, model, for_relation=True) %}
     {%- endif -%}
 
     {% set should_revoke = should_revoke(existing_relation, full_refresh_mode) %}

--- a/dbt/include/databricks/macros/materializations/incremental/incremental.sql
+++ b/dbt/include/databricks/macros/materializations/incremental/incremental.sql
@@ -133,9 +133,6 @@
         {{ set_overwrite_mode('DYNAMIC') }}
       {%- endif -%}
       {#-- Relation must be merged --#}
-      {%- set _existing_config = adapter.get_relation_config(existing_relation) -%}
-      {%- set model_config = adapter.get_config_from_model(config.model) -%}
-      {%- set _configuration_changes = model_config.get_changeset(_existing_config) -%}
       {%- call statement('create_temp_relation', language=language) -%}
         {{ create_table_as(True, temp_relation, compiled_code, language) }}
       {%- endcall -%}
@@ -173,30 +170,7 @@
         Also, why does not either drop_relation or adapter.drop_relation work here?!
         --#}
       {%- endif -%}
-      {% if _configuration_changes is not none %}
-        {% set tags = _configuration_changes.changes.get("tags", None) %}
-        {% set tblproperties = _configuration_changes.changes.get("tblproperties", None) %}
-        {% set liquid_clustering = _configuration_changes.changes.get("liquid_clustering") %}
-        {% set row_filter = _configuration_changes.changes.get("row_filter") %}
-        {% set constraints = _configuration_changes.changes.get("constraints") %}
-        {% if tags is not none %}
-          {% do apply_tags(target_relation, tags.set_tags) %}
-        {%- endif -%}
-        {% if tblproperties is not none %}
-          {% do apply_tblproperties(target_relation, tblproperties.tblproperties) %}
-        {%- endif -%}
-        {% if liquid_clustering is not none %}
-          {% do apply_liquid_clustered_cols(target_relation, liquid_clustering) %}
-        {% endif %}
-        {% if row_filter is not none %}
-          {{ apply_row_filter(target_relation, row_filter) }}
-        {% endif %}
-        {#- Incremental constraint application requires information_schema access (see fetch_*_constraints macros) -#}
-        {% set contract_config = config.get('contract') %}
-        {% if constraints and contract_config and contract_config.enforced and not target_relation.is_hive_metastore() %}
-          {{ apply_constraints(target_relation, constraints) }}
-        {% endif %}
-      {%- endif -%}
+      {{ process_config_changes(target_relation) }}
       {% do persist_docs(target_relation, model, for_relation=True) %}
     {%- endif -%}
 

--- a/dbt/include/databricks/macros/relations/table/alter.sql
+++ b/dbt/include/databricks/macros/relations/table/alter.sql
@@ -31,7 +31,9 @@
       {% if constraints %}
         {{ apply_constraints(target_relation, constraints) }}
       {% endif %}
-      {% if column_masks %}
+      {#-- Column masks are only applied in V2 to avoid a window where data is unmasked (CTAS in V1
+           writes data before masks can be applied, whereas V2 creates an empty table first) --#}
+      {% if column_masks and adapter.behavior.use_materialization_v2 %}
         {{ apply_column_masks(target_relation, column_masks) }}
       {% endif %}
       {% if row_filter %}

--- a/tests/functional/adapter/incremental/fixtures.py
+++ b/tests/functional/adapter/incremental/fixtures.py
@@ -1118,6 +1118,96 @@ def model(dbt, spark):
     return spark.createDataFrame(data, schema=['id', 'msg', 'color'])
 """
 
+v1_config_changes_sql = """
+{{ config(
+    materialized = 'incremental',
+    unique_key = 'id',
+    merge_update_columns = ['msg'],
+) }}
+
+{% if not is_incremental() %}
+
+select cast(1 as bigint) as id, 'hello' as msg, 'blue' as color
+
+{% else %}
+
+select cast(1 as bigint) as id, 'updated' as msg, 'blue' as color
+
+{% endif %}
+"""
+
+v1_skip_config_changes_sql = """
+{{ config(
+    materialized = 'incremental',
+    unique_key = 'id',
+    incremental_apply_config_changes = false,
+) }}
+
+{% if not is_incremental() %}
+
+select cast(1 as bigint) as id, 'hello' as msg
+
+{% else %}
+
+select cast(1 as bigint) as id, 'updated' as msg
+
+{% endif %}
+"""
+
+v1_column_tags_a = """
+version: 2
+
+models:
+  - name: v1_config_changes_sql
+    columns:
+        - name: id
+          databricks_tags:
+            pii: "false"
+        - name: msg
+        - name: color
+"""
+
+v1_column_tags_b = """
+version: 2
+
+models:
+  - name: v1_config_changes_sql
+    columns:
+        - name: id
+          databricks_tags:
+            pii: "true"
+        - name: msg
+          databricks_tags:
+            source: "app"
+        - name: color
+"""
+
+fail_if_metadata_fetched_macros = """
+{% macro fetch_tags(relation) %}
+  {{ exceptions.raise_compiler_error("fetch_tags should not be called when incremental_apply_config_changes is false") }}
+{% endmacro %}
+
+{% macro fetch_column_tags(relation) %}
+  {{ exceptions.raise_compiler_error("fetch_column_tags should not be called") }}
+{% endmacro %}
+
+{% macro fetch_non_null_constraint_columns(relation) %}
+  {{ exceptions.raise_compiler_error("fetch_non_null_constraint_columns should not be called") }}
+{% endmacro %}
+
+{% macro fetch_primary_key_constraints(relation) %}
+  {{ exceptions.raise_compiler_error("fetch_primary_key_constraints should not be called") }}
+{% endmacro %}
+
+{% macro fetch_foreign_key_constraints(relation) %}
+  {{ exceptions.raise_compiler_error("fetch_foreign_key_constraints should not be called") }}
+{% endmacro %}
+
+{% macro fetch_column_masks(relation) %}
+  {{ exceptions.raise_compiler_error("fetch_column_masks should not be called") }}
+{% endmacro %}
+"""
+
 warn_unenforced_override_sql = """
 select "abc" as id
 """

--- a/tests/functional/adapter/incremental/fixtures.py
+++ b/tests/functional/adapter/incremental/fixtures.py
@@ -1118,24 +1118,6 @@ def model(dbt, spark):
     return spark.createDataFrame(data, schema=['id', 'msg', 'color'])
 """
 
-v1_config_changes_sql = """
-{{ config(
-    materialized = 'incremental',
-    unique_key = 'id',
-    merge_update_columns = ['msg'],
-) }}
-
-{% if not is_incremental() %}
-
-select cast(1 as bigint) as id, 'hello' as msg, 'blue' as color
-
-{% else %}
-
-select cast(1 as bigint) as id, 'updated' as msg, 'blue' as color
-
-{% endif %}
-"""
-
 v1_skip_config_changes_sql = """
 {{ config(
     materialized = 'incremental',
@@ -1152,34 +1134,6 @@ select cast(1 as bigint) as id, 'hello' as msg
 select cast(1 as bigint) as id, 'updated' as msg
 
 {% endif %}
-"""
-
-v1_column_tags_a = """
-version: 2
-
-models:
-  - name: v1_config_changes_sql
-    columns:
-        - name: id
-          databricks_tags:
-            pii: "false"
-        - name: msg
-        - name: color
-"""
-
-v1_column_tags_b = """
-version: 2
-
-models:
-  - name: v1_config_changes_sql
-    columns:
-        - name: id
-          databricks_tags:
-            pii: "true"
-        - name: msg
-          databricks_tags:
-            source: "app"
-        - name: color
 """
 
 fail_if_metadata_fetched_macros = """
@@ -1206,6 +1160,33 @@ fail_if_metadata_fetched_macros = """
 {% macro fetch_column_masks(relation) %}
   {{ exceptions.raise_compiler_error("fetch_column_masks should not be called") }}
 {% endmacro %}
+"""
+
+fail_if_column_masks_applied_macro = """
+{% macro apply_column_masks(relation, column_masks) %}
+  {{ exceptions.raise_compiler_error("apply_column_masks should not be called in V1 — column masks must only be applied in V2 to prevent unmasked data exposure") }}
+{% endmacro %}
+"""
+
+v1_column_mask_model_sql = """
+{{ config(
+    materialized = 'incremental',
+    unique_key = 'id',
+) }}
+
+select cast(1 as bigint) as id, 'hello' as name
+"""
+
+v1_column_mask_schema = """
+version: 2
+
+models:
+  - name: v1_column_mask_model_sql
+    columns:
+        - name: id
+        - name: name
+          column_mask:
+            function: full_mask
 """
 
 warn_unenforced_override_sql = """

--- a/tests/functional/adapter/incremental/test_v1_incremental_config_changes.py
+++ b/tests/functional/adapter/incremental/test_v1_incremental_config_changes.py
@@ -1,0 +1,129 @@
+import pytest
+from dbt.tests import util
+
+from tests.functional.adapter.incremental import fixtures
+
+
+@pytest.mark.skip_profile("databricks_cluster")
+class TestV1IncrementalColumnTags:
+    """Test that V1 incremental path applies column tag changes via process_config_changes."""
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "v1_config_changes_sql.sql": fixtures.v1_config_changes_sql,
+            "schema.yml": fixtures.v1_column_tags_a,
+        }
+
+    def test_changing_column_tags(self, project):
+        # First run creates the table
+        util.run_dbt(["run"])
+
+        # Update column tags
+        util.write_file(fixtures.v1_column_tags_b, "models", "schema.yml")
+        util.run_dbt(["run"])
+
+        # Verify column tags were applied
+        results = project.run_sql(
+            f"""
+            select column_name, tag_name, tag_value
+            from `system`.`information_schema`.`column_tags`
+            where schema_name = '{project.test_schema}'
+            and table_name = 'v1_config_changes_sql'
+            order by column_name, tag_name
+            """,
+            fetch="all",
+        )
+
+        tags_dict = {}
+        for row in results:
+            col = row.column_name
+            if col not in tags_dict:
+                tags_dict[col] = {}
+            tags_dict[col][row.tag_name] = row.tag_value
+
+        # Verify expected final state
+        expected_tags = {
+            "id": {"pii": "true"},
+            "msg": {"source": "app"},
+        }
+        assert tags_dict == expected_tags
+
+
+@pytest.mark.skip_profile("databricks_cluster")
+class TestV1IncrementalColumnMasks:
+    """Test that V1 incremental path applies column mask changes via process_config_changes."""
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "column_mask_sql.sql": fixtures.column_mask_sql,
+            "schema.yml": fixtures.column_mask_base,
+        }
+
+    def test_changing_column_masks(self, project):
+        # Create mask functions
+        project.run_sql(
+            f"""
+            CREATE OR REPLACE FUNCTION
+                {project.database}.{project.test_schema}.full_mask(password STRING)
+            RETURNS STRING
+            RETURN '*****';
+            """
+        )
+        project.run_sql(
+            f"""
+            CREATE OR REPLACE FUNCTION
+                {project.database}.{project.test_schema}.email_mask(value STRING)
+            RETURNS STRING
+            RETURN CONCAT(
+                REPEAT('*', POSITION('@' IN value) - 1),
+                SUBSTR(value, POSITION('@' IN value))
+            );
+            """
+        )
+
+        # First run with initial masks
+        util.run_dbt(["run"])
+        masks = project.run_sql(
+            "SELECT id, name, email, password FROM column_mask_sql",
+            fetch="all",
+        )
+        assert len(masks) == 1
+        assert masks[0][1] == "*****"  # name (masked)
+        assert masks[0][3] == "password123"  # password (unmasked)
+
+        # Update masks and verify changes
+        util.write_file(fixtures.column_mask_valid_mask_updates, "models", "schema.yml")
+        util.run_dbt(["run"])
+
+        result = project.run_sql(
+            "SELECT id, name, email, password FROM column_mask_sql", fetch="all"
+        )
+        assert len(result) == 1
+        assert result[0][1] == "hello"  # name (unmasked)
+        assert result[0][3] == "*****"  # password (masked)
+
+
+@pytest.mark.skip_profile("databricks_cluster")
+class TestV1IncrementalSkipConfigChanges:
+    """Test that incremental_apply_config_changes=false skips metadata fetch queries."""
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "v1_skip_config_changes_sql.sql": fixtures.v1_skip_config_changes_sql,
+        }
+
+    @pytest.fixture(scope="class")
+    def macros(self):
+        return {
+            "fail_if_metadata_fetched.sql": fixtures.fail_if_metadata_fetched_macros,
+        }
+
+    def test_incremental_run_skips_metadata_queries(self, project):
+        # First run creates the table
+        util.run_dbt(["run"])
+        # Second run exercises the incremental merge path.
+        # If metadata fetch macros are called, they will raise errors and the run will fail.
+        util.run_dbt(["run"])

--- a/tests/functional/adapter/incremental/test_v1_incremental_config_changes.py
+++ b/tests/functional/adapter/incremental/test_v1_incremental_config_changes.py
@@ -5,109 +5,8 @@ from tests.functional.adapter.incremental import fixtures
 
 
 @pytest.mark.skip_profile("databricks_cluster")
-class TestV1IncrementalColumnTags:
-    """Test that V1 incremental path applies column tag changes via process_config_changes."""
-
-    @pytest.fixture(scope="class")
-    def models(self):
-        return {
-            "v1_config_changes_sql.sql": fixtures.v1_config_changes_sql,
-            "schema.yml": fixtures.v1_column_tags_a,
-        }
-
-    def test_changing_column_tags(self, project):
-        # First run creates the table
-        util.run_dbt(["run"])
-
-        # Update column tags
-        util.write_file(fixtures.v1_column_tags_b, "models", "schema.yml")
-        util.run_dbt(["run"])
-
-        # Verify column tags were applied
-        results = project.run_sql(
-            f"""
-            select column_name, tag_name, tag_value
-            from `system`.`information_schema`.`column_tags`
-            where schema_name = '{project.test_schema}'
-            and table_name = 'v1_config_changes_sql'
-            order by column_name, tag_name
-            """,
-            fetch="all",
-        )
-
-        tags_dict = {}
-        for row in results:
-            col = row.column_name
-            if col not in tags_dict:
-                tags_dict[col] = {}
-            tags_dict[col][row.tag_name] = row.tag_value
-
-        # Verify expected final state
-        expected_tags = {
-            "id": {"pii": "true"},
-            "msg": {"source": "app"},
-        }
-        assert tags_dict == expected_tags
-
-
-@pytest.mark.skip_profile("databricks_cluster")
-class TestV1IncrementalColumnMasks:
-    """Test that V1 incremental path applies column mask changes via process_config_changes."""
-
-    @pytest.fixture(scope="class")
-    def models(self):
-        return {
-            "column_mask_sql.sql": fixtures.column_mask_sql,
-            "schema.yml": fixtures.column_mask_base,
-        }
-
-    def test_changing_column_masks(self, project):
-        # Create mask functions
-        project.run_sql(
-            f"""
-            CREATE OR REPLACE FUNCTION
-                {project.database}.{project.test_schema}.full_mask(password STRING)
-            RETURNS STRING
-            RETURN '*****';
-            """
-        )
-        project.run_sql(
-            f"""
-            CREATE OR REPLACE FUNCTION
-                {project.database}.{project.test_schema}.email_mask(value STRING)
-            RETURNS STRING
-            RETURN CONCAT(
-                REPEAT('*', POSITION('@' IN value) - 1),
-                SUBSTR(value, POSITION('@' IN value))
-            );
-            """
-        )
-
-        # First run with initial masks
-        util.run_dbt(["run"])
-        masks = project.run_sql(
-            "SELECT id, name, email, password FROM column_mask_sql",
-            fetch="all",
-        )
-        assert len(masks) == 1
-        assert masks[0][1] == "*****"  # name (masked)
-        assert masks[0][3] == "password123"  # password (unmasked)
-
-        # Update masks and verify changes
-        util.write_file(fixtures.column_mask_valid_mask_updates, "models", "schema.yml")
-        util.run_dbt(["run"])
-
-        result = project.run_sql(
-            "SELECT id, name, email, password FROM column_mask_sql", fetch="all"
-        )
-        assert len(result) == 1
-        assert result[0][1] == "hello"  # name (unmasked)
-        assert result[0][3] == "*****"  # password (masked)
-
-
-@pytest.mark.skip_profile("databricks_cluster")
 class TestV1IncrementalSkipConfigChanges:
-    """Test that incremental_apply_config_changes=false skips metadata fetch queries."""
+    """Test that incremental_apply_config_changes=false skips metadata fetch queries in V1 path."""
 
     @pytest.fixture(scope="class")
     def models(self):
@@ -126,4 +25,44 @@ class TestV1IncrementalSkipConfigChanges:
         util.run_dbt(["run"])
         # Second run exercises the incremental merge path.
         # If metadata fetch macros are called, they will raise errors and the run will fail.
+        util.run_dbt(["run"])
+
+
+@pytest.mark.skip_profile("databricks_cluster")
+class TestV1IncrementalColumnMasksNotApplied:
+    """Test that column masks are NOT applied in V1 incremental path.
+
+    Column masks must only be applied in V2 where the empty table is created before data
+    arrives. In V1 (CTAS), data is written immediately, so applying masks after the fact
+    would leave a window where data is unmasked — a security/privacy vulnerability.
+    """
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "v1_column_mask_model_sql.sql": fixtures.v1_column_mask_model_sql,
+            "schema.yml": fixtures.v1_column_mask_schema,
+        }
+
+    @pytest.fixture(scope="class")
+    def macros(self):
+        return {
+            "fail_if_column_masks_applied.sql": fixtures.fail_if_column_masks_applied_macro,
+        }
+
+    def test_column_masks_not_applied_in_v1(self, project):
+        # Create the mask function so the model config is valid
+        project.run_sql(
+            f"""
+            CREATE OR REPLACE FUNCTION
+                {project.database}.{project.test_schema}.full_mask(val STRING)
+            RETURNS STRING
+            RETURN '*****';
+            """
+        )
+
+        # First run creates the table
+        util.run_dbt(["run"])
+        # Second run exercises the incremental merge path with config change detection.
+        # If apply_column_masks is called, the overridden macro raises an error.
         util.run_dbt(["run"])


### PR DESCRIPTION
Resolves #1402

### Description

The V1 incremental materialization path calls `adapter.get_relation_config()` unconditionally during every incremental merge run. This triggers 8 sequential metadata queries against `information_schema` and `system` tables — even when none of the related features (tags, constraints, column masks) are in use.

The V2 path already uses `process_config_changes()`, which respects the `incremental_apply_config_changes` config flag. This PR replaces the V1 inline code with the same macro, bringing V1 in line with V2.

**Change:**
- Remove inline config change detection (3 lines) and application (19 lines) from V1 incremental path
- Replace with single `{{ process_config_changes(target_relation) }}` call

**Queries eliminated when `incremental_apply_config_changes: false`:**
1. `SELECT ... FROM system.information_schema.table_tags`
2. `SELECT ... FROM system.information_schema.column_tags`
3. `SELECT ... FROM information_schema.columns` (NOT NULL constraints)
4. `SELECT ... FROM information_schema.key_column_usage` (PRIMARY KEY)
5. `SELECT ... FROM information_schema.key_column_usage` (FOREIGN KEY)
6. `SELECT ... FROM system.information_schema.column_masks`
7. `SHOW TBLPROPERTIES`
8. `DESCRIBE TABLE EXTENDED`

**Measured results** (Serverless SQL Warehouse, incremental merge model with `auto_liquid_cluster: true`):

| | Default | `incremental_apply_config_changes: false` |
|--|---------|------------------------------------------|
| Queries (model execution) | 13 | 5 |
| Model execution time | 13.89s | 6.55s |
| `get_relation_config` overhead | 3.70s | 0s |
| **Speedup** | — | **2.12x** |

<details>
<summary>Test assets used for benchmarking</summary>

**dbt_project.yml:**
```yaml
name: 'perf_test'
version: '1.0.0'
profile: 'perf_test'

model-paths: ["models"]
macro-paths: ["macros"]
test-paths: ["tests"]
seed-paths: ["seeds"]

target-path: "target"
clean-targets:
  - "target"
  - "dbt_packages"

flags:
  use_materialization_v2: false
```

**models/incremental_merge_test.sql** (default run):
```sql
{{
  config(
    materialized='incremental',
    incremental_strategy='merge',
    unique_key='id',
    auto_liquid_cluster=true
  )
}}

SELECT
  id, name, category, amount, updated_at
FROM (
  VALUES
    (1, 'Alice', 'A', 100.0, current_timestamp()),
    (2, 'Bob', 'B', 200.0, current_timestamp()),
    (3, 'Charlie', 'A', 150.0, current_timestamp()),
    (4, 'Diana', 'C', 300.0, current_timestamp()),
    (5, 'Eve', 'B', 250.0, current_timestamp())
) AS t(id, name, category, amount, updated_at)
```

**models/incremental_merge_test.sql** (skip run — only config diff):
```sql
{{
  config(
    materialized='incremental',
    incremental_strategy='merge',
    unique_key='id',
    auto_liquid_cluster=true,
    incremental_apply_config_changes=false
  )
}}
```

Steps: `dbt run` (initial table creation) → `dbt run` (incremental merge, default) → add `incremental_apply_config_changes=false` → `dbt run` (incremental merge, skip). Compare `dbt.log` from the last two runs.

</details>

<details>
<summary>Query-level breakdown (default run)</summary>

```
  1. 0.470s  CREATE TEMPORARY VIEW (temp relation)
  2. 0.290s  DESCRIBE TABLE EXTENDED (target)
  3. 0.180s  DESCRIBE TABLE EXTENDED (temp)
  4. 6.200s  MERGE INTO (model SQL)
  5. 0.360s  fetch_tags ← get_relation_config
  6. 0.350s  fetch_column_tags ← get_relation_config
  7. 0.480s  fetch_non_null_constraints ← get_relation_config
  8. 0.790s  fetch_primary_key_constraints ← get_relation_config
  9. 1.070s  fetch_foreign_key_constraints ← get_relation_config
 10. 0.320s  fetch_column_masks ← get_relation_config
 11. 0.330s  SHOW TBLPROPERTIES ← get_relation_config
 12. 0.350s  DESCRIBE TABLE EXTENDED ← get_relation_config
 13. 2.700s  OPTIMIZE
```
</details>

<details>
<summary>Query-level breakdown (skip run)</summary>

```
  1. 0.420s  CREATE TEMPORARY VIEW (temp relation)
  2. 0.260s  DESCRIBE TABLE EXTENDED (target)
  3. 0.160s  DESCRIBE TABLE EXTENDED (temp)
  4. 3.540s  MERGE INTO (model SQL)
  5. 2.170s  OPTIMIZE
```
</details>

**Functional parity:** `apply_config_changeset` (used by `process_config_changes`) handles all config types that the V1 inline code handled (tags, tblproperties, liquid_clustering, constraints) plus additional types (column_comments, column_tags, column_masks).

When `incremental_apply_config_changes` is `true` (default), behavior is unchanged — all 8 queries run and config changes are applied.

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.