### PR TITLE
chore(changelog): collapse 1.12.1 into 1.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 - Fix `metric_view` failing with `METRIC_VIEW_INVALID_VIEW_DEFINITION` when models use bare `{{ ref(...) }}` for the `source:` field ([#1361](https://github.com/databricks/dbt-databricks/issues/1361))
 - Fix `RefreshConfig.__eq__` self/other typo where two configs with the same `cron` but different `time_zone_value` compared equal
 - Fix streaming-table DROP-SCHEDULE path that was silently filtered out of the changeset
-- Use pydantic v1-compatible API in `refresh.py` so the adapter imports on environments shipping pydantic v1 (notably DBR 15.x runtimes) ([#1461](https://github.com/databricks/dbt-databricks/pull/1461))
+- Use pydantic v1-compatible API in `refresh.py` so the adapter imports on environments shipping pydantic v1 ([#1461](https://github.com/databricks/dbt-databricks/pull/1461))
 
 ### Under the Hood
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,4 @@
-## dbt-databricks 1.12.1 (TBD)
-
-### Fixes
-
-- Use pydantic v1-compatible API in `refresh.py` so the adapter works on environments shipping pydantic v1.
-
-## dbt-databricks 1.12.0 (May 14, 2026)
+## dbt-databricks 1.12.0 (May 18, 2026)
 
 ### Features
 
@@ -20,6 +14,7 @@
 - Fix `metric_view` failing with `METRIC_VIEW_INVALID_VIEW_DEFINITION` when models use bare `{{ ref(...) }}` for the `source:` field ([#1361](https://github.com/databricks/dbt-databricks/issues/1361))
 - Fix `RefreshConfig.__eq__` self/other typo where two configs with the same `cron` but different `time_zone_value` compared equal
 - Fix streaming-table DROP-SCHEDULE path that was silently filtered out of the changeset
+- Use pydantic v1-compatible API in `refresh.py` so the adapter imports on environments shipping pydantic v1 (notably DBR 15.x runtimes) ([#1461](https://github.com/databricks/dbt-databricks/pull/1461))
 
 ### Under the Hood
 


### PR DESCRIPTION
## Summary

Folds the `1.12.1 (TBD)` entry into `1.12.0` and sets the release date to **May 18, 2026** (upcoming Monday).

## Why

`v1.12.0` was tagged at `75753515` but never published to PyPI: pre-release Databricks Jobs verification caught a pydantic-import regression on DBR 15.4 ([details](https://adb-6436897454825492.12.azuredatabricks.net/jobs/runs/495666598031332)). The fix landed as #1461 on `main`.

Since 1.12.0 never reached production PyPI, there's no published artifact pinned to the buggy commit. Cleanest path is to collapse 1.12.1 back into 1.12.0 rather than carry a one-bullet patch release.

## Bookkeeping (done outside this PR)

- The `v1.12.0` GitHub tag at `75753515` has been **deleted** — it will be re-cut on the merge commit of this PR before publishing.
- test-pypi will need the existing `1.12.0` release deleted before re-uploading from the new tag.