### PR TITLE
fix: missing metadata handling in is_hudi and is_iceberg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Fixes
 
+- Fix latent AssertionError when evaluating `is_hudi` or `is_iceberg` properties on relations without metadata
 - Validate relation identifier length at creation time and raise a clear error when it exceeds Databricks' 255-character limit ([#1309](https://github.com/databricks/dbt-databricks/issues/1309))
 - Fix spurious `MicrobatchConcurrency` behavior-change warning firing on every run regardless of whether the project contained microbatch models ([#1406](https://github.com/databricks/dbt-databricks/issues/1406))
 - Fix DBR capability cache being permanently poisoned by a transient version-query failure ([#1398](https://github.com/databricks/dbt-databricks/issues/1398))

--- a/dbt/adapters/databricks/relation.py
+++ b/dbt/adapters/databricks/relation.py
@@ -146,13 +146,11 @@ class DatabricksRelation(BaseRelation):
 
     @property
     def is_hudi(self) -> bool:
-        assert self.metadata is not None
-        return self.metadata.get(KEY_TABLE_PROVIDER) == "hudi"
+        return self.metadata is not None and self.metadata.get(KEY_TABLE_PROVIDER) == "hudi"
 
     @property
     def is_iceberg(self) -> bool:
-        assert self.metadata is not None
-        return self.metadata.get(KEY_TABLE_PROVIDER) == "iceberg"
+        return self.metadata is not None and self.metadata.get(KEY_TABLE_PROVIDER) == "iceberg"
 
     @property
     def owner(self) -> Optional[str]:

--- a/tests/unit/test_relation.py
+++ b/tests/unit/test_relation.py
@@ -264,6 +264,22 @@ class TestRelationsFunctions:
         )
         assert relation.is_iceberg is False
 
+    def test_is_iceberg_no_metadata(self):
+        relation = DatabricksRelation.create(
+            identifier="no_metadata_iceberg_table",
+            type="table",
+            metadata=None,
+        )
+        assert relation.is_iceberg is False
+
+    def test_is_hudi_no_metadata(self):
+        relation = DatabricksRelation.create(
+            identifier="no_metadata_hudi_table",
+            type="table",
+            metadata=None,
+        )
+        assert relation.is_hudi is False
+
     @pytest.mark.parametrize(
         "type_, is_delta, is_iceberg, expected_can_be_replaced",
         [


### PR DESCRIPTION
### description

`can_be_replaced` calls `is_iceberg` without first checking whether metadata is available. on relations that haven't fetched extended metadata yet (`metadata=None`) this hits an unconditional `assert self.metadata is not None` and crashes the dbt run with an `AssertionError`.

the fix 

- updates `is_hudi` and `is_iceberg` to safely return `False` when `self.metadata is None`, making their behavior consistent with other metadata properties like `owner` and `stats`. 
- unit tests have also been added to ensure properties evaluate gracefully on un-hydrated relations.

### checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
