### PR TITLE
fix: prevent spurious MicrobatchConcurrency warning on every run (#1406)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## dbt-databricks next (TBD)
+
+### Fixes
+
+- Fix spurious `MicrobatchConcurrency` behavior-change warning firing on every run regardless of whether the project contained microbatch models ([#1406](https://github.com/databricks/dbt-databricks/issues/1406))
+
 ## dbt-databricks 1.11.7 (Apr 17, 2026)
 
 ### Features

--- a/dbt/adapters/databricks/impl.py
+++ b/dbt/adapters/databricks/impl.py
@@ -261,9 +261,9 @@ class DatabricksAdapter(SparkAdapter):
         ]
 
     def supports(self, capability: Capability) -> bool:
-        # Gate MicrobatchConcurrency on the use_concurrent_microbatch behavior flag.
         if capability == Capability.MicrobatchConcurrency:
-            return bool(self.behavior.use_concurrent_microbatch)
+            # `.no_warn` avoids a BehaviorChangeEvent on dbt-core's per-parse probe.
+            return self.behavior.use_concurrent_microbatch.no_warn
         return super().supports(capability)
 
     def quote(self, identifier):  # type: ignore[override,no-untyped-def]

--- a/tests/unit/test_adapter_capabilities.py
+++ b/tests/unit/test_adapter_capabilities.py
@@ -7,6 +7,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 from dbt.adapters.capability import Capability
+from dbt_common.events.event_manager_client import add_callback_to_manager
 from dbt_common.exceptions import DbtConfigError
 
 from dbt.adapters.databricks.dbr_capabilities import DBRCapabilities, DBRCapability
@@ -177,5 +178,25 @@ class TestAdapterCapabilities:
 
     def test_microbatch_concurrency_enabled_with_flag(self, adapter):
         """Test that MicrobatchConcurrency is enabled when behavior flag is on."""
-        adapter.behavior.use_concurrent_microbatch = True
+        adapter.behavior.use_concurrent_microbatch.setting = True
         assert adapter.supports(Capability.MicrobatchConcurrency)
+
+    def test_microbatch_concurrency_probe_does_not_warn(self, adapter):
+        """Test that supports(MicrobatchConcurrency) does not fire BehaviorChangeEvent."""
+        caught = []
+
+        def record(event_msg):
+            if (
+                event_msg.info.name == "BehaviorChangeEvent"
+                and event_msg.data.flag_name == "use_concurrent_microbatch"
+            ):
+                caught.append(event_msg)
+
+        add_callback_to_manager(record)
+
+        adapter.supports(Capability.MicrobatchConcurrency)
+
+        assert caught == [], (
+            "supports(MicrobatchConcurrency) must not fire BehaviorChangeEvent "
+            f"(fired {len(caught)} times)"
+        )


### PR DESCRIPTION
Fixes #1406.

`supports(Capability.MicrobatchConcurrency)` read the `use_concurrent_microbatch` behavior flag via `bool(...)`, which goes through the warning-firing `BehaviorFlagRendered.setting` path. dbt-core probes this capability on every parse (via `check_forcing_batch_concurrency`), so the one-shot `BehaviorChangeEvent` fired on every run regardless of whether the project contained microbatch models — breaking `--warn-error` builds.

Read via `.no_warn` instead — same gating, no event.

## Test plan
- [x] `hatch run unit` → 742 passed, 0 regressions
- [x] New `test_microbatch_concurrency_probe_does_not_warn`