### PR TITLE
ci: trigger integration tests on /integration-test comment + nightly main

### DIFF
--- a/.github/workflows/integration-trigger.yml
+++ b/.github/workflows/integration-trigger.yml
@@ -1,0 +1,88 @@
+# Integration Test Trigger
+#
+# Listens for `/integration-test` PR comments and dispatches the integration
+# test workflow against the PR head. Works uniformly for internal and forked
+# PRs because the dispatch runs in the main repo context (which has access to
+# the Databricks secrets).
+#
+# Authorization: only users whose author_association is OWNER, MEMBER, or
+# COLLABORATOR can trigger a run. Anyone else gets a reply comment explaining
+# that only maintainers can run this.
+name: Integration Test Trigger
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  pull-requests: write
+  actions: write
+  contents: read
+
+jobs:
+  dispatch:
+    # Exact command match, or the command followed by whitespace (so maintainers
+    # can add context like `/integration-test please retry the sqlw flake`) —
+    # never matches `/integration-test-foo`.
+    if: |
+      github.event.issue.pull_request &&
+      (github.event.comment.body == '/integration-test' || startsWith(github.event.comment.body, '/integration-test ')) &&
+      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
+    runs-on:
+      group: databricks-protected-runner-group
+      labels: linux-ubuntu-latest
+    steps:
+      - name: React to comment
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b  # v7
+        with:
+          script: |
+            await github.rest.reactions.createForIssueComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+              content: 'rocket',
+            });
+
+      - name: Dispatch integration workflow
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b  # v7
+        with:
+          script: |
+            const prNumber = String(context.payload.issue.number);
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'integration.yml',
+              ref: 'main',
+              inputs: { pr_number: prNumber },
+            });
+            const actionsUrl =
+              `https://github.com/${context.repo.owner}/${context.repo.repo}` +
+              `/actions/workflows/integration.yml`;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.issue.number,
+              body: `Integration tests dispatched for PR #${prNumber} by @${context.payload.comment.user.login}. ` +
+                    `Track progress in the [Actions tab](${actionsUrl}).`,
+            });
+
+  reject:
+    if: |
+      github.event.issue.pull_request &&
+      (github.event.comment.body == '/integration-test' || startsWith(github.event.comment.body, '/integration-test ')) &&
+      !contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
+    runs-on:
+      group: databricks-protected-runner-group
+      labels: linux-ubuntu-latest
+    steps:
+      - name: Reply with maintainer-only notice
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b  # v7
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.issue.number,
+              body: `Sorry @${context.payload.comment.user.login}, only repo maintainers can trigger integration tests. ` +
+                    `A maintainer will run \`/integration-test\` once they've reviewed the changes.`,
+            });

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,33 +1,28 @@
 # Integration Tests for dbt-databricks
 #
-# This workflow runs integration tests that require Databricks secrets.
+# This workflow runs integration tests that require Databricks secrets. It is
+# never triggered by PR events directly — every PR-based run is the result of
+# a maintainer's explicit decision.
 #
-# For testing external contributions (PRs from forks):
-# 1. Go to Actions tab -> Integration Tests -> Run workflow
-# 2. Enter the PR number in the 'pr_number' field
-# 3. Click "Run workflow"
+# Triggering:
+# 1. On a PR (internal OR fork): a maintainer comments `/integration-test`.
+#    The integration-trigger workflow validates the comment author and
+#    dispatches this workflow with the PR number. The run posts a result
+#    comment back to the PR when the matrix completes.
+# 2. Manually from the Actions tab (workflow_dispatch) with pr_number or
+#    git_ref, for ad-hoc testing.
+# 3. Nightly on `main` at 03:00 IST (21:30 UTC). The schedule is skipped if
+#    the current main SHA has already had a successful integration run.
 #
-# This approach is secure because:
-# - The workflow runs in the databricks repository context (access to secrets)
-# - The code to test is explicitly specified by maintainers
-# - No automatic execution of untrusted code with secrets
+# Security: PR-triggered runs are gated on maintainer comment authorization;
+# fork-PR code runs in the main repo context (access to secrets) only because
+# a maintainer explicitly approved it via the slash command.
 name: Integration Tests
 on:
-  pull_request:
-    # Run on PRs to the same repository (internal contributors)
-    paths-ignore:
-      - "**.MD"
-      - "**.md"
-      - "adapters/databricks/__version__.py"
-      - "tests/unit/**"
-      - ".github/workflows/main.yml"
-      - ".github/workflows/stale.yml"
-
   workflow_dispatch:
-    # Manual triggering for external contributions and ad-hoc testing
     inputs:
       pr_number:
-        description: "PR number to test (for external contributions)"
+        description: "PR number to test (for external contributions and ad-hoc runs)"
         required: false
         type: string
       git_ref:
@@ -35,22 +30,60 @@ on:
         required: false
         type: string
 
+  schedule:
+    - cron: "30 21 * * *"   # 21:30 UTC = 03:00 IST
+
 permissions:
   id-token: write
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # Each PR and each ad-hoc git_ref gets its own concurrency group so parallel
+  # dispatches don't cancel each other. Schedule runs share the main group.
+  group: ${{ github.workflow }}-${{ inputs.pr_number || inputs.git_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:
+  # Schedule-only gate: skip the nightly run if the current main SHA has
+  # already had a successful integration run. Does not run for
+  # workflow_dispatch, so PR-triggered dispatches skip the ~30s runner spin.
+  check-nightly-needed:
+    if: github.event_name == 'schedule'
+    runs-on:
+      group: databricks-protected-runner-group
+      labels: linux-ubuntu-latest
+    outputs:
+      should_run: ${{ steps.decide.outputs.should_run }}
+    steps:
+      - name: Decide whether to run
+        id: decide
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b  # v7
+        with:
+          script: |
+            const runs = await github.rest.actions.listWorkflowRuns({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'integration.yml',
+              branch: 'main',
+              status: 'success',
+              head_sha: context.sha,
+            });
+            core.info(`main SHA=${context.sha}, prior successful runs=${runs.data.total_count}`);
+            core.setOutput('should_run', runs.data.total_count > 0 ? 'false' : 'true');
+
   run-uc-cluster-e2e-tests:
+    needs: check-nightly-needed
+    # On workflow_dispatch the gate is skipped (schedule-only), so use !cancelled()
+    # to let the job run; on schedule it runs iff the gate says should_run.
+    if: |
+      !cancelled() && (
+        github.event_name != 'schedule' ||
+        needs.check-nightly-needed.outputs.should_run == 'true'
+      )
     runs-on:
       group: databricks-protected-runner-group
       labels: linux-ubuntu-latest
     environment: azure-prod
-    # Only run on internal PRs or manual dispatch - skip external forks to avoid secret access failures
-    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
     env:
       DBT_DATABRICKS_HOST_NAME: ${{ secrets.DATABRICKS_HOST }}
       DBT_DATABRICKS_CLIENT_ID: ${{ secrets.TEST_PECO_SP_ID }}
@@ -63,11 +96,10 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
-          # For pull_request: checkout the PR head commit
-          # For workflow_dispatch with pr_number: checkout that PR's head
+          # For workflow_dispatch with pr_number: checkout that PR's head (internal or fork)
           # For workflow_dispatch with git_ref: checkout that ref
-          # Otherwise: checkout current branch
-          ref: ${{ github.event.pull_request.head.sha || (github.event.inputs.pr_number && format('refs/pull/{0}/head', github.event.inputs.pr_number)) || github.event.inputs.git_ref || github.ref }}
+          # For schedule: falls through to github.ref (refs/heads/main)
+          ref: ${{ (github.event.inputs.pr_number && format('refs/pull/{0}/head', github.event.inputs.pr_number)) || github.event.inputs.git_ref || github.ref }}
           # Fetch enough history for PR testing
           fetch-depth: 0
 
@@ -104,12 +136,18 @@ jobs:
           retention-days: 5
 
   run-sqlwarehouse-e2e-tests:
+    needs: check-nightly-needed
+    # On workflow_dispatch the gate is skipped (schedule-only), so use !cancelled()
+    # to let the job run; on schedule it runs iff the gate says should_run.
+    if: |
+      !cancelled() && (
+        github.event_name != 'schedule' ||
+        needs.check-nightly-needed.outputs.should_run == 'true'
+      )
     runs-on:
       group: databricks-protected-runner-group
       labels: linux-ubuntu-latest
     environment: azure-prod
-    # Only run on internal PRs or manual dispatch - skip external forks to avoid secret access failures
-    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
     env:
       DBT_DATABRICKS_HOST_NAME: ${{ secrets.DATABRICKS_HOST }}
       DBT_DATABRICKS_CLIENT_ID: ${{ secrets.TEST_PECO_SP_ID }}
@@ -123,11 +161,10 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
-          # For pull_request: checkout the PR head commit
-          # For workflow_dispatch with pr_number: checkout that PR's head
+          # For workflow_dispatch with pr_number: checkout that PR's head (internal or fork)
           # For workflow_dispatch with git_ref: checkout that ref
-          # Otherwise: checkout current branch
-          ref: ${{ github.event.pull_request.head.sha || (github.event.inputs.pr_number && format('refs/pull/{0}/head', github.event.inputs.pr_number)) || github.event.inputs.git_ref || github.ref }}
+          # For schedule: falls through to github.ref (refs/heads/main)
+          ref: ${{ (github.event.inputs.pr_number && format('refs/pull/{0}/head', github.event.inputs.pr_number)) || github.event.inputs.git_ref || github.ref }}
           # Fetch enough history for PR testing
           fetch-depth: 0
 
@@ -164,12 +201,18 @@ jobs:
           retention-days: 5
 
   run-cluster-e2e-tests:
+    needs: check-nightly-needed
+    # On workflow_dispatch the gate is skipped (schedule-only), so use !cancelled()
+    # to let the job run; on schedule it runs iff the gate says should_run.
+    if: |
+      !cancelled() && (
+        github.event_name != 'schedule' ||
+        needs.check-nightly-needed.outputs.should_run == 'true'
+      )
     runs-on:
       group: databricks-protected-runner-group
       labels: linux-ubuntu-latest
     environment: azure-prod
-    # Only run on internal PRs or manual dispatch - skip external forks to avoid secret access failures
-    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
     env:
       DBT_DATABRICKS_HOST_NAME: ${{ secrets.DATABRICKS_HOST }}
       DBT_DATABRICKS_CLIENT_ID: ${{ secrets.TEST_PECO_SP_ID }}
@@ -181,11 +224,10 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
-          # For pull_request: checkout the PR head commit
-          # For workflow_dispatch with pr_number: checkout that PR's head
+          # For workflow_dispatch with pr_number: checkout that PR's head (internal or fork)
           # For workflow_dispatch with git_ref: checkout that ref
-          # Otherwise: checkout current branch
-          ref: ${{ github.event.pull_request.head.sha || (github.event.inputs.pr_number && format('refs/pull/{0}/head', github.event.inputs.pr_number)) || github.event.inputs.git_ref || github.ref }}
+          # For schedule: falls through to github.ref (refs/heads/main)
+          ref: ${{ (github.event.inputs.pr_number && format('refs/pull/{0}/head', github.event.inputs.pr_number)) || github.event.inputs.git_ref || github.ref }}
           # Fetch enough history for PR testing
           fetch-depth: 0
 
@@ -220,3 +262,43 @@ jobs:
           name: cluster-test-logs
           path: logs/
           retention-days: 5
+
+  report-status:
+    needs:
+      - run-uc-cluster-e2e-tests
+      - run-sqlwarehouse-e2e-tests
+      - run-cluster-e2e-tests
+    if: always() && github.event_name == 'workflow_dispatch' && inputs.pr_number != ''
+    runs-on:
+      group: databricks-protected-runner-group
+      labels: linux-ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Post result comment
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b  # v7
+        env:
+          PR_NUMBER: ${{ inputs.pr_number }}
+          UC_RESULT: ${{ needs.run-uc-cluster-e2e-tests.result }}
+          SQLW_RESULT: ${{ needs.run-sqlwarehouse-e2e-tests.result }}
+          CLUSTER_RESULT: ${{ needs.run-cluster-e2e-tests.result }}
+        with:
+          script: |
+            const ICONS = { success: ':white_check_mark:', skipped: ':fast_forward:' };
+            const results = {
+              'UC cluster':          process.env.UC_RESULT,
+              'SQL warehouse':       process.env.SQLW_RESULT,
+              'All-purpose cluster': process.env.CLUSTER_RESULT,
+            };
+            const line = Object.entries(results)
+              .map(([name, r]) => `${name} ${ICONS[r] || ':x:'} ${r}`)
+              .join(' · ');
+            const runUrl =
+              `https://github.com/${context.repo.owner}/${context.repo.repo}` +
+              `/actions/runs/${context.runId}`;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: parseInt(process.env.PR_NUMBER, 10),
+              body: `Integration results for PR #${process.env.PR_NUMBER} — ${line}\n\n[Run details](${runUrl}).`,
+            });

--- a/CONTRIBUTING.MD
+++ b/CONTRIBUTING.MD
@@ -24,19 +24,19 @@ If it is appropriate to write a design document, the document must be hosted eit
 
 ## Pull request review process
 
-dbt-databricks uses a **two-step review process** to merge PRs to `main`. We first squash the patch onto a staging branch so that we can securely run our full matrix of integration tests against a real Databricks workspace. Then we merge the staging branch to `main`.
-
-> **Note:** When you create a pull request we recommend that you _[Allow Edits from Maintainers]_. This smooths our two-step process and also lets your reviewer easily commit minor fixes or changes.
+When you open a PR, the unit-test / lint / build checks run automatically. The full integration test matrix (against a real Databricks workspace) is **not** run automatically — it's an explicit maintainer decision, because those tests require compute resources.
 
 A dbt-databricks maintainer will review your PR and may suggest changes for style and clarity, or they may request that you add unit or integration tests.
 
-Once your patch is approved, a maintainer will create a staging branch and either you or the maintainer (if you allowed edits from maintainers) will change the base branch of your PR to the staging branch. Then a maintainer will squash and merge the PR into the staging branch.
+> **Note:** When you create a pull request we recommend that you _[Allow Edits from Maintainers]_ so a reviewer can easily commit minor fixes.
 
-dbt-databricks uses staging branches to run our full matrix of functional and integration tests via Github Actions. This extra step is required for security because GH Action workflows that run on pull requests from forks can't access our testing Databricks workspace.
+When the reviewer is ready to run the integration matrix, they'll comment `/integration-test` on the PR. This works the same way for PRs from forks — the command runs the tests in the main repo context so they can use the Databricks workspace. Only repo maintainers can issue the command; comments from other users get a reply explaining this.
 
-If the functional or integration tests fail as a result of your change, a maintainer will work with you to fix it _on your fork_ and then repeat this step.
+The PR will receive a reply comment when the dispatch succeeds and a follow-up comment with the per-job pass/fail when the run completes.
 
-Once all tests pass a maintainer will rebase and merge your change to `main` so that your authorship is maintained in our commit history and GitHub statistics.
+If the integration tests fail as a result of your change, a maintainer will work with you to fix it _on your fork_ and re-run `/integration-test`.
+
+Once all tests pass a maintainer will rebase and merge your change to `main` so that your authorship is maintained in our commit history and GitHub statistics. `main` is additionally covered by a nightly integration run that skips itself if the branch hasn't advanced since the last green run.
 
 ---
 
@@ -143,7 +143,7 @@ Update `test.env` with the relevant HTTP paths and tokens.
 ### Please test what you can
 
 We understand that not every contributor will have all three types of compute resources in their Databricks workspace.
-For this reason, once a change has been reviewed and merged into a staging branch, we will run the full matrix of tests against our testing workspace at our expense (see the [pull request review process](#pull-request-review-process) for more detail).
+For this reason, once a change has been reviewed, a maintainer will run the full matrix of tests against our testing workspace at our expense via the `/integration-test` comment command (see the [pull request review process](#pull-request-review-process) for more detail).
 
 That said, we ask that you include integration tests where relevant and that you indicate in your pull request description the environment type(s) you tested the change against.
 


### PR DESCRIPTION
## Summary

Replaces the automatic on-PR integration test run with two explicit triggers, so the expensive warehouse-backed tests are only spun up when a maintainer opts in (or a nightly safety net fires on `main`).

- **`/integration-test` PR comment** — new `integration-trigger.yml` listens for the command, authorizes via `author_association` (`OWNER` / `MEMBER` / `COLLABORATOR`), reacts with 🚀, dispatches `integration.yml` with the PR number, and posts a reply linking the run. Non-maintainers get a comment explaining only maintainers can trigger it. Works uniformly for internal *and* forked PRs — the command runs in the main repo context so fork code still gets the workspace secrets, but only after a maintainer's explicit dispatch.
- **Nightly schedule on `main` at 03:00 IST** (cron `30 21 * * *`). A `check-nightly-needed` gate short-circuits via `head_sha:` filter on prior successful runs — if the current `main` SHA has already had a green run, the three integration jobs are skipped. The gate only runs for `schedule` events, so PR-triggered dispatches don't pay the ~30s runner-spin cost.
- **`report-status` job** in `integration.yml` posts a per-job pass/fail comment back to the PR when dispatched with `pr_number`. `if: always()` so failures still report.

`CONTRIBUTING.MD` is updated to describe the new flow (and drop the now-obsolete staging-branch language around integration testing).