### PR TITLE
test: UTF-8 round-trip regression for dbt seed

### DIFF
--- a/tests/functional/adapter/simple_seed/test_utf8_seed.py
+++ b/tests/functional/adapter/simple_seed/test_utf8_seed.py
@@ -1,0 +1,32 @@
+import pytest
+from dbt.tests import util
+
+from tests.functional.adapter.fixtures import MaterializationV2Mixin
+
+
+UTF8_DATA = {
+    "arabic": "مرحبا بالعالم",
+    "greek": "Γειά σου Κόσμε",
+    "chinese": "你好世界",
+    "emoji": "Hello 🌍 World ✨",
+    "mixed": "café naïve résumé — ",
+}
+SEED_CSV = "label,value\n" + "\n".join(f"{k},{v}" for k, v in UTF8_DATA.items())
+
+
+class TestUtf8SeedRoundTrip:
+    @pytest.fixture(scope="class")
+    def seeds(self):
+        return {"utf8_roundtrip.csv": SEED_CSV}
+
+    def test_utf8_roundtrip(self, project):
+        results = util.run_dbt(["seed"])
+        assert len(results) == 1
+
+        relation = util.relation_from_name(project.adapter, "utf8_roundtrip")
+        rows = project.run_sql(f"select label, value from {relation}", fetch="all")
+        assert dict(rows) == UTF8_DATA
+
+
+class TestUtf8SeedRoundTripV2(TestUtf8SeedRoundTrip, MaterializationV2Mixin):
+    pass

--- a/tests/functional/adapter/simple_seed/test_utf8_seed.py
+++ b/tests/functional/adapter/simple_seed/test_utf8_seed.py
@@ -3,7 +3,6 @@ from dbt.tests import util
 
 from tests.functional.adapter.fixtures import MaterializationV2Mixin
 
-
 UTF8_DATA = {
     "arabic": "مرحبا بالعالم",
     "greek": "Γειά σου Κόσμε",


### PR DESCRIPTION
## Summary

Adds a functional test that seeds a CSV containing Arabic, Greek, Chinese, emoji, and accented Latin, then asserts every cell round-trips byte-exact through the seed path. Covers both V1 and V2 materialization.

This guards the fix for #332 (non-ASCII characters being mangled on seed, reported against 1.4.3). The current parameterized-insert path (`adapter.add_query(sql, bindings=bindings, ...)` in `dbt/include/databricks/macros/materializations/seeds/helpers.sql`) handles UTF-8 correctly — this test locks that in.

## Test plan

- [x] `hatch run pytest tests/functional/adapter/simple_seed/test_utf8_seed.py -v` — 2 passed in ~36s against a live Databricks cluster (V1 + V2)

Closes #332.

This pull request and its description were written by Isaac.