### PR TITLE
fix: suppress warning on materialization v2 behavior flags.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Validate relation identifier length at creation time and raise a clear error when it exceeds Databricks' 255-character limit ([#1309](https://github.com/databricks/dbt-databricks/issues/1309))
 - Fix spurious `MicrobatchConcurrency` behavior-change warning firing on every run regardless of whether the project contained microbatch models ([#1406](https://github.com/databricks/dbt-databricks/issues/1406))
 - Fix DBR capability cache being permanently poisoned by a transient version-query failure ([#1398](https://github.com/databricks/dbt-databricks/issues/1398))
+- Fix spurious `use_materialization_v2` behavior-change warning firing on table, view, seed, and incremental materializations ([#1089](https://github.com/databricks/dbt-databricks/issues/1089))
 
 ## dbt-databricks 1.11.7 (Apr 17, 2026)
 

--- a/dbt/adapters/databricks/impl.py
+++ b/dbt/adapters/databricks/impl.py
@@ -770,6 +770,20 @@ class DatabricksAdapter(SparkAdapter):
             as_dict["column_type"] = as_dict.pop("dtype")
             yield as_dict
 
+    @available
+    def get_behavior_flag_no_warn(self, behavior_flag_name: str) -> bool:
+        """Get the value of a behavior flag without triggering a warning.
+
+        dbt logs a warning the first time a behavior flag with a False value is accessed. Use
+        this method to access the value of a behavior flag without triggering a warning.
+
+        Decorated with `@available` so that Jinja macros can call it via the
+        `RuntimeDatabaseWrapper` exposed in the dbt runtime context.
+        """
+        # As intended - This method will error out if the behavior flag is missing.
+        behavior_flag = getattr(self.behavior, behavior_flag_name)
+        return behavior_flag.no_warn
+
     def add_query(
         self,
         sql: str,

--- a/dbt/adapters/databricks/impl.py
+++ b/dbt/adapters/databricks/impl.py
@@ -792,7 +792,6 @@ class DatabricksAdapter(SparkAdapter):
             as_dict["column_type"] = as_dict.pop("dtype")
             yield as_dict
 
-
     @available
     def get_behavior_flag_no_warn(self, behavior_flag_name: str) -> bool:
         """Get the value of a behavior flag without triggering a warning.

--- a/dbt/include/databricks/macros/materializations/incremental/incremental.sql
+++ b/dbt/include/databricks/macros/materializations/incremental/incremental.sql
@@ -16,7 +16,7 @@
   {% set is_replaceable_format = is_delta or is_iceberg %}
   {% set compiled_code = adapter.clean_sql(model['compiled_code']) %}
 
-  {% if adapter.behavior.use_materialization_v2 %}
+  {% if adapter.get_behavior_flag_no_warn('use_materialization_v2') %}
     {{ log("USING V2 MATERIALIZATION") }}
     {#-- Set vars --#}
     {% set safe_create = config.get('use_safer_relation_operations', False) | as_bool  %}

--- a/dbt/include/databricks/macros/materializations/seeds/seeds.sql
+++ b/dbt/include/databricks/macros/materializations/seeds/seeds.sql
@@ -1,7 +1,7 @@
 {% materialization seed, adapter='databricks' %}
   {% set target_relation = this.incorporate(type='table') %}
 
-  {% if adapter.behavior.use_materialization_v2 %}
+  {% if adapter.get_behavior_flag_no_warn('use_materialization_v2') %}
     {{ create_seed_v2(target_relation) }}
   {% else %}
     {{ create_seed_v1(target_relation) }}

--- a/dbt/include/databricks/macros/materializations/table.sql
+++ b/dbt/include/databricks/macros/materializations/table.sql
@@ -10,7 +10,7 @@
   {% set target_relation = this.incorporate(type='table') %}
   {% set compiled_code = adapter.clean_sql(compiled_code) %}
 
-  {% if adapter.behavior.use_materialization_v2 %}
+  {% if adapter.get_behavior_flag_no_warn('use_materialization_v2') %}
     {% set intermediate_relation = make_intermediate_relation(target_relation) %}
     {% set staging_relation = make_staging_relation(target_relation) %}
 

--- a/dbt/include/databricks/macros/materializations/view.sql
+++ b/dbt/include/databricks/macros/materializations/view.sql
@@ -6,7 +6,7 @@
   {% set tags = config.get('databricks_tags') %}
   {% set sql = adapter.clean_sql(sql) %}
 
-  {% if adapter.behavior.use_materialization_v2 %}
+  {% if adapter.get_behavior_flag_no_warn('use_materialization_v2') %}
     {{ run_pre_hooks() }}
     {% if existing_relation %}
       {% if relation_should_be_altered(existing_relation) %}

--- a/tests/functional/adapter/materialized_view_tests/test_basic.py
+++ b/tests/functional/adapter/materialized_view_tests/test_basic.py
@@ -139,14 +139,6 @@ class TestMaterializedViews(TestMaterializedViewsMixin, MaterializedViewBasic):
         )
         assert results[0][1] == expected_struct_type
 
-    def test_use_materialization_v2_warning_absent(self, project, my_table):
-        """A project on the default `use_materialization_v2` setting must not emit the
-        deprecation warning. Running a `table` model exercises the v2 check."""
-        _, logs = util.run_dbt_and_capture(["run", "--models", my_table.identifier])
-        warning_substring = USE_MATERIALIZATION_V2["description"][:40]
-        util.assert_message_in_logs(warning_substring, logs, False)
-
-
 @pytest.mark.dlt
 @pytest.mark.skip_profile("databricks_cluster", "databricks_uc_cluster")
 class TestMaterializedViewLiquidClustering(TestMaterializedViewsMixin):

--- a/tests/functional/adapter/materialized_view_tests/test_basic.py
+++ b/tests/functional/adapter/materialized_view_tests/test_basic.py
@@ -6,6 +6,7 @@ from dbt.tests import util
 from dbt.tests.adapter.materialized_view import files
 from dbt.tests.adapter.materialized_view.basic import MaterializedViewBasic
 
+from dbt.adapters.databricks.impl import USE_MATERIALIZATION_V2
 from tests.functional.adapter.materialized_view_tests import fixtures
 
 
@@ -137,6 +138,13 @@ class TestMaterializedViews(TestMaterializedViewsMixin, MaterializedViewBasic):
             + ">"
         )
         assert results[0][1] == expected_struct_type
+
+    def test_use_materialization_v2_warning_absent(self, project, my_table):
+        """A project on the default `use_materialization_v2` setting must not emit the
+        deprecation warning. Running a `table` model exercises the v2 check."""
+        _, logs = util.run_dbt_and_capture(["run", "--models", my_table.identifier])
+        warning_substring = USE_MATERIALIZATION_V2["description"][:40]
+        util.assert_message_in_logs(warning_substring, logs, False)
 
 
 @pytest.mark.dlt

--- a/tests/functional/adapter/materialized_view_tests/test_basic.py
+++ b/tests/functional/adapter/materialized_view_tests/test_basic.py
@@ -6,7 +6,6 @@ from dbt.tests import util
 from dbt.tests.adapter.materialized_view import files
 from dbt.tests.adapter.materialized_view.basic import MaterializedViewBasic
 
-from dbt.adapters.databricks.impl import USE_MATERIALIZATION_V2
 from tests.functional.adapter.materialized_view_tests import fixtures
 
 
@@ -138,6 +137,7 @@ class TestMaterializedViews(TestMaterializedViewsMixin, MaterializedViewBasic):
             + ">"
         )
         assert results[0][1] == expected_struct_type
+
 
 @pytest.mark.dlt
 @pytest.mark.skip_profile("databricks_cluster", "databricks_uc_cluster")

--- a/tests/unit/test_adapter.py
+++ b/tests/unit/test_adapter.py
@@ -7,6 +7,7 @@ import dbt.flags as flags
 import pytest
 from agate import Row
 from dbt.config import RuntimeConfig
+from dbt_common.events.event_manager_client import add_callback_to_manager
 from dbt_common.exceptions import DbtConfigError, DbtDatabaseError, DbtValidationError
 
 from dbt.adapters.databricks import DatabricksAdapter, __version__, constants
@@ -1351,3 +1352,39 @@ class TestManagedIcebergBehaviorFlag(DatabricksAdapterBase):
             DbtConfigError, match="When table_format is 'iceberg', materialized must be"
         ):
             adapter.is_uniform(mock_config)
+
+
+class TestMaterializationV2BehaviorFlag(DatabricksAdapterBase):
+    """The `use_materialization_v2` deprecation warning must not fire on every dbt run.
+    The fix routes all 4 Jinja-side accesses through `adapter.get_behavior_flag_no_warn(...)`,
+    which reads the flag via dbt-core's `.no_warn` property and bypasses the event."""
+
+    @pytest.fixture
+    def adapter(self):
+        with patch("dbt.adapters.databricks.connections.DatabricksConnectionManager"):
+            return DatabricksAdapter(self._get_config(), get_context("spawn"))
+
+    @pytest.mark.parametrize("flag_value", [False, True])
+    def test_get_behavior_flag_no_warn_does_not_fire_event(self, adapter, flag_value):
+        """The helper must return the flag value without firing
+        BehaviorChangeEvent for `use_materialization_v2`, regardless of value."""
+        adapter.behavior.use_materialization_v2.setting = flag_value
+
+        caught = []
+
+        def record(event_msg):
+            if (
+                event_msg.info.name == "BehaviorChangeEvent"
+                and event_msg.data.flag_name == "use_materialization_v2"
+            ):
+                caught.append(event_msg)
+
+        add_callback_to_manager(record)
+
+        result = adapter.get_behavior_flag_no_warn("use_materialization_v2")
+
+        assert result == flag_value
+        assert caught == [], (
+            "get_behavior_flag_no_warn must not fire BehaviorChangeEvent for "
+            f"use_materialization_v2 (fired {len(caught)} times)"
+        )

--- a/tests/unit/test_adapter.py
+++ b/tests/unit/test_adapter.py
@@ -1355,9 +1355,7 @@ class TestManagedIcebergBehaviorFlag(DatabricksAdapterBase):
 
 
 class TestMaterializationV2BehaviorFlag(DatabricksAdapterBase):
-    """The `use_materialization_v2` deprecation warning must not fire on every dbt run.
-    The fix routes all 4 Jinja-side accesses through `adapter.get_behavior_flag_no_warn(...)`,
-    which reads the flag via dbt-core's `.no_warn` property and bypasses the event."""
+    """The `use_materialization_v2` deprecation warning must not fire on every dbt run."""
 
     @pytest.fixture
     def adapter(self):


### PR DESCRIPTION
Fixes https://github.com/databricks/dbt-databricks/issues/1089.

dbt-core's BehaviorFlag emits a deprecation warning the first time a flag with default=False is read. As a result, every dbt run with incremental materialization logs a confusing use_materialization_v2 warning on every model, with no clean way to silence it short of opting in to the flag itself.
                                                                                                                                                                                                              
This PR fixes this by accessing the flag with no_warn in the code paths. A new get_behavior_flag_no_warn helper on the adapter is decorated with @available so Jinja can call it at runtime. All four materialization macros that gate v1/v2 (table.sql, view.sql, seeds.sql, incremental.sql) now route through that helper, which reads the flag via BehaviorFlagRendered.no_warn and bypasses the BehaviorChangeEvent entirely.   

PECOBLR-2649