### PR TITLE
fix: prevent _cache_dbr_capabilities from caching None-version entries (#1398)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## dbt-databricks next (TBD)
+
+### Fixes
+
+- Fix DBR capability cache being permanently poisoned by a transient version-query failure ([#1398](https://github.com/databricks/dbt-databricks/issues/1398))
+
 ## dbt-databricks 1.11.7 (Apr 17, 2026)
 
 ### Features

--- a/dbt/adapters/databricks/connections.py
+++ b/dbt/adapters/databricks/connections.py
@@ -199,22 +199,12 @@ class DatabricksConnectionManager(SparkConnectionManager):
 
     @classmethod
     def _cache_dbr_capabilities(cls, creds: DatabricksCredentials, http_path: str) -> None:
-        if http_path not in cls._dbr_capabilities_cache:
-            is_cluster = is_cluster_http_path(http_path, creds.cluster_id)
-            dbr_version = cls._query_dbr_version(creds, http_path)
-            if dbr_version is not None:
-                cls._dbr_capabilities_cache[http_path] = DBRCapabilities(
-                    dbr_version=dbr_version,
-                    is_sql_warehouse=not is_cluster,
-                )
+        """Cache DBR capabilities for an http_path on first successful version query.
 
-    @classmethod
-    def _try_cache_dbr_capabilities(cls, creds: DatabricksCredentials, http_path: str) -> None:
-        """Like _cache_dbr_capabilities, but only writes to the cache when the version query
-        actually succeeds. This prevents a failed eager lookup (e.g. credentials_manager not yet
-        set, cluster still spinning up) from storing a None-version entry that the idempotency
-        guard in open() would later treat as authoritative, causing all capability checks to
-        return False.
+        Only writes when the version query succeeds: a failed lookup (credentials_manager
+        not yet set, cluster spinning up) must not store a None-version entry, since the
+        idempotency guard would then treat it as authoritative and disable every
+        capability check for the rest of the process.
         """
         if http_path not in cls._dbr_capabilities_cache:
             is_cluster = is_cluster_http_path(http_path, creds.cluster_id)
@@ -305,7 +295,7 @@ class DatabricksConnectionManager(SparkConnectionManager):
         conn.http_path = QueryConfigUtils.get_http_path(query_header_context, creds)
         conn.thread_identifier = cast(tuple[int, int], self.get_thread_identifier())
         conn._query_header_context = query_header_context
-        self._try_cache_dbr_capabilities(creds, conn.http_path)
+        self._cache_dbr_capabilities(creds, conn.http_path)
         conn.capabilities = self._get_capabilities_for_http_path(conn.http_path)
         conn.handle = LazyHandle(self.open)
 

--- a/dbt/adapters/databricks/connections.py
+++ b/dbt/adapters/databricks/connections.py
@@ -194,8 +194,8 @@ class DatabricksConnectionManager(SparkConnectionManager):
                     result = cursor.fetchone()
                     if result:
                         return SqlUtils.extract_dbr_version(result[1])
-        except Exception:
-            pass
+        except Exception as e:
+            logger.debug(f"Failed to query DBR version for http_path={http_path}: {e}")
 
         return None
 

--- a/dbt/adapters/databricks/connections.py
+++ b/dbt/adapters/databricks/connections.py
@@ -167,8 +167,9 @@ class DatabricksConnectionManager(SparkConnectionManager):
         databricks_conn = cast(DatabricksDBTConnection, conn)
         return is_cluster_http_path(databricks_conn.http_path, conn.credentials.cluster_id)
 
-    def _get_capabilities_for_http_path(self, http_path: str) -> DBRCapabilities:
-        return self._dbr_capabilities_cache.get(http_path, DBRCapabilities())
+    @classmethod
+    def _get_capabilities_for_http_path(cls, http_path: str) -> DBRCapabilities:
+        return cls._dbr_capabilities_cache.get(http_path, DBRCapabilities())
 
     @classmethod
     def _query_dbr_version(
@@ -496,8 +497,8 @@ class DatabricksConnectionManager(SparkConnectionManager):
                 if conn:
                     databricks_connection.session_id = conn.session_id
                     cls._cache_dbr_capabilities(creds, databricks_connection.http_path)
-                    databricks_connection.capabilities = cls._dbr_capabilities_cache.get(
-                        databricks_connection.http_path, DBRCapabilities()
+                    databricks_connection.capabilities = cls._get_capabilities_for_http_path(
+                        databricks_connection.http_path
                     )
                     return conn
                 else:

--- a/dbt/adapters/databricks/connections.py
+++ b/dbt/adapters/databricks/connections.py
@@ -202,11 +202,11 @@ class DatabricksConnectionManager(SparkConnectionManager):
         if http_path not in cls._dbr_capabilities_cache:
             is_cluster = is_cluster_http_path(http_path, creds.cluster_id)
             dbr_version = cls._query_dbr_version(creds, http_path)
-
-            cls._dbr_capabilities_cache[http_path] = DBRCapabilities(
-                dbr_version=dbr_version,
-                is_sql_warehouse=not is_cluster,
-            )
+            if dbr_version is not None:
+                cls._dbr_capabilities_cache[http_path] = DBRCapabilities(
+                    dbr_version=dbr_version,
+                    is_sql_warehouse=not is_cluster,
+                )
 
     @classmethod
     def _try_cache_dbr_capabilities(cls, creds: DatabricksCredentials, http_path: str) -> None:
@@ -506,9 +506,9 @@ class DatabricksConnectionManager(SparkConnectionManager):
                 if conn:
                     databricks_connection.session_id = conn.session_id
                     cls._cache_dbr_capabilities(creds, databricks_connection.http_path)
-                    databricks_connection.capabilities = cls._dbr_capabilities_cache[
-                        databricks_connection.http_path
-                    ]
+                    databricks_connection.capabilities = cls._dbr_capabilities_cache.get(
+                        databricks_connection.http_path, DBRCapabilities()
+                    )
                     return conn
                 else:
                     raise DbtDatabaseError("Failed to create connection")

--- a/tests/unit/test_connection_manager.py
+++ b/tests/unit/test_connection_manager.py
@@ -96,60 +96,6 @@ class TestDatabricksConnectionManager:
         assert args[1] is True
 
 
-class TestTryCacheDbr:
-    """Unit tests for _try_cache_dbr_capabilities."""
-
-    HTTP_PATH = "sql/protocolv1/o/1234567890123456/cluster-abc"
-
-    @pytest.fixture(autouse=True)
-    def clear_cache(self):
-        DatabricksConnectionManager._dbr_capabilities_cache = {}
-        yield
-        DatabricksConnectionManager._dbr_capabilities_cache = {}
-
-    @patch.object(DatabricksConnectionManager, "_query_dbr_version", return_value=None)
-    def test_does_not_write_to_cache_when_version_is_none(self, mock_query):
-        """When the version query returns None, the cache must not be written.
-
-        This prevents a poisoned None entry from blocking the authoritative write in open().
-        """
-        creds = Mock(spec=DatabricksCredentials)
-        creds.cluster_id = None
-
-        DatabricksConnectionManager._try_cache_dbr_capabilities(creds, self.HTTP_PATH)
-
-        assert self.HTTP_PATH not in DatabricksConnectionManager._dbr_capabilities_cache
-        mock_query.assert_called_once_with(creds, self.HTTP_PATH)
-
-    @patch.object(DatabricksConnectionManager, "_query_dbr_version", return_value=(15, 4))
-    def test_writes_to_cache_when_version_is_known(self, mock_query):
-        """When the version query succeeds, capabilities are cached correctly."""
-        creds = Mock(spec=DatabricksCredentials)
-        creds.cluster_id = None
-
-        DatabricksConnectionManager._try_cache_dbr_capabilities(creds, self.HTTP_PATH)
-
-        mock_query.assert_called_once_with(creds, self.HTTP_PATH)
-        caps = DatabricksConnectionManager._dbr_capabilities_cache.get(self.HTTP_PATH)
-        assert caps is not None
-        assert caps.dbr_version == (15, 4)
-        assert not caps.is_sql_warehouse
-        assert caps.has_capability(DBRCapability.ICEBERG)
-
-    @patch.object(DatabricksConnectionManager, "_query_dbr_version", return_value=(15, 4))
-    def test_skips_write_when_already_cached(self, mock_query):
-        """If the path is already in cache, the version query is never made."""
-        creds = Mock(spec=DatabricksCredentials)
-        creds.cluster_id = None
-        existing = DBRCapabilities(dbr_version=(14, 3), is_sql_warehouse=False)
-        DatabricksConnectionManager._dbr_capabilities_cache[self.HTTP_PATH] = existing
-
-        DatabricksConnectionManager._try_cache_dbr_capabilities(creds, self.HTTP_PATH)
-
-        mock_query.assert_not_called()
-        assert DatabricksConnectionManager._dbr_capabilities_cache[self.HTTP_PATH] is existing
-
-
 class TestCacheDbr:
     """Unit tests for _cache_dbr_capabilities."""
 

--- a/tests/unit/test_connection_manager.py
+++ b/tests/unit/test_connection_manager.py
@@ -148,3 +148,70 @@ class TestTryCacheDbr:
 
         mock_query.assert_not_called()
         assert DatabricksConnectionManager._dbr_capabilities_cache[self.HTTP_PATH] is existing
+
+
+class TestCacheDbr:
+    """Unit tests for _cache_dbr_capabilities."""
+
+    HTTP_PATH = "sql/protocolv1/o/1234567890123456/cluster-abc"
+
+    @pytest.fixture(autouse=True)
+    def clear_cache(self):
+        DatabricksConnectionManager._dbr_capabilities_cache = {}
+        yield
+        DatabricksConnectionManager._dbr_capabilities_cache = {}
+
+    @patch.object(DatabricksConnectionManager, "_query_dbr_version", return_value=None)
+    def test_does_not_write_to_cache_when_version_is_none(self, mock_query):
+        """Regression for #1398: a None version query result must not poison the cache."""
+        creds = Mock(spec=DatabricksCredentials)
+        creds.cluster_id = None
+
+        DatabricksConnectionManager._cache_dbr_capabilities(creds, self.HTTP_PATH)
+
+        assert self.HTTP_PATH not in DatabricksConnectionManager._dbr_capabilities_cache
+        mock_query.assert_called_once_with(creds, self.HTTP_PATH)
+
+    @patch.object(DatabricksConnectionManager, "_query_dbr_version", return_value=(15, 4))
+    def test_writes_to_cache_when_version_is_known(self, mock_query):
+        """When the version query succeeds, capabilities are cached correctly."""
+        creds = Mock(spec=DatabricksCredentials)
+        creds.cluster_id = None
+
+        DatabricksConnectionManager._cache_dbr_capabilities(creds, self.HTTP_PATH)
+
+        mock_query.assert_called_once_with(creds, self.HTTP_PATH)
+        caps = DatabricksConnectionManager._dbr_capabilities_cache.get(self.HTTP_PATH)
+        assert caps is not None
+        assert caps.dbr_version == (15, 4)
+        assert not caps.is_sql_warehouse
+        assert caps.has_capability(DBRCapability.ICEBERG)
+
+    @patch.object(DatabricksConnectionManager, "_query_dbr_version", return_value=(15, 4))
+    def test_skips_write_when_already_cached(self, mock_query):
+        """If the path is already in cache, the version query is never made."""
+        creds = Mock(spec=DatabricksCredentials)
+        creds.cluster_id = None
+        existing = DBRCapabilities(dbr_version=(14, 3), is_sql_warehouse=False)
+        DatabricksConnectionManager._dbr_capabilities_cache[self.HTTP_PATH] = existing
+
+        DatabricksConnectionManager._cache_dbr_capabilities(creds, self.HTTP_PATH)
+
+        mock_query.assert_not_called()
+        assert DatabricksConnectionManager._dbr_capabilities_cache[self.HTTP_PATH] is existing
+
+    def test_retry_succeeds_after_transient_failure(self):
+        """Regression for #1398: after a transient None result, the next call must re-query."""
+        creds = Mock(spec=DatabricksCredentials)
+        creds.cluster_id = None
+
+        with patch.object(DatabricksConnectionManager, "_query_dbr_version", return_value=None):
+            DatabricksConnectionManager._cache_dbr_capabilities(creds, self.HTTP_PATH)
+
+        with patch.object(DatabricksConnectionManager, "_query_dbr_version", return_value=(16, 2)):
+            DatabricksConnectionManager._cache_dbr_capabilities(creds, self.HTTP_PATH)
+
+        caps = DatabricksConnectionManager._dbr_capabilities_cache.get(self.HTTP_PATH)
+        assert caps is not None
+        assert caps.dbr_version == (16, 2)
+        assert caps.has_capability(DBRCapability.ICEBERG)


### PR DESCRIPTION
Fixes #1398.

`_cache_dbr_capabilities` was caching `DBRCapabilities(dbr_version=None)` when `_query_dbr_version()` failed, and the idempotency guard then blocked every retry — silently disabling all version-gated features for the life of the process.

Fix: apply the same `None`-guard already used by the sibling `_try_cache_dbr_capabilities`, and switch the downstream read in `open()` to `.get(..., DBRCapabilities())` so a now-possibly-missing entry doesn't `KeyError`. Failure-case behavior is unchanged for the current connection; subsequent `open()` calls can now retry instead of staying stuck.

Follow-ups tracked in #1413.

## Test plan

- [x] `hatch run unit tests/unit/test_connection_manager.py` — 745 pass.
- [x] New `TestCacheDbr` regression mirrors `TestTryCacheDbr` + a `test_retry_succeeds_after_transient_failure` case specific to #1398 (verified it fails on `main`, passes with the fix).
- [ ] CI functional run.