### PR TITLE
fix: warn on contract.enforced=true for materialized_view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## dbt-databricks 1.11.8 (TBD)
+
+### Fixes
+
+- Warn when `contract.enforced: true` is set on a `materialized_view` model ([#1279](https://github.com/databricks/dbt-databricks/issues/1279))
+
 ## dbt-databricks 1.11.7 (Apr 17, 2026)
 
 ### Features

--- a/dbt/include/databricks/macros/relations/materialized_view/create.sql
+++ b/dbt/include/databricks/macros/relations/materialized_view/create.sql
@@ -24,6 +24,9 @@
   {%- set model_columns = model.get('columns', {}) -%}
   {%- set contract_config = config.get('contract') -%}
   {%- if contract_config and contract_config.enforced -%}
+    {%- do exceptions.warn(
+         "model '" ~ model.name ~ "' sets contract.enforced=true, but contracts are not supported for materialized_view. See https://docs.getdbt.com/docs/mesh/govern/model-contracts"
+       ) -%}
     {%- set model_constraints = model.get('constraints', []) -%}
   {%- else -%}
     {%- set model_constraints = [] -%}

--- a/dbt/include/databricks/macros/relations/materialized_view/create.sql
+++ b/dbt/include/databricks/macros/relations/materialized_view/create.sql
@@ -25,7 +25,7 @@
   {%- set contract_config = config.get('contract') -%}
   {%- if contract_config and contract_config.enforced -%}
     {%- do exceptions.warn(
-         "model '" ~ model.name ~ "' sets contract.enforced=true, but contracts are not supported for materialized_view. See https://docs.getdbt.com/docs/mesh/govern/model-contracts"
+         "contract.enforced=true on materialized_view '" ~ model.name ~ "': not supported by dbt (https://docs.getdbt.com/docs/mesh/govern/model-contracts). dbt-databricks provides best-effort support that may change without notice."
        ) -%}
     {%- set model_constraints = model.get('constraints', []) -%}
   {%- else -%}


### PR DESCRIPTION
Resolves #1279

Upstream dbt does not support contracts on materialized views ([docs](https://docs.getdbt.com/docs/mesh/govern/model-contracts)). dbt-databricks was silently accepting `contract.enforced: true`, hiding yml/SQL drift. This PR emits a warning pointing at the dbt docs. Strictly additive; no existing build outcome changes.

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md`