### PR TITLE
fix: missing f-string prefix in JobRunsApi.submit debug log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - Expose `job_id`, `job_run_id`, and `task_run_id` from the Databricks Jobs `dbt_task` runtime in `adapter_response`, enabling correlation between dbt runs and Databricks workflow executions via `run_results.json` ([#1451](https://github.com/databricks/dbt-databricks/pull/1451) closes [#722](https://github.com/databricks/dbt-databricks/issues/722))
 
+### Fixes
+
+- Fix missing f-string prefix in `JobRunsApi.submit` debug log ([#1471](https://github.com/databricks/dbt-databricks/pull/1471))
+
 ## dbt-databricks 1.12.0 (May 18, 2026)
 
 ### Features

--- a/dbt/adapters/databricks/api_client.py
+++ b/dbt/adapters/databricks/api_client.py
@@ -483,7 +483,7 @@ class JobRunsApi:
     ) -> str:
         logger.debug(
             f"Submitting job with run_name={run_name} and job_spec={job_spec}"
-            " and additional_job_settings={additional_job_settings}"
+            f" and additional_job_settings={additional_job_settings}"
         )
         try:
             tasks = self._convert_job_spec_to_tasks(job_spec)


### PR DESCRIPTION
<!-- Please review our pull request review process in CONTRIBUTING.md before your proceed. -->

Resolves #

<!---
  Include the number of the issue addressed by this PR above if applicable.
  Example:
    resolves #1234
  Please review our pull request review process in CONTRIBUTING.md before your proceed.
-->

### Description

In `JobRunsApi.submit`, the `logger.debug` call constructs its message via
implicit string concatenation across two lines. The second string literal was
missing the `f` prefix, causing `{additional_job_settings}` to be emitted
**verbatim** in the log output instead of interpolating the actual value.

**Before:**
```python
logger.debug(
    f"Submitting job with run_name={run_name} and job_spec={job_spec}"
    " and additional_job_settings={additional_job_settings}"
)
```

**After:**
```python
logger.debug(
    f"Submitting job with run_name={run_name} and job_spec={job_spec}"
    f" and additional_job_settings={additional_job_settings}"
)
```

One character change (`f` prefix added). No logic, behaviour, or API surface
is affected.

### Checklist

- [ ] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.