### PR TITLE
ci: add post-merge min-deps parse gate

### DIFF
--- a/.github/workflows/min-deps-parse.yml
+++ b/.github/workflows/min-deps-parse.yml
@@ -10,6 +10,7 @@ on:
     branches:
       - "main"
       - "*.latest"
+  pull_request:  # TEMP: remove before merge — only here to prove the gate works on this PR
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/min-deps-parse.yml
+++ b/.github/workflows/min-deps-parse.yml
@@ -1,0 +1,54 @@
+# Installs dbt-databricks at lowest-direct dependency resolution and
+# runs `dbt parse`, catching constraint ranges that admit versions
+# the code doesn't support. Default test paths resolve to
+# highest-compatible versions, so lower bounds drift untested.
+
+name: Min-Deps Parse
+
+on:
+  push:
+    branches:
+      - "main"
+      - "*.latest"
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  parse-at-lowest-direct:
+    name: dbt parse at lowest-direct resolution
+    runs-on:
+      group: databricks-protected-runner-group
+      labels: linux-ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+      - name: Setup JFrog PyPI Proxy
+        uses: ./.github/actions/setup-jfrog-pypi
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
+        with:
+          python-version: "3.10"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a  # v4
+        with:
+          cache-local-path: ~/.cache/uv
+
+      - name: Install dbt-databricks at lowest-direct dep resolution
+        run: |
+          uv venv --python 3.10
+          uv pip install --resolution lowest-direct .
+
+      - name: dbt parse against min-deps fixture
+        run: .venv/bin/dbt parse --project-dir tests/min_deps_smoke --profiles-dir tests/min_deps_smoke

--- a/.github/workflows/min-deps-parse.yml
+++ b/.github/workflows/min-deps-parse.yml
@@ -2,6 +2,11 @@
 # runs `dbt parse`, catching constraint ranges that admit versions
 # the code doesn't support. Default test paths resolve to
 # highest-compatible versions, so lower bounds drift untested.
+#
+# Runs post-merge rather than on PRs because fork PRs cannot issue
+# the OIDC token required by the JFrog proxy and protected runner.
+# Acceptable compromise: a bad merge sits on the target branch
+# briefly before the gate fires, but well before any release tag.
 
 name: Min-Deps Parse
 

--- a/.github/workflows/min-deps-parse.yml
+++ b/.github/workflows/min-deps-parse.yml
@@ -10,7 +10,6 @@ on:
     branches:
       - "main"
       - "*.latest"
-  pull_request:  # TEMP: remove before merge — only here to prove the gate works on this PR
   workflow_dispatch:
 
 permissions:

--- a/tests/min_deps_smoke/.gitignore
+++ b/tests/min_deps_smoke/.gitignore
@@ -1,0 +1,4 @@
+target/
+logs/
+dbt_packages/
+.user.yml

--- a/tests/min_deps_smoke/dbt_project.yml
+++ b/tests/min_deps_smoke/dbt_project.yml
@@ -1,0 +1,5 @@
+name: 'min_deps_smoke'
+version: '1.0.0'
+config-version: 2
+
+profile: 'min_deps_smoke'

--- a/tests/min_deps_smoke/models/select_one.sql
+++ b/tests/min_deps_smoke/models/select_one.sql
@@ -1,0 +1,1 @@
+select 1 as n

--- a/tests/min_deps_smoke/profiles.yml
+++ b/tests/min_deps_smoke/profiles.yml
@@ -1,0 +1,9 @@
+min_deps_smoke:
+  target: dev
+  outputs:
+    dev:
+      type: databricks
+      schema: min_deps_smoke
+      host: fake.databricks.test
+      http_path: /sql/1.0/warehouses/fake
+      token: fake-token


### PR DESCRIPTION
### Description

Post-merge CI gate. Installs dbt-databricks at `uv pip install --resolution lowest-direct` and runs `dbt parse` against an embedded minimal project. Catches constraint ranges that admit versions the code doesn't support.

### Testing

[Run 25900943714](https://github.com/databricks/dbt-databricks/actions/runs/25900943714) — gate fired and failed with the `model_validator from pydantic` ImportError that broke 1.12.0's release verification. Run was via a temporary `pull_request:` trigger, reverted in the next commit. Validates the full pipeline (JFrog proxy + protected runner + uv lowest-direct + dbt parse).

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.