### PR TITLE
docs: add explicit functional vs unit test scope rules to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,6 +85,12 @@ hatch run pytest path/to/test_file.py::TestClass::test_method -v
    - Require live Databricks workspace
    - Run with: `hatch run cluster-e2e` (or `uc-cluster-e2e`, `sqlw-e2e`)
 
+### What to Assert in Each Test Type
+
+Functional tests assert user-visible outcomes: the model materializes and the resulting rows are correct. Unit and macro tests assert implementation details like the exact SQL a macro generates or the exact text of a warning.
+
+When there is nothing meaningful to assert in either category, the change does not need a test.
+
 ### Test Environments
 
 - **HMS Cluster** (`databricks_cluster`): Legacy Hive Metastore


### PR DESCRIPTION
Makes the unit vs functional test split explicit in AGENTS.md. The current section distinguishes the two by where they live and how they run, but the rule for *what each type should assert* was conveyed only through examples. A contributor could reasonably put specific-warning or compiled-SQL assertions in a functional test without tripping any review signal (surfaced in #1421 review).

Adds two short paragraphs: the principle (functional = outcomes, unit = specifics) and a note that trivial macro additions do not need a test.

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.

> Docs-only change; CHANGELOG entry intentionally omitted.