### PR TITLE
test: stabilize UC-cluster flake retry and ACL skip ordering

### DIFF
--- a/tests/functional/adapter/python_model/test_python_model.py
+++ b/tests/functional/adapter/python_model/test_python_model.py
@@ -138,6 +138,7 @@ class TestChangingSchemaIncremental:
 
 @pytest.mark.python
 @pytest.mark.skip_profile("databricks_cluster", "databricks_uc_cluster")
+@pytest.mark.flaky(reruns=2, reruns_delay=120)
 class TestSpecifyingHttpPath(BasePythonModelTests):
     @pytest.fixture(scope="class")
     def models(self):
@@ -280,6 +281,9 @@ class TestWorkflowJob:
 @pytest.mark.python
 @pytest.mark.acl
 @pytest.mark.skip_profile("databricks_uc_sql_endpoint")
+@pytest.mark.skipif(
+    not ACL_TESTS_ENABLED, reason="ACL tests disabled (set DBT_ENABLE_ACL_TESTS=1 to enable)"
+)
 class TestPythonModelNotebookACL:
     @pytest.fixture(scope="class")
     def models(self):
@@ -293,9 +297,6 @@ class TestPythonModelNotebookACL:
         return {"models": {"+create_notebook": "true"}}
 
     def test_python_model_with_notebook_acl(self, project):
-        if not ACL_TESTS_ENABLED:
-            pytest.skip("ACL tests are not enabled")
-
         result = util.run_dbt(["run"])
         assert len(result) == 1
 
@@ -346,6 +347,9 @@ class TestPythonModelNotebookACL:
 @pytest.mark.python
 @pytest.mark.acl
 @pytest.mark.skip_profile("databricks_uc_sql_endpoint")
+@pytest.mark.skipif(
+    not ACL_TESTS_ENABLED, reason="ACL tests disabled (set DBT_ENABLE_ACL_TESTS=1 to enable)"
+)
 class TestPythonModelAccessControlList:
     @pytest.fixture(scope="class")
     def models(self):
@@ -359,9 +363,6 @@ class TestPythonModelAccessControlList:
         return {"models": {"+create_notebook": "true"}}
 
     def test_python_model_with_access_control_list(self, project):
-        if not ACL_TESTS_ENABLED:
-            pytest.skip("ACL tests are not enabled")
-
         adapter = project.adapter
         conn_mgr = adapter.connections
         api_client = conn_mgr.api_client


### PR DESCRIPTION
## Summary

Two test-only fixes triggered by nightly run [26192790727](https://github.com/databricks/dbt-databricks/actions/runs/26192790727). Both observed failures were environmental — no dbt-databricks regression.

- **`TestSpecifyingHttpPath`** — add `@pytest.mark.flaky(reruns=2, reruns_delay=120)`. The test drives a python model on the shared UC all-purpose cluster, which intermittently fails with *"Could not reach driver of cluster"*. Same failure observed on at least 4 nightly/dispatch runs spanning 3 unrelated SHAs (2026-05-08, 2026-05-14, 2026-05-20 ×2). Real assertion failures still surface; only transient cluster-warm issues retry.

- **`TestPythonModelNotebookACL` + `TestPythonModelAccessControlList`** — move `ACL_TESTS_ENABLED` skip from test body to class-level `@pytest.mark.skipif`. The `project` fixture is class-scope and ran before the in-body skip, so a transient SQL-warehouse AADSTS blip in the failing nightly turned a clean SKIP into ERROR at setup. `skipif` fires before any fixture runs.

## Test plan

- [x] `hatch run pre-commit run --all-files` clean.
- [x] Skip path (ACL disabled): `1 skipped in 0.68s`, no DB hit.
- [x] Run path (`DBT_ENABLE_ACL_TESTS=1 --profile databricks_uc_cluster`): body executes end-to-end through the ACL API call; fails only because `DBT_TEST_USER_*` is unset (workspace user does not exist) — equivalent to today's CI state where ACL tests are off.
- [ ] Run integration tests to verify