### PR TITLE
test: add replace_where coverage to incremental column-order tests

### DIFF
--- a/tests/functional/adapter/incremental/test_incremental_column_order.py
+++ b/tests/functional/adapter/incremental/test_incremental_column_order.py
@@ -202,3 +202,31 @@ class TestIncrementalColumnOrderInsertOverwriteV2(
                 "+partition_by": "status",
             }
         }
+
+
+class TestIncrementalColumnOrderReplaceWhere(TestIncrementalColumnOrderBase):
+    """Test column order with replace_where strategy"""
+
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {
+            "models": {
+                "+incremental_strategy": "replace_where",
+                "+incremental_predicates": "id is not null",
+            }
+        }
+
+
+class TestIncrementalColumnOrderReplaceWhereV2(
+    MaterializationV2Mixin, TestIncrementalColumnOrderBase
+):
+    """Test column order with replace_where strategy (V2 materialization)"""
+
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {
+            "models": {
+                "+incremental_strategy": "replace_where",
+                "+incremental_predicates": "id is not null",
+            }
+        }


### PR DESCRIPTION
Closes regression-coverage gap from #1289 / #1348. Adds two test classes mirroring the existing merge / append / insert_overwrite pattern.