### PR TITLE
fix: stop emitting insert_overwrite noise warning on every run (#1305)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - Validate relation identifier length at creation time and raise a clear error when it exceeds Databricks' 255-character limit ([#1309](https://github.com/databricks/dbt-databricks/issues/1309))
 - Fix spurious `MicrobatchConcurrency` behavior-change warning firing on every run regardless of whether the project contained microbatch models ([#1406](https://github.com/databricks/dbt-databricks/issues/1406))
+- Stop emitting the `insert_overwrite will perform a dynamic insert overwrite` warning on every `insert_overwrite` run on SQL warehouses; warn instead only when `use_replace_on_for_insert_overwrite` is enabled but the cluster's DBR version does not support REPLACE ON ([#1305](https://github.com/databricks/dbt-databricks/issues/1305))
 
 ## dbt-databricks 1.11.7 (Apr 17, 2026)
 

--- a/dbt/include/databricks/macros/materializations/incremental/strategies.sql
+++ b/dbt/include/databricks/macros/materializations/incremental/strategies.sql
@@ -45,7 +45,6 @@
             select * from {{ source_relation }}
         {%- endif -%}
     {%- else -%}
-        {#-- SQL Warehouses: REPLACE ON is always supported; the behavior flag toggles opt-in --#}
         {%- if adapter.behavior.use_replace_on_for_insert_overwrite -%}
             {{ get_insert_replace_on_sql(source_relation, target_relation) }}
         {%- else -%}

--- a/dbt/include/databricks/macros/materializations/incremental/strategies.sql
+++ b/dbt/include/databricks/macros/materializations/incremental/strategies.sql
@@ -35,7 +35,9 @@
         {%- if adapter.has_dbr_capability('replace_on') -%}
             {{ get_insert_replace_on_sql(source_relation, target_relation) }}
         {%- else -%}
-            {#-- Use legacy DPO INSERT OVERWRITE for older DBR versions --#}
+            {%- if adapter.behavior.use_replace_on_for_insert_overwrite -%}
+                {{ exceptions.warn("insert_overwrite: use_replace_on_for_insert_overwrite is enabled but this cluster's DBR version does not support REPLACE ON (requires DBR 17.1+). Falling back to legacy INSERT OVERWRITE.") }}
+            {%- endif -%}
             {%- set has_insert_by_name = adapter.has_dbr_capability('insert_by_name') -%}
             insert overwrite table {{ target_relation }}
             {{ partition_cols(label="partition") }}
@@ -43,10 +45,8 @@
             select * from {{ source_relation }}
         {%- endif -%}
     {%- else -%}
-        {#-- SQL Warehouses: Check behavior flag first --#}
+        {#-- SQL Warehouses: REPLACE ON is always supported; the behavior flag toggles opt-in --#}
         {%- if adapter.behavior.use_replace_on_for_insert_overwrite -%}
-            {#-- Behavior flag enabled, SQL warehouses are assumed capable --#}
-            {{ exceptions.warn("insert_overwrite will perform a dynamic insert overwrite. If you depended on the legacy truncation behavior, consider disabling the behavior flag use_replace_on_for_insert_overwrite.") }}
             {{ get_insert_replace_on_sql(source_relation, target_relation) }}
         {%- else -%}
             {#-- Behavior flag disabled, use legacy DPO INSERT OVERWRITE --#}

--- a/tests/unit/macros/materializations/incremental/test_insert_overwrite_macros.py
+++ b/tests/unit/macros/materializations/incremental/test_insert_overwrite_macros.py
@@ -238,16 +238,17 @@ class TestInsertOverwriteMacros(MacroTestBase):
         self.assert_sql_equal(result, expected_sql)
 
     @pytest.mark.parametrize(
-        "use_replace_on_flag",
+        "use_replace_on_flag,expect_warning",
         [
-            False,  # Behavior flag disabled
-            True,  # Behavior flag enabled
+            (False, False),  # Flag disabled: user did not opt in, no warning
+            (True, True),  # Flag enabled: user expected REPLACE ON, warn about fallback
         ],
     )
     def test_get_insert_overwrite_sql__old_dbr_cluster_behavior_flag(
-        self, template, context, config, use_replace_on_flag
+        self, template, context, config, use_replace_on_flag, expect_warning
     ):
-        """Old DBR cluster always uses traditional INSERT OVERWRITE regardless of behavior flag"""
+        """Old DBR cluster always uses legacy INSERT OVERWRITE SQL regardless of flag,
+        but warns when the user opted into REPLACE ON via the flag."""
 
         # Mock has_capability to NOT support REPLACE ON (DBR < 17.1)
         def has_dbr_capability_side_effect(capability_name):
@@ -262,6 +263,7 @@ class TestInsertOverwriteMacros(MacroTestBase):
         context["adapter"].is_cluster.return_value = True
         # Set the behavior flag (should not affect old DBR clusters)
         context["adapter"].behavior.use_replace_on_for_insert_overwrite = use_replace_on_flag
+        context["exceptions"].warn.reset_mock()
         config["partition_by"] = ["a"]
 
         source_relation = Mock()
@@ -276,15 +278,18 @@ class TestInsertOverwriteMacros(MacroTestBase):
             target_relation,
         )
 
-        # Verify it always uses traditional INSERT OVERWRITE syntax for old DBR cluster
         expected_sql = """
             insert overwrite table target_table
             partition (a)
             by name
             select * from source_table
         """
-
         self.assert_sql_equal(result, expected_sql)
+
+        if expect_warning:
+            context["exceptions"].warn.assert_called_once()
+        else:
+            context["exceptions"].warn.assert_not_called()
 
     @pytest.mark.parametrize(
         "use_replace_on_flag,expected_sql",
@@ -311,7 +316,8 @@ class TestInsertOverwriteMacros(MacroTestBase):
     def test_get_insert_overwrite_sql__sql_warehouse_behavior_flag(
         self, template, context, config, use_replace_on_flag, expected_sql
     ):
-        """Test that SQL warehouse behavior flag controls INSERT OVERWRITE syntax"""
+        """Test that SQL warehouse behavior flag controls INSERT OVERWRITE syntax,
+        and that no warning is emitted on either path (regression for #1305)."""
 
         # Mock has_capability (SQL warehouses are assumed capable)
         def has_dbr_capability_side_effect(capability_name):
@@ -326,6 +332,7 @@ class TestInsertOverwriteMacros(MacroTestBase):
         context["adapter"].is_cluster.return_value = False
         # Set the behavior flag
         context["adapter"].behavior.use_replace_on_for_insert_overwrite = use_replace_on_flag
+        context["exceptions"].warn.reset_mock()
         config["partition_by"] = ["a"]
 
         source_relation = Mock()
@@ -341,3 +348,4 @@ class TestInsertOverwriteMacros(MacroTestBase):
         )
 
         self.assert_sql_equal(result, expected_sql)
+        context["exceptions"].warn.assert_not_called()


### PR DESCRIPTION
## Summary

Fixes [#1305](https://github.com/databricks/dbt-databricks/issues/1305) partially

Every `insert_overwrite` run on a SQL warehouse was emitting:

> insert_overwrite will perform a dynamic insert overwrite. If you depended on the legacy truncation behavior, consider disabling the behavior flag use_replace_on_for_insert_overwrite.

Once a user is on the default `use_replace_on_for_insert_overwrite=True`, this carries no actionable signal — it just spams the run log on every model.

## Change

- Drop the unconditional warning on the SQL-warehouse + flag-enabled path. SQL warehouses always support `REPLACE ON`, so there's nothing to warn about.
- Add a targeted warning for the only case where the flag's intent can't be honored: cluster compute on DBR < 17.1 with `use_replace_on_for_insert_overwrite=True`. There, the user opted into REPLACE ON but the runtime falls back to legacy `INSERT OVERWRITE` — that mismatch is worth surfacing.
- Emitted SQL is unchanged.

## Test plan

- [x] Unit tests cover both new behaviors:
  - SQL warehouse + flag toggled either way: no warning (regression for #1305)
  - Cluster + DBR<17.1: warning iff flag is enabled
- [x] Verified locally against a real SQL warehouse: `insert_overwrite` runs no longer emit the warning. Pre-fix code with the same harness confirmed the warning fired (test failed); fixed code confirmed silence (test passed).
- [x] `TestInsertOverwriteWithPartitionsDelta` still passes — no behavioral regression.