### PR TITLE
test: fix failing `TestStreamingTableLiquidClusteringChanges`

### DIFF
--- a/tests/functional/adapter/streaming_tables/test_st_basic.py
+++ b/tests/functional/adapter/streaming_tables/test_st_basic.py
@@ -331,17 +331,10 @@ class TestStreamingTableLiquidClusteringChanges:
             type=DatabricksRelationType.StreamingTable,
         )
 
-    @pytest.fixture(scope="class", autouse=True)
-    def setup(self, project, liquid_clustered_st):
-        util.run_dbt(["seed"])
-        util.run_dbt(["run", "--models", liquid_clustered_st.identifier, "--full-refresh"])
-
-        yield
-
-        project.run_sql(f"drop schema if exists {project.test_schema} cascade")
-
     def test_liquid_clustering_change_is_applied(self, project, liquid_clustered_st):
         """Changing liquid_clustered_by on an existing ST should apply via ALTER."""
+        util.run_dbt(["seed"])
+        util.run_dbt(["run", "--models", liquid_clustered_st.identifier, "--full-refresh"])
         util.write_file(fixtures.liquid_clustered_st_schema_v2, "models", "schema.yml")
         util.run_dbt(["run", "--models", liquid_clustered_st.identifier])
 


### PR DESCRIPTION
## Summary

See cluster/uc-cluster integration test runs failing with the same error

```
_ ERROR at setup of TestStreamingTableLiquidClusteringChanges.test_liquid_clustering_change_is_applied _
[gw7] linux -- Python 3.10.20 /home/runner/.local/share/hatch/env/virtual/dbt-databricks/x3VOX0GX/dbt-databricks/bin/python3

self = <test_st_basic.TestStreamingTableLiquidClusteringChanges object at 0x7fef1c646830>
project = <dbt.tests.fixtures.project.TestProjInfo object at 0x7fef04b32ad0>
liquid_clustered_st = <DatabricksRelation `hive_metastore`.`test17775258095118707534_test_st_basic`.`liquid_clustered_st`>

    @pytest.fixture(scope="class", autouse=True)
    def setup(self, project, liquid_clustered_st):
        util.run_dbt(["seed"])
>       util.run_dbt(["run", "--models", liquid_clustered_st.identifier, "--full-refresh"])

/home/runner/work/dbt-databricks/dbt-databricks/tests/functional/adapter/streaming_tables/test_st_basic.py:337: 
```

While the test is gated behind a profile check and runs only on `sqlwarehouse`, the underlying setup is not gated which is what leads to the error here. The fix is simple to remove the common setup utility and move this inside the function which has the proper gating.


## Test plan

- [x] `hatch run pytest tests/functional/adapter/streaming_tables/test_st_basic.py::TestStreamingTableLiquidClusteringChanges -v --profile databricks_uc_sql_endpoint` — `1 passed` in 76s
- [x] `hatch run pytest tests/functional/adapter/streaming_tables/test_st_basic.py::TestStreamingTableLiquidClusteringChanges -v --profile databricks_uc_cluster` — `1 skipped` (no dbt-run output emitted)
- [x] run full suite of integration tests against the PR