### PR TITLE
fix: return True from has_dbr_capability parse stub on SQL warehouses (#1331)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Fixes
 
 - Use pydantic v1-compatible API in `refresh.py` so the adapter works on environments shipping pydantic v1.
+- Fix capability-branching macros falling through to their legacy path at parse/compile time on SQL warehouses. The parse-time stub of `has_dbr_capability` now returns `True` on warehouse profiles for capabilities flagged `sql_warehouse_supported`, so macros select the modern branch during compilation instead of the legacy fallback. ([#1331](https://github.com/databricks/dbt-databricks/issues/1331))
 
 ## dbt-databricks 1.12.0 (May 14, 2026)
 

--- a/dbt/adapters/databricks/impl.py
+++ b/dbt/adapters/databricks/impl.py
@@ -51,7 +51,7 @@ from dbt.adapters.databricks.connections import (
     DatabricksConnectionManager,
     DatabricksDBTConnection,
 )
-from dbt.adapters.databricks.dbr_capabilities import DBRCapability
+from dbt.adapters.databricks.dbr_capabilities import DBRCapabilities, DBRCapability
 from dbt.adapters.databricks.global_state import GlobalState
 from dbt.adapters.databricks.handle import SqlUtils
 from dbt.adapters.databricks.python_models.python_submissions import (
@@ -90,6 +90,7 @@ from dbt.adapters.databricks.relation_configs.view import ViewConfig
 from dbt.adapters.databricks.utils import (
     get_first_row,
     handle_missing_objects,
+    is_cluster_http_path,
     quote,
     redact_credentials,
 )
@@ -268,6 +269,25 @@ class DatabricksAdapter(SparkAdapter):
         GlobalState.set_use_managed_iceberg(
             self.get_behavior_flag_no_warn(USE_MANAGED_ICEBERG["name"])
         )
+
+        # Warehouses always meet capability cutoffs at parse time; clusters keep the
+        # conservative False until a real connection is available.
+        # `_parse_replacements_` is injected by AdapterMeta, so mypy can't resolve it here.
+        self._parse_replacements_ = {
+            **self.__class__._parse_replacements_,  # type: ignore[has-type]
+            "has_dbr_capability": self._has_dbr_capability_parse,
+        }
+
+    def _has_dbr_capability_parse(self, capability_name: str) -> bool:
+        """Parse-time stub: True only on SQL warehouses for warehouse-supported capabilities."""
+        creds = self.config.credentials
+        if is_cluster_http_path(creds.http_path, creds.cluster_id):
+            return False
+        try:
+            capability = DBRCapability(capability_name.lower())
+        except ValueError:
+            return False
+        return DBRCapabilities(is_sql_warehouse=True).has_capability(capability)
 
     @property
     def _behavior_flags(self) -> list[BehaviorFlag]:

--- a/tests/functional/adapter/utils/test_dateadd_uppercase.py
+++ b/tests/functional/adapter/utils/test_dateadd_uppercase.py
@@ -1,0 +1,22 @@
+import pytest
+from dbt.tests import util
+
+# Exercises the parse-time stub for `has_dbr_capability` on SQL warehouses.
+#
+# `databricks__dateadd` branches on `has_dbr_capability('timestampdiff')`. If the
+# parse stub returned False, the legacy `spark__dateadd` path is selected at compile
+# time and raises a compile error on uppercase dateparts. With the warehouse stub
+# returning True, the modern `timestampadd` path is selected and the run succeeds.
+model_sql = """
+select {{ dateadd('DAY', 1, "cast('2024-01-01' as timestamp)") }} as ts
+"""
+
+
+class TestDateAddUppercaseDatepartOnWarehouse:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"uppercase_dateadd.sql": model_sql}
+
+    @pytest.mark.skip_profile("databricks_uc_cluster", "databricks_cluster")
+    def test_uppercase_datepart_compiles_and_runs(self, project):
+        util.run_dbt(["run"])

--- a/tests/unit/test_adapter_capabilities.py
+++ b/tests/unit/test_adapter_capabilities.py
@@ -200,3 +200,65 @@ class TestAdapterCapabilities:
             "supports(MicrobatchConcurrency) must not fire BehaviorChangeEvent "
             f"(fired {len(caught)} times)"
         )
+
+
+class TestHasDbrCapabilityParseStub:
+    """Parse-time stub for has_dbr_capability."""
+
+    def _make_adapter(self, http_path: str) -> DatabricksAdapter:
+        project_cfg = {
+            "name": "test_project",
+            "version": "0.1",
+            "profile": "test",
+            "project-root": "/tmp/dbt/does-not-exist",
+            "config-version": 2,
+        }
+        profile_cfg = {
+            "outputs": {
+                "test": {
+                    "type": "databricks",
+                    "catalog": "main",
+                    "schema": "analytics",
+                    "host": "test.databricks.com",
+                    "http_path": http_path,
+                    "token": "dapi" + "X" * 32,
+                }
+            },
+            "target": "test",
+        }
+        config = config_from_parts_or_dicts(project_cfg, profile_cfg)
+        return DatabricksAdapter(config, get_context("spawn"))
+
+    @pytest.fixture
+    def cluster_adapter(self) -> DatabricksAdapter:
+        return self._make_adapter("sql/protocolv1/o/1234567890123456/1234-567890-test123")
+
+    @pytest.fixture
+    def warehouse_adapter(self) -> DatabricksAdapter:
+        return self._make_adapter("/sql/1.0/warehouses/abc123")
+
+    def test_warehouse_returns_true_for_sql_warehouse_supported_capability(self, warehouse_adapter):
+        stub = warehouse_adapter._parse_replacements_["has_dbr_capability"]
+        assert stub("timestampdiff") is True
+        assert stub("insert_by_name") is True
+        assert stub("comment_on_column") is True
+        assert stub("replace_on") is True
+        assert stub("iceberg") is True
+
+    def test_warehouse_returns_false_for_unsupported_capability(self, warehouse_adapter):
+        # STREAMING_TABLE_JSON_METADATA is cluster-only (sql_warehouse_supported=False).
+        stub = warehouse_adapter._parse_replacements_["has_dbr_capability"]
+        assert stub("streaming_table_json_metadata") is False
+
+    def test_cluster_returns_false_for_all_capabilities(self, cluster_adapter):
+        stub = cluster_adapter._parse_replacements_["has_dbr_capability"]
+        assert stub("timestampdiff") is False
+        assert stub("insert_by_name") is False
+        assert stub("comment_on_column") is False
+        assert stub("streaming_table_json_metadata") is False
+
+    def test_unknown_capability_returns_false(self, warehouse_adapter, cluster_adapter):
+        # Runtime method raises ValueError; parse stub silently returns False.
+        for adapter in (warehouse_adapter, cluster_adapter):
+            stub = adapter._parse_replacements_["has_dbr_capability"]
+            assert stub("not_a_real_capability") is False


### PR DESCRIPTION
Motivated by [#1331](https://github.com/databricks/dbt-databricks/issues/1331).

The class-level `@available.parse(lambda *a, **k: False)` stub on `has_dbr_capability` returns a constant `False` at parse time, so every macro branching on a capability takes the legacy path during parse/compile — even on SQL warehouses, which support all capabilities we currently ship.

This is a 1.11.0 regression: the pre-1.11 stub (`compare_dbr_version`) returned `0`, and `0 >= 0` accidentally selected the modern path.

## Fix

Shadow `_parse_replacements_` at adapter `__init__` with a bound method that consults the profile's `http_path`:

- **SQL warehouse** → `True` for capabilities with `sql_warehouse_supported=True`.
- **Cluster** → `False` (real DBR version is only known at runtime).

Cluster users on supported DBR are still affected — fully fixing that requires a larger change. This PR is the contained warehouse-only fix.

## Test plan

- [x] `hatch run pytest tests/unit/test_adapter_capabilities.py -v` — 19 pass (4 new).
- [x] `hatch run pre-commit run --all-files` — clean.
- [ ] CI functional run.