### PR TITLE
test: regression test for --empty with dbt_utils.union_relations (#807)

### DIFF
--- a/tests/functional/adapter/empty/test_empty.py
+++ b/tests/functional/adapter/empty/test_empty.py
@@ -1,4 +1,6 @@
+import pytest
 from dbt.tests.adapter.empty.test_empty import BaseTestEmpty, BaseTestEmptyInlineSourceRef
+from dbt.tests.util import run_dbt
 
 
 class TestDatabricksEmpty(BaseTestEmpty):
@@ -7,3 +9,35 @@ class TestDatabricksEmpty(BaseTestEmpty):
 
 class TestDatabricksEmptyInlineSourceRef(BaseTestEmptyInlineSourceRef):
     pass
+
+
+_my_model_sql = "select 1 as id"
+
+_my_model_unioned_sql = """
+with unioned as (
+    {{ dbt_utils.union_relations(relations=[ref("my_model")]) }}
+)
+select * from unioned
+"""
+
+
+class TestDatabricksEmptyWithUnionRelations:
+    """`--empty` must not break dbt_utils.union_relations introspection."""
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "my_model.sql": _my_model_sql,
+            "my_model_unioned.sql": _my_model_unioned_sql,
+        }
+
+    @pytest.fixture(scope="class")
+    def packages(self):
+        return {"packages": [{"package": "dbt-labs/dbt_utils", "version": "1.3.0"}]}
+
+    def test_union_relations_succeeds(self, project):
+        run_dbt(["deps"])
+        results = run_dbt(["run", "-s", "+my_model_unioned", "--empty"])
+        assert len(results) == 2
+        for r in results:
+            assert r.status == "success", f"{r.node.name} failed: {r.message}"


### PR DESCRIPTION
## Summary

Regression test locking in #903's fix for #807: `dbt run --empty` on a model using `dbt_utils.union_relations` no longer fails with `PARSE_SYNTAX_ERROR` from `DESCRIBE TABLE (select * from ... limit 0)`.

## Test plan

- [x] Passes against live cluster