### PR TITLE
ci: bounded FIFO queue for integration test runs

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -171,17 +171,13 @@ jobs:
         uses: pypa/hatch@257e27e51a6a5616ed08a39a408a21c35c9931bc  # install
 
       - name: Collect tests and assign to shards
-        env:
-          SHARDS_CLUSTER: ${{ needs.prepare.outputs.shards_cluster }}
-          SHARDS_UC_CLUSTER: ${{ needs.prepare.outputs.shards_uc_cluster }}
-          SHARDS_UC_SQL_ENDPOINT: ${{ needs.prepare.outputs.shards_uc_sql_endpoint }}
         run: |
           set -euo pipefail
           mkdir -p shard-assignments
           declare -A NUM_SHARDS=(
-            [databricks_cluster]=$(jq 'length' <<< "$SHARDS_CLUSTER")
-            [databricks_uc_cluster]=$(jq 'length' <<< "$SHARDS_UC_CLUSTER")
-            [databricks_uc_sql_endpoint]=$(jq 'length' <<< "$SHARDS_UC_SQL_ENDPOINT")
+            [databricks_cluster]=${{ needs.prepare.outputs.count_cluster }}
+            [databricks_uc_cluster]=${{ needs.prepare.outputs.count_uc_cluster }}
+            [databricks_uc_sql_endpoint]=${{ needs.prepare.outputs.count_uc_sql_endpoint }}
           )
           for PROFILE in "${!NUM_SHARDS[@]}"; do
             (

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -54,12 +54,8 @@ jobs:
       labels: linux-ubuntu-latest
     outputs:
       targets: ${{ steps.parse.outputs.targets }}
-      # Shard arrays are the single source of truth for shard counts. Test jobs
-      # reference these for `matrix.shard`; the matching `count_*` outputs feed
-      # `max-parallel` (GHA expressions have no `length()` function on arrays).
-      # Both are emitted from the same bash variable in `parse`, so a one-line
-      # edit there reshapes the per-profile shard fan-out everywhere.
-      # `prepare-shards` also derives its NUM_SHARDS map from these outputs.
+      # `count_*` is emitted alongside `shards_*` because GHA expressions have
+      # no `length()` for arrays — `max-parallel` can't derive it from the array.
       shards_cluster: ${{ steps.parse.outputs.shards_cluster }}
       shards_uc_cluster: ${{ steps.parse.outputs.shards_uc_cluster }}
       shards_uc_sql_endpoint: ${{ steps.parse.outputs.shards_uc_sql_endpoint }}
@@ -209,7 +205,7 @@ jobs:
   # matrix's shard count so a multi-PR batch dispatch stays inside this slot.
   gate:
     needs: prepare
-    if: needs.prepare.outputs.targets != '[]' && needs.prepare.outputs.targets != ''
+    if: needs.prepare.outputs.targets != '[]'
     runs-on:
       group: databricks-protected-runner-group
       labels: linux-ubuntu-latest
@@ -226,12 +222,7 @@ jobs:
     # Do not add `if: always()` / `if: !cancelled()` here or on sibling test jobs —
     # `needs: prepare` propagates the external-fork skip cleanly, and forcing
     # evaluation would make `fromJSON(needs.prepare.outputs.targets)` fail on an
-    # empty output. Matrix shape contract: {pr, ref, shard} — pr+ref from
-    # `prepare.outputs.targets`, shard from `prepare.outputs.shards_uc_cluster`.
-    # `needs: gate` enforces the global bounded FIFO; `max-parallel` is the
-    # shard count from `prepare.outputs.count_uc_cluster` so a single PR's
-    # shards run in parallel but a multi-PR batch dispatch stays inside the
-    # gate's "one PR's worth of compute" intent.
+    # empty output.
     needs:
       - prepare
       - prepare-shards
@@ -334,8 +325,6 @@ jobs:
           retention-days: 5
 
   run-sqlwarehouse-e2e-tests:
-    # Matrix shape contract: {pr, ref, shard} — pr+ref from `prepare.outputs.targets`,
-    # shard from `prepare.outputs.shards_uc_sql_endpoint`.
     needs:
       - prepare
       - prepare-shards
@@ -437,8 +426,6 @@ jobs:
           retention-days: 5
 
   run-cluster-e2e-tests:
-    # Matrix shape contract: {pr, ref, shard} — pr+ref from `prepare.outputs.targets`,
-    # shard from `prepare.outputs.shards_cluster`.
     needs:
       - prepare
       - prepare-shards

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -181,21 +181,51 @@ jobs:
           path: shard-assignments/
           retention-days: 5
 
+  # Bounded FIFO queue for integration runs. One workflow run holds the slot at
+  # a time across the whole repo (queue-name is repo-scoped, branch filter off).
+  # Combined with per-job `max-parallel` matching the shard count (so a single
+  # workflow run's matrix never exceeds one PR's worth of cluster cells), at
+  # most one PR's worth of cluster/warehouse load is in flight at any moment.
+  # Other runs (PR /integration-test triggers, the nightly schedule) wait FIFO
+  # by run created_at, and abort their wait after `abort-after-seconds` so the
+  # queue is bounded by time. Skipped when prepare emits empty targets so the
+  # slot is not held for nothing.
+  gate:
+    needs: prepare
+    if: needs.prepare.outputs.targets != '[]' && needs.prepare.outputs.targets != ''
+    runs-on:
+      group: databricks-protected-runner-group
+      labels: linux-ubuntu-latest
+    timeout-minutes: 240
+    steps:
+      - name: Wait for integration slot
+        uses: softprops/turnstyle@e15e934b3f69ee283ba389ea05c8886baa656d93  # v3.2.4
+        with:
+          queue-name: integration-shared-compute
+          same-branch-only: false
+          poll-interval-seconds: 30
+          abort-after-seconds: 14400
+
   run-uc-cluster-e2e-tests:
     # Do not add `if: always()` / `if: !cancelled()` here or on sibling test jobs —
     # `needs: prepare` propagates the external-fork skip cleanly, and forcing
     # evaluation would make `fromJSON(needs.prepare.outputs.targets)` fail on an
     # empty output. Matrix shape contract: {pr, ref, shard} — defined in the
     # `prepare` job (pr+ref) plus the static `shard` dimension below.
+    # `needs: gate` enforces the global bounded FIFO; `max-parallel` matches
+    # the shard count so a single PR's shards run in parallel but a multi-PR
+    # batch does not blow past the gate's "one PR's worth of compute" intent.
     needs:
       - prepare
       - prepare-shards
+      - gate
     # Skip when `prepare` emits an empty targets array (nightly skip-if-unchanged).
     # Without this, GitHub Actions treats a job with a zero-combination matrix as
     # a failure, so every already-tested nightly run gets reported as failed.
     if: needs.prepare.outputs.targets != '[]'
     strategy:
       fail-fast: false
+      max-parallel: 3
       matrix:
         target: ${{ fromJSON(needs.prepare.outputs.targets) }}
         shard: [0, 1, 2]
@@ -292,10 +322,12 @@ jobs:
     needs:
       - prepare
       - prepare-shards
+      - gate
     # See run-uc-cluster-e2e-tests for empty-matrix rationale.
     if: needs.prepare.outputs.targets != '[]'
     strategy:
       fail-fast: false
+      max-parallel: 3
       matrix:
         target: ${{ fromJSON(needs.prepare.outputs.targets) }}
         shard: [0, 1, 2]
@@ -393,10 +425,12 @@ jobs:
     needs:
       - prepare
       - prepare-shards
+      - gate
     # See run-uc-cluster-e2e-tests for empty-matrix rationale.
     if: needs.prepare.outputs.targets != '[]'
     strategy:
       fail-fast: false
+      max-parallel: 2
       matrix:
         target: ${{ fromJSON(needs.prepare.outputs.targets) }}
         shard: [0, 1]

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -181,22 +181,9 @@ jobs:
           path: shard-assignments/
           retention-days: 5
 
-  # Bounded FIFO queue for integration runs. One workflow run holds the slot at
-  # a time across the whole repo. Combined with per-job `max-parallel` matching
-  # the shard count (so a single workflow run's matrix never exceeds one PR's
-  # worth of cluster cells), at most one PR's worth of cluster/warehouse load
-  # is in flight at any moment. Other runs (PR /integration-test triggers, the
-  # nightly schedule) wait FIFO by run id, and abort their wait after
-  # `abort-after-seconds` so the queue is bounded by time. Skipped when prepare
-  # emits empty targets so the slot is not held for nothing.
-  #
-  # Implementation note: `queue-name` is intentionally NOT set. Turnstyle treats
-  # it as a substring filter against `run.display_title` / `run.name` (see
-  # softprops/turnstyle src/wait.ts), not as an arbitrary tag — passing a value
-  # that doesn't appear in the run's auto-generated title makes the filter
-  # match nothing and the gate exit immediately. With queue-name omitted,
-  # turnstyle defaults to filtering by workflow_id, which is exactly the
-  # serialization scope we want.
+  # Serialize integration runs across the repo. Others wait FIFO by run id and
+  # abort after `abort-after-seconds`. Per-job `max-parallel` matches each
+  # matrix's shard count so a multi-PR batch dispatch stays inside this slot.
   gate:
     needs: prepare
     if: needs.prepare.outputs.targets != '[]' && needs.prepare.outputs.targets != ''

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -55,12 +55,17 @@ jobs:
     outputs:
       targets: ${{ steps.parse.outputs.targets }}
       # Shard arrays are the single source of truth for shard counts. Test jobs
-      # reference these for both `matrix.shard` and `max-parallel` so a multi-PR
-      # batch dispatch is capped at one PR's worth of cells in flight at a time.
-      # `prepare-shards` derives its bash NUM_SHARDS map from these outputs too.
+      # reference these for `matrix.shard`; the matching `count_*` outputs feed
+      # `max-parallel` (GHA expressions have no `length()` function on arrays).
+      # Both are emitted from the same bash variable in `parse`, so a one-line
+      # edit there reshapes the per-profile shard fan-out everywhere.
+      # `prepare-shards` also derives its NUM_SHARDS map from these outputs.
       shards_cluster: ${{ steps.parse.outputs.shards_cluster }}
       shards_uc_cluster: ${{ steps.parse.outputs.shards_uc_cluster }}
       shards_uc_sql_endpoint: ${{ steps.parse.outputs.shards_uc_sql_endpoint }}
+      count_cluster: ${{ steps.parse.outputs.count_cluster }}
+      count_uc_cluster: ${{ steps.parse.outputs.count_uc_cluster }}
+      count_uc_sql_endpoint: ${{ steps.parse.outputs.count_uc_sql_endpoint }}
     steps:
       - name: Parse targets
         id: parse
@@ -110,10 +115,17 @@ jobs:
           targets+="]"
           echo "targets=$targets" >> "$GITHUB_OUTPUT"
           echo "Parsed targets: $targets"
-          # Shard arrays — change here to reshape the per-profile shard fan-out.
-          echo "shards_cluster=[0, 1]" >> "$GITHUB_OUTPUT"
-          echo "shards_uc_cluster=[0, 1, 2]" >> "$GITHUB_OUTPUT"
-          echo "shards_uc_sql_endpoint=[0, 1, 2]" >> "$GITHUB_OUTPUT"
+          # Shard fan-out — single source of truth. Reshape here and matrix +
+          # max-parallel + prepare-shards NUM_SHARDS all follow.
+          shards_cluster='[0, 1]'
+          shards_uc_cluster='[0, 1, 2]'
+          shards_uc_sql_endpoint='[0, 1, 2]'
+          for profile in cluster uc_cluster uc_sql_endpoint; do
+            arr_var="shards_${profile}"
+            arr="${!arr_var}"
+            echo "shards_${profile}=${arr}" >> "$GITHUB_OUTPUT"
+            echo "count_${profile}=$(jq 'length' <<< "$arr")" >> "$GITHUB_OUTPUT"
+          done
 
   # Collects test ids per profile and partitions files into shards.
   # `--collect-only` imports test modules but never hits the workspace.
@@ -220,9 +232,10 @@ jobs:
     # evaluation would make `fromJSON(needs.prepare.outputs.targets)` fail on an
     # empty output. Matrix shape contract: {pr, ref, shard} — pr+ref from
     # `prepare.outputs.targets`, shard from `prepare.outputs.shards_uc_cluster`.
-    # `needs: gate` enforces the global bounded FIFO; `max-parallel = length(shards)`
-    # so a single PR's shards run in parallel but a multi-PR batch dispatch
-    # stays inside the gate's "one PR's worth of compute" intent.
+    # `needs: gate` enforces the global bounded FIFO; `max-parallel` is the
+    # shard count from `prepare.outputs.count_uc_cluster` so a single PR's
+    # shards run in parallel but a multi-PR batch dispatch stays inside the
+    # gate's "one PR's worth of compute" intent.
     needs:
       - prepare
       - prepare-shards
@@ -233,7 +246,7 @@ jobs:
     if: needs.prepare.outputs.targets != '[]'
     strategy:
       fail-fast: false
-      max-parallel: ${{ length(fromJSON(needs.prepare.outputs.shards_uc_cluster)) }}
+      max-parallel: ${{ fromJSON(needs.prepare.outputs.count_uc_cluster) }}
       matrix:
         target: ${{ fromJSON(needs.prepare.outputs.targets) }}
         shard: ${{ fromJSON(needs.prepare.outputs.shards_uc_cluster) }}
@@ -335,7 +348,7 @@ jobs:
     if: needs.prepare.outputs.targets != '[]'
     strategy:
       fail-fast: false
-      max-parallel: ${{ length(fromJSON(needs.prepare.outputs.shards_uc_sql_endpoint)) }}
+      max-parallel: ${{ fromJSON(needs.prepare.outputs.count_uc_sql_endpoint) }}
       matrix:
         target: ${{ fromJSON(needs.prepare.outputs.targets) }}
         shard: ${{ fromJSON(needs.prepare.outputs.shards_uc_sql_endpoint) }}
@@ -438,7 +451,7 @@ jobs:
     if: needs.prepare.outputs.targets != '[]'
     strategy:
       fail-fast: false
-      max-parallel: ${{ length(fromJSON(needs.prepare.outputs.shards_cluster)) }}
+      max-parallel: ${{ fromJSON(needs.prepare.outputs.count_cluster) }}
       matrix:
         target: ${{ fromJSON(needs.prepare.outputs.targets) }}
         shard: ${{ fromJSON(needs.prepare.outputs.shards_cluster) }}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -199,7 +199,7 @@ jobs:
     timeout-minutes: 240
     steps:
       - name: Wait for integration slot
-        uses: softprops/turnstyle@e15e934b3f69ee283ba389ea05c8886baa656d93  # v3.2.4
+        uses: softprops/turnstyle@15f9da4059166900981058ba251e0b652511c68f  # v3.2.2
         with:
           queue-name: integration-shared-compute
           same-branch-only: false

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -182,14 +182,21 @@ jobs:
           retention-days: 5
 
   # Bounded FIFO queue for integration runs. One workflow run holds the slot at
-  # a time across the whole repo (queue-name is repo-scoped, branch filter off).
-  # Combined with per-job `max-parallel` matching the shard count (so a single
-  # workflow run's matrix never exceeds one PR's worth of cluster cells), at
-  # most one PR's worth of cluster/warehouse load is in flight at any moment.
-  # Other runs (PR /integration-test triggers, the nightly schedule) wait FIFO
-  # by run created_at, and abort their wait after `abort-after-seconds` so the
-  # queue is bounded by time. Skipped when prepare emits empty targets so the
-  # slot is not held for nothing.
+  # a time across the whole repo. Combined with per-job `max-parallel` matching
+  # the shard count (so a single workflow run's matrix never exceeds one PR's
+  # worth of cluster cells), at most one PR's worth of cluster/warehouse load
+  # is in flight at any moment. Other runs (PR /integration-test triggers, the
+  # nightly schedule) wait FIFO by run id, and abort their wait after
+  # `abort-after-seconds` so the queue is bounded by time. Skipped when prepare
+  # emits empty targets so the slot is not held for nothing.
+  #
+  # Implementation note: `queue-name` is intentionally NOT set. Turnstyle treats
+  # it as a substring filter against `run.display_title` / `run.name` (see
+  # softprops/turnstyle src/wait.ts), not as an arbitrary tag — passing a value
+  # that doesn't appear in the run's auto-generated title makes the filter
+  # match nothing and the gate exit immediately. With queue-name omitted,
+  # turnstyle defaults to filtering by workflow_id, which is exactly the
+  # serialization scope we want.
   gate:
     needs: prepare
     if: needs.prepare.outputs.targets != '[]' && needs.prepare.outputs.targets != ''
@@ -201,7 +208,6 @@ jobs:
       - name: Wait for integration slot
         uses: softprops/turnstyle@15f9da4059166900981058ba251e0b652511c68f  # v3.2.2
         with:
-          queue-name: integration-shared-compute
           same-branch-only: false
           poll-interval-seconds: 30
           abort-after-seconds: 14400

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -54,6 +54,13 @@ jobs:
       labels: linux-ubuntu-latest
     outputs:
       targets: ${{ steps.parse.outputs.targets }}
+      # Shard arrays are the single source of truth for shard counts. Test jobs
+      # reference these for both `matrix.shard` and `max-parallel` so a multi-PR
+      # batch dispatch is capped at one PR's worth of cells in flight at a time.
+      # `prepare-shards` derives its bash NUM_SHARDS map from these outputs too.
+      shards_cluster: ${{ steps.parse.outputs.shards_cluster }}
+      shards_uc_cluster: ${{ steps.parse.outputs.shards_uc_cluster }}
+      shards_uc_sql_endpoint: ${{ steps.parse.outputs.shards_uc_sql_endpoint }}
     steps:
       - name: Parse targets
         id: parse
@@ -103,6 +110,10 @@ jobs:
           targets+="]"
           echo "targets=$targets" >> "$GITHUB_OUTPUT"
           echo "Parsed targets: $targets"
+          # Shard arrays — change here to reshape the per-profile shard fan-out.
+          echo "shards_cluster=[0, 1]" >> "$GITHUB_OUTPUT"
+          echo "shards_uc_cluster=[0, 1, 2]" >> "$GITHUB_OUTPUT"
+          echo "shards_uc_sql_endpoint=[0, 1, 2]" >> "$GITHUB_OUTPUT"
 
   # Collects test ids per profile and partitions files into shards.
   # `--collect-only` imports test modules but never hits the workspace.
@@ -148,13 +159,17 @@ jobs:
         uses: pypa/hatch@257e27e51a6a5616ed08a39a408a21c35c9931bc  # install
 
       - name: Collect tests and assign to shards
+        env:
+          SHARDS_CLUSTER: ${{ needs.prepare.outputs.shards_cluster }}
+          SHARDS_UC_CLUSTER: ${{ needs.prepare.outputs.shards_uc_cluster }}
+          SHARDS_UC_SQL_ENDPOINT: ${{ needs.prepare.outputs.shards_uc_sql_endpoint }}
         run: |
           set -euo pipefail
           mkdir -p shard-assignments
           declare -A NUM_SHARDS=(
-            [databricks_cluster]=2
-            [databricks_uc_cluster]=3
-            [databricks_uc_sql_endpoint]=3
+            [databricks_cluster]=$(jq 'length' <<< "$SHARDS_CLUSTER")
+            [databricks_uc_cluster]=$(jq 'length' <<< "$SHARDS_UC_CLUSTER")
+            [databricks_uc_sql_endpoint]=$(jq 'length' <<< "$SHARDS_UC_SQL_ENDPOINT")
           )
           for PROFILE in "${!NUM_SHARDS[@]}"; do
             (
@@ -203,11 +218,11 @@ jobs:
     # Do not add `if: always()` / `if: !cancelled()` here or on sibling test jobs —
     # `needs: prepare` propagates the external-fork skip cleanly, and forcing
     # evaluation would make `fromJSON(needs.prepare.outputs.targets)` fail on an
-    # empty output. Matrix shape contract: {pr, ref, shard} — defined in the
-    # `prepare` job (pr+ref) plus the static `shard` dimension below.
-    # `needs: gate` enforces the global bounded FIFO; `max-parallel` matches
-    # the shard count so a single PR's shards run in parallel but a multi-PR
-    # batch does not blow past the gate's "one PR's worth of compute" intent.
+    # empty output. Matrix shape contract: {pr, ref, shard} — pr+ref from
+    # `prepare.outputs.targets`, shard from `prepare.outputs.shards_uc_cluster`.
+    # `needs: gate` enforces the global bounded FIFO; `max-parallel = length(shards)`
+    # so a single PR's shards run in parallel but a multi-PR batch dispatch
+    # stays inside the gate's "one PR's worth of compute" intent.
     needs:
       - prepare
       - prepare-shards
@@ -218,10 +233,10 @@ jobs:
     if: needs.prepare.outputs.targets != '[]'
     strategy:
       fail-fast: false
-      max-parallel: 3
+      max-parallel: ${{ length(fromJSON(needs.prepare.outputs.shards_uc_cluster)) }}
       matrix:
         target: ${{ fromJSON(needs.prepare.outputs.targets) }}
-        shard: [0, 1, 2]
+        shard: ${{ fromJSON(needs.prepare.outputs.shards_uc_cluster) }}
     runs-on:
       group: databricks-protected-runner-group
       labels: linux-ubuntu-latest
@@ -310,8 +325,8 @@ jobs:
           retention-days: 5
 
   run-sqlwarehouse-e2e-tests:
-    # Matrix shape contract: {pr, ref, shard} — pr+ref from `prepare`, shard
-    # is the static dimension below.
+    # Matrix shape contract: {pr, ref, shard} — pr+ref from `prepare.outputs.targets`,
+    # shard from `prepare.outputs.shards_uc_sql_endpoint`.
     needs:
       - prepare
       - prepare-shards
@@ -320,10 +335,10 @@ jobs:
     if: needs.prepare.outputs.targets != '[]'
     strategy:
       fail-fast: false
-      max-parallel: 3
+      max-parallel: ${{ length(fromJSON(needs.prepare.outputs.shards_uc_sql_endpoint)) }}
       matrix:
         target: ${{ fromJSON(needs.prepare.outputs.targets) }}
-        shard: [0, 1, 2]
+        shard: ${{ fromJSON(needs.prepare.outputs.shards_uc_sql_endpoint) }}
     runs-on:
       group: databricks-protected-runner-group
       labels: linux-ubuntu-latest
@@ -413,8 +428,8 @@ jobs:
           retention-days: 5
 
   run-cluster-e2e-tests:
-    # Matrix shape contract: {pr, ref, shard} — pr+ref from `prepare`, shard
-    # is the static dimension below.
+    # Matrix shape contract: {pr, ref, shard} — pr+ref from `prepare.outputs.targets`,
+    # shard from `prepare.outputs.shards_cluster`.
     needs:
       - prepare
       - prepare-shards
@@ -423,10 +438,10 @@ jobs:
     if: needs.prepare.outputs.targets != '[]'
     strategy:
       fail-fast: false
-      max-parallel: 2
+      max-parallel: ${{ length(fromJSON(needs.prepare.outputs.shards_cluster)) }}
       matrix:
         target: ${{ fromJSON(needs.prepare.outputs.targets) }}
-        shard: [0, 1]
+        shard: ${{ fromJSON(needs.prepare.outputs.shards_cluster) }}
     runs-on:
       group: databricks-protected-runner-group
       labels: linux-ubuntu-latest


### PR DESCRIPTION
## Summary

Today there is no coordination between integration runs that share Databricks compute. The existing per-PR `concurrency:` block in `integration.yml:46-48` only cancels stale re-dispatches of the *same* PR — it does not stop different PRs (or PR + nightly schedule) from running simultaneously and dog-piling the cluster/warehouse. Reviewers triggering `/integration-test` on several PRs in quick succession, or a batch `pr_numbers: "100,200,300"` workflow_dispatch, can multiply the load.

This PR adds a repo-wide bounded FIFO queue: at most **one PR's worth of compute** runs at a time; everything else queues in arrival order; waiters time out after 4 hours so the queue is bounded.

## Test plan

### Pre-merge verification (manual `workflow_dispatch` with `--ref` pointing at this branch)

- [x] **Single-run sanity** — gate acquires slot immediately, test jobs proceed.
  ```bash
  gh workflow run integration.yml \
    --repo databricks/dbt-databricks \
    --ref ci/integration-bounded-queue \
    --field pr_numbers=1439
  ```
  Watch the `gate` job log: a single poll, then "no other runs found", proceed.

- [x] **Concurrency / FIFO ordering** — second run queues behind the first.
  ```bash
  # Kick off two in quick succession (different PRs so per-PR concurrency doesn't cancel)
  gh workflow run integration.yml --repo databricks/dbt-databricks --ref ci/integration-bounded-queue --field pr_numbers=1438
  gh workflow run integration.yml --repo databricks/dbt-databricks --ref ci/integration-bounded-queue --field pr_numbers=1439
  ```
  Confirm in the Actions tab: the second run's `gate` step polls and waits