### PR TITLE
chore(deps): bump databricks-sdk and databricks-sql-connector ceilings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 - Fix missing f-string prefix in `JobRunsApi.submit` debug log ([#1471](https://github.com/databricks/dbt-databricks/pull/1471))
 
+### Under the Hood
+
+- Defer SDK `Config` construction to connection-open time so offline paths (`dbt parse`/`list`/`compile`) don't trigger the host-metadata probe introduced in `databricks-sdk>=0.103`; as a side effect, auth errors now surface at first connection rather than during profile parsing. ([#1474](https://github.com/databricks/dbt-databricks/pull/1474))
+
 ## dbt-databricks 1.12.0 (May 18, 2026)
 
 ### Features

--- a/dbt/adapters/databricks/credentials.py
+++ b/dbt/adapters/databricks/credentials.py
@@ -331,10 +331,15 @@ class DatabricksCredentialManager(DataClassDictMixin):
         )
 
     def __post_init__(self) -> None:
+        # Defer Config construction to first use so dbt parse/list/compile
+        # stay offline.
         if not hasattr(self, "_config"):
             self._config: Optional[Config] = None
+
+    def _ensure_config(self) -> Config:
+        """Build (or return cached) SDK Config. Triggers authentication."""
         if self._config is not None:
-            return
+            return self._config
 
         if self.token:
             self._config = self.authenticate_with_pat()
@@ -380,9 +385,13 @@ class DatabricksCredentialManager(DataClassDictMixin):
                         )
                         raise Exception(f"All authentication methods failed. Details: {exceptions}")
 
+        # Narrow Optional[Config] for the return type.
+        assert self._config is not None
+        return self._config
+
     @property
     def api_client(self) -> WorkspaceClient:
-        return WorkspaceClient(config=self._config)
+        return WorkspaceClient(config=self._ensure_config())
 
     @property
     def credentials_provider(self) -> PySQLCredentialProvider:
@@ -393,14 +402,10 @@ class DatabricksCredentialManager(DataClassDictMixin):
 
     @property
     def header_factory(self) -> CredentialsProvider:
-        if self._config is None:
-            raise RuntimeError("Config is not initialized")
-        header_factory = self._config._header_factory
+        header_factory = self._ensure_config()._header_factory
         assert header_factory is not None, "Header factory is not set."
         return header_factory
 
     @property
     def config(self) -> Config:
-        if self._config is None:
-            raise RuntimeError("Config is not initialized")
-        return self._config
+        return self._ensure_config()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,13 +23,14 @@ classifiers = [
 ]
 dependencies = [
     "click>=8.2.0, <9.0.0",
-    "databricks-sdk>=0.68.0, <0.78.0",
-    "databricks-sql-connector[pyarrow]>=4.1.1, <4.1.6",
+    "databricks-sdk>=0.68.0, <0.105.0",
+    "databricks-sql-connector[pyarrow]>=4.1.1, <4.3.0",
     "dbt-adapters>=1.22.0, <1.23.0",
     "dbt-common>=1.37.0, <1.38.0",
     "dbt-core>=1.11.2, <1.11.9",
     "dbt-spark>=1.10.0, <1.11.0",
     "keyring>=23.13.0, <25.6.0",
+    "packaging>=21.0, <26.0",
     "pydantic>=1.10.0, <2.13.0",
 ]
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,0 +1,23 @@
+"""Unit-test-only fixtures."""
+
+from contextlib import nullcontext
+from unittest import mock
+
+import pytest
+from databricks.sdk import config as _sdk_config
+
+# databricks-sdk >=0.103 added a network probe to Config(); on older SDKs
+# this symbol doesn't exist and there's nothing to stub.
+_SDK_HAS_HOST_METADATA = hasattr(_sdk_config, "get_host_metadata")
+
+
+@pytest.fixture(autouse=True)
+def _stub_sdk_host_metadata():
+    """Stub the SDK's host-metadata probe — unit tests must stay offline."""
+    if not _SDK_HAS_HOST_METADATA:
+        with nullcontext() as m:
+            yield m
+        return
+    with mock.patch("databricks.sdk.config.get_host_metadata") as m:
+        m.side_effect = ValueError("offline unit test")
+        yield m

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -1,11 +1,155 @@
 import os
 import tempfile
 from os.path import join
+from unittest import mock
 
 import keyring.backend
 import pytest
+from databricks.sdk import config as _sdk_config
 
 from dbt.adapters.databricks.credentials import DatabricksCredentials
+
+# databricks-sdk >=0.103 added a network probe to Config(); on older SDKs
+# this symbol doesn't exist and the lazy `_ensure_config` path is unnecessary.
+_REQUIRES_LAZY_CONFIG = pytest.mark.skipif(
+    not hasattr(_sdk_config, "get_host_metadata"),
+    reason="lazy _ensure_config is only required when Config() does a network probe",
+)
+
+
+_COMMON_KWARGS = {
+    "host": "yourorg.databricks.com",
+    "database": "andre",
+    "http_path": "sql/protocolv1/o/1234567890123456/1234-cluster",
+    "schema": "dbt",
+}
+
+
+@_REQUIRES_LAZY_CONFIG
+class TestParseTimeIsOffline:
+    """`dbt parse/list/compile` must stay fully offline. Building
+    `DatabricksCredentials` is on that path, so for every supported auth
+    method we verify that constructing the credentials never calls
+    `Config()` (which is what triggers the SDK's network I/O)."""
+
+    def test_pat_credentials_init_does_not_call_config(self):
+        with mock.patch("dbt.adapters.databricks.credentials.Config") as mock_config:
+            DatabricksCredentials(token="foo", **_COMMON_KWARGS)
+            mock_config.assert_not_called()
+
+    def test_oauth_m2m_credentials_init_does_not_call_config(self):
+        with mock.patch("dbt.adapters.databricks.credentials.Config") as mock_config:
+            DatabricksCredentials(
+                client_id="cid",
+                client_secret="dose-secret",
+                **_COMMON_KWARGS,
+            )
+            mock_config.assert_not_called()
+
+    def test_external_browser_credentials_init_does_not_call_config(self):
+        # client_id with no client_secret triggers external-browser auth
+        with mock.patch("dbt.adapters.databricks.credentials.Config") as mock_config:
+            DatabricksCredentials(client_id="cid", **_COMMON_KWARGS)
+            mock_config.assert_not_called()
+
+    def test_azure_client_secret_credentials_init_does_not_call_config(self):
+        with mock.patch("dbt.adapters.databricks.credentials.Config") as mock_config:
+            DatabricksCredentials(
+                azure_client_id="acid",
+                azure_client_secret="asecret",
+                **_COMMON_KWARGS,
+            )
+            mock_config.assert_not_called()
+
+
+@_REQUIRES_LAZY_CONFIG
+class TestEnsureConfigTriggersTheRightAuth:
+    """Connect-time counterpart to TestParseTimeIsOffline: when something
+    actually does need the config (e.g. opening a connection), `_ensure_config`
+    must build it via the correct auth method per credential shape. This also
+    exercises every branch of the selection logic in `_ensure_config`."""
+
+    def test_pat_uses_pat_auth(self):
+        creds = DatabricksCredentials(token="foo", **_COMMON_KWARGS)
+        with mock.patch("dbt.adapters.databricks.credentials.Config") as mock_config:
+            creds.authenticate().config
+            mock_config.assert_called_once_with(host=_COMMON_KWARGS["host"], token="foo")
+
+    def test_explicit_azure_uses_azure_client_secret(self):
+        creds = DatabricksCredentials(
+            azure_client_id="acid",
+            azure_client_secret="asecret",
+            auth_type="oauth",
+            **_COMMON_KWARGS,
+        )
+        with mock.patch("dbt.adapters.databricks.credentials.Config") as mock_config:
+            creds.authenticate().config
+            mock_config.assert_called_once_with(
+                host=_COMMON_KWARGS["host"],
+                azure_client_id="acid",
+                azure_client_secret="asecret",
+                auth_type="azure-client-secret",
+            )
+
+    def test_client_id_only_uses_external_browser(self):
+        creds = DatabricksCredentials(client_id="cid", auth_type="oauth", **_COMMON_KWARGS)
+        with mock.patch("dbt.adapters.databricks.credentials.Config") as mock_config:
+            creds.authenticate().config
+            mock_config.assert_called_once_with(
+                host=_COMMON_KWARGS["host"],
+                client_id="cid",
+                client_secret="",
+                auth_type="external-browser",
+            )
+
+    def test_dose_secret_tries_oauth_m2m_first(self):
+        creds = DatabricksCredentials(
+            client_id="cid",
+            client_secret="dose-secret",
+            auth_type="oauth",
+            **_COMMON_KWARGS,
+        )
+        with mock.patch("dbt.adapters.databricks.credentials.Config") as mock_config:
+            creds.authenticate().config
+            mock_config.assert_called_once_with(
+                host=_COMMON_KWARGS["host"],
+                client_id="cid",
+                client_secret="dose-secret",
+                auth_type="oauth-m2m",
+            )
+
+    def test_non_dose_secret_tries_legacy_azure_first(self):
+        creds = DatabricksCredentials(
+            client_id="cid",
+            client_secret="plain-secret",
+            auth_type="oauth",
+            **_COMMON_KWARGS,
+        )
+        with mock.patch("dbt.adapters.databricks.credentials.Config") as mock_config:
+            creds.authenticate().config
+            mock_config.assert_called_once_with(
+                host=_COMMON_KWARGS["host"],
+                azure_client_id="cid",
+                azure_client_secret="plain-secret",
+                auth_type="azure-client-secret",
+            )
+
+    def test_falls_back_to_second_method_when_first_raises(self):
+        creds = DatabricksCredentials(
+            client_id="cid",
+            client_secret="plain-secret",
+            auth_type="oauth",
+            **_COMMON_KWARGS,
+        )
+        fake_config = mock.MagicMock()
+        with mock.patch("dbt.adapters.databricks.credentials.Config") as mock_config:
+            mock_config.side_effect = [RuntimeError("first method fails"), fake_config]
+            creds.authenticate().config
+            assert mock_config.call_count == 2
+            # First call: legacy-azure (default order for non-dose secret).
+            assert mock_config.call_args_list[0].kwargs["auth_type"] == "azure-client-secret"
+            # Second call: oauth-m2m fallback.
+            assert mock_config.call_args_list[1].kwargs["auth_type"] == "oauth-m2m"
 
 
 @pytest.mark.skip(reason="Need to mock requests to OIDC")

--- a/uv.lock
+++ b/uv.lock
@@ -2,7 +2,8 @@ version = 1
 revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
-    "python_full_version >= '3.13'",
+    "python_full_version >= '3.14'",
+    "python_full_version == '3.13.*'",
     "python_full_version == '3.12.*'",
     "python_full_version == '3.11.*'",
     "python_full_version < '3.11'",
@@ -350,36 +351,37 @@ wheels = [
 
 [[package]]
 name = "databricks-sdk"
-version = "0.77.0"
+version = "0.104.0"
 source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "google-auth" },
     { name = "protobuf" },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1e/54/f2393af72974d8e70bfd44b52f17b917190b4934bab66508f4afec9e9285/databricks_sdk-0.77.0.tar.gz", hash = "sha256:56b6017ae17dc31ee821e49746d2ff627a029127166c702088428527813422bd", size = 827462, upload-time = "2026-01-06T13:19:09.432Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/71/ac/8e541337e36c4bb10811a57b505530d996c2c760391b08b275cc04858f62/databricks_sdk-0.104.0.tar.gz", hash = "sha256:527c35aac3a28665a7933f34b7dd0c1bd6e9450a487f2c02fcfb6dce72ca82c9", size = 910975, upload-time = "2026-04-23T07:53:09.117Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/03/aa/d9186684dbcd338cf51e93621bcf53efa843fe647c0f29f549ebddbf2870/databricks_sdk-0.77.0-py3-none-any.whl", hash = "sha256:42e3211b7dbd53b81a795981149ee08d5b025442a73e464264569edc8c46ee0a", size = 779180, upload-time = "2026-01-06T13:19:07.757Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/7b/5a82875dc4b92b60cdc233b153dda3a0d599e4fc169753c3e351850ebd5b/databricks_sdk-0.104.0-py3-none-any.whl", hash = "sha256:37d1b7b123c027ca4a2e6c783036f932956a354ca92d26076a4fcfab9a58caa7", size = 858519, upload-time = "2026-04-23T07:53:07.476Z" },
 ]
 
 [[package]]
 name = "databricks-sql-connector"
-version = "4.1.5"
+version = "4.2.6"
 source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "lz4" },
     { name = "oauthlib" },
     { name = "openpyxl" },
     { name = "pandas" },
+    { name = "pybreaker" },
     { name = "pyjwt" },
     { name = "python-dateutil" },
     { name = "requests" },
     { name = "thrift" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/36/37/c842e73242a00f54cd82806b15db6c8899da53ec99e67fbccfa3db1812f4/databricks_sql_connector-4.1.5.tar.gz", hash = "sha256:e3e22554c0fb11011b830d88d735c0d0629eea8328944f47ce5b241e501a87ba", size = 178578, upload-time = "2026-03-23T12:18:13.202Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2b/2f/2c1a96b1d40d53dc9a0abf639c823895b6da76b1b5dc2f2230df2ae1aa6c/databricks_sql_connector-4.2.6.tar.gz", hash = "sha256:65e59f08e55dcc563c05e02e2321d5171dd9482e5792328d99ac097377795d01", size = 189069, upload-time = "2026-04-23T10:40:33.878Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b7/88/5980d75fa709ed76508ebcf583bf85b22941833ab3c810ec75b39be14f09/databricks_sql_connector-4.1.5-py3-none-any.whl", hash = "sha256:9a65155e576c4971d1037b772a322f57b28497c6cdfa4bb2851e471c163c3569", size = 202555, upload-time = "2026-03-23T12:18:11.291Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/4f/4ea282af1e413d26e47b9e987c1cbef1d3fc599da81eb54ac2bf74b6b822/databricks_sql_connector-4.2.6-py3-none-any.whl", hash = "sha256:61e0f425c990a0ec52c31165ea7dd0582cc0ad90c5fbd5fc9bea59bb38faeb00", size = 216743, upload-time = "2026-04-23T10:40:32.216Z" },
 ]
 
 [package.optional-dependencies]
@@ -475,19 +477,21 @@ dependencies = [
     { name = "dbt-core" },
     { name = "dbt-spark" },
     { name = "keyring" },
+    { name = "packaging" },
     { name = "pydantic" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "click", specifier = ">=8.2.0,<9.0.0" },
-    { name = "databricks-sdk", specifier = ">=0.68.0,<0.78.0" },
-    { name = "databricks-sql-connector", extras = ["pyarrow"], specifier = ">=4.1.1,<4.1.6" },
+    { name = "databricks-sdk", specifier = ">=0.68.0,<0.105.0" },
+    { name = "databricks-sql-connector", extras = ["pyarrow"], specifier = ">=4.1.1,<4.3.0" },
     { name = "dbt-adapters", specifier = ">=1.22.0,<1.23.0" },
     { name = "dbt-common", specifier = ">=1.37.0,<1.38.0" },
     { name = "dbt-core", specifier = ">=1.11.2,<1.11.9" },
     { name = "dbt-spark", specifier = ">=1.10.0,<1.11.0" },
     { name = "keyring", specifier = ">=23.13.0,<25.6.0" },
+    { name = "packaging", specifier = ">=21.0,<26.0" },
     { name = "pydantic", specifier = ">=1.10.0,<2.13.0" },
 ]
 
@@ -981,7 +985,8 @@ name = "networkx"
 version = "3.6.1"
 source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 resolution-markers = [
-    "python_full_version >= '3.13'",
+    "python_full_version >= '3.14'",
+    "python_full_version == '3.13.*'",
     "python_full_version == '3.12.*'",
     "python_full_version == '3.11.*'",
 ]
@@ -1060,7 +1065,8 @@ name = "numpy"
 version = "2.4.3"
 source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 resolution-markers = [
-    "python_full_version >= '3.13'",
+    "python_full_version >= '3.14'",
+    "python_full_version == '3.13.*'",
     "python_full_version == '3.12.*'",
     "python_full_version == '3.11.*'",
 ]
@@ -1171,11 +1177,11 @@ wheels = [
 
 [[package]]
 name = "packaging"
-version = "26.0"
+version = "25.0"
 source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416, upload-time = "2026-01-21T20:50:39.064Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727, upload-time = "2025-04-19T11:48:59.673Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366, upload-time = "2026-01-21T20:50:37.788Z" },
+    { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469, upload-time = "2025-04-19T11:48:57.875Z" },
 ]
 
 [[package]]
@@ -1336,6 +1342,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e9/e6/78ebbb10a8c8e4b61a59249394a4a594c1a7af95593dc933a349c8d00964/pyasn1_modules-0.4.2.tar.gz", hash = "sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6", size = 307892, upload-time = "2025-03-28T02:41:22.17Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/47/8d/d529b5d697919ba8c11ad626e835d4039be708a35b0d22de83a269a6682c/pyasn1_modules-0.4.2-py3-none-any.whl", hash = "sha256:29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a", size = 181259, upload-time = "2025-03-28T02:41:19.028Z" },
+]
+
+[[package]]
+name = "pybreaker"
+version = "1.4.1"
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
+sdist = { url = "https://files.pythonhosted.org/packages/f2/89/fbf98e383f1ec6d117af2cd983efdb3eb7018b63834c427025764194cac2/pybreaker-1.4.1.tar.gz", hash = "sha256:8df2d245c73ba40c8242c56ffb4f12138fbadc23e296224740c2028ea9dc1178", size = 15555, upload-time = "2025-09-21T15:12:04.499Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/44/75/e64d3d40a741e2be21d69154f4e5c43a66f0c603c5ef11f49e01429a5932/pybreaker-1.4.1-py3-none-any.whl", hash = "sha256:b4dab4a05195b7f2a64a6c1a6c4ba7a96534ef56ea7210e6bcb59f28897160e0", size = 12915, upload-time = "2025-09-21T15:12:02.284Z" },
 ]
 
 [[package]]
@@ -1822,12 +1837,9 @@ wheels = [
 
 [[package]]
 name = "thrift"
-version = "0.20.0"
+version = "0.22.0"
 source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
-dependencies = [
-    { name = "six" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/3c/2d/8946864f716ac82dcc88d290ed613cba7a80ec75df4f553ec3ff275f486e/thrift-0.20.0.tar.gz", hash = "sha256:4dd662eadf6b8aebe8a41729527bd69adf6ceaa2a8681cbef64d1273b3e8feba", size = 62295, upload-time = "2024-03-22T22:53:08.228Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b2/c2/db648cc10dd7d15560f2eafd92a27cd280811924696e0b4a87175fb28c94/thrift-0.22.0.tar.gz", hash = "sha256:42e8276afbd5f54fe1d364858b6877bc5e5a4a5ed69f6a005b94ca4918fe1466", size = 62303, upload-time = "2025-05-23T20:49:33.309Z" }
 
 [[package]]
 name = "typing-extensions"


### PR DESCRIPTION
Bump ceilings on `databricks-sdk` and `databricks-sql-connector` to admit newer versions. Floors unchanged.

- `databricks-sdk`: `<0.78.0` → `<0.105.0`
- `databricks-sql-connector[pyarrow]`: `<4.1.6` → `<4.3.0`
- `packaging>=21.0, <26.0` declared explicitly (was transitive via `dbt-core`).
- `uv.lock` refreshed to the latest within the new ranges.