### PR TITLE
test: try -n auto for faster unit tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,8 +91,8 @@ uc-cluster-e2e-dev = "pytest --color=yes -v --profile databricks_uc_cluster -n 1
 sqlw-e2e-dev = "pytest --color=yes -v --profile databricks_uc_sql_endpoint -n 10 --dist=loadfile tests/functional"
 
 [tool.hatch.envs.test.scripts]
-unit = "pytest --color=yes -v --profile databricks_cluster -n 10 --dist=loadscope tests/unit"
-unit-with-cov = "pytest --color=yes -v --profile databricks_cluster -n 10 --dist=loadscope tests/unit --cov=dbt"
+unit = "pytest --color=yes -v --profile databricks_cluster -n auto --dist=loadscope tests/unit"
+unit-with-cov = "pytest --color=yes -v --profile databricks_cluster -n auto --dist=loadscope tests/unit --cov=dbt"
 
 [[tool.hatch.envs.test.matrix]]
 python = ["3.10", "3.11", "3.12", "3.13"]


### PR DESCRIPTION
Unit tests are CPU-bound and run on small-CPU CI runners. Switching pytest-xdist from `-n 10` → `-n auto` matches workers to actual core count and removes context-switching contention.

Per-Python "Run Unit Tests and Generate Coverage" step duration (baseline = mean of last 3 `main` runs; treatment = mean of 3 reruns on this PR):

> Note: 3.12 is slower as it calculates Coverage Report as well

| Python | Baseline | Treatment | Δ |
|---|---|---|---|
| 3.10 | 3m 37s | 3m 23s | −6% |
| 3.11 | 3m 34s | 3m 20s | −7% |
| 3.12 | 12m 44s | 5m 19s | **−58%** |
| 3.13 | 3m 54s | 3m 39s | −6% |

py3.12 gates the matrix wall-clock and drops from ~13m → ~5m. All 12 treatment jobs passed (758 tests, 6 skipped).