### PR TITLE
docs(changelog): note deps ceiling bumps from #1474

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Under the Hood
 
 - Defer SDK `Config` construction to connection-open time so offline paths (`dbt parse`/`list`/`compile`) don't trigger the host-metadata probe introduced in `databricks-sdk>=0.103`; as a side effect, auth errors now surface at first connection rather than during profile parsing. ([#1474](https://github.com/databricks/dbt-databricks/pull/1474))
+- Bump ceilings on `databricks-sdk` (now `<0.105.0`) and `databricks-sql-connector[pyarrow]` (now `<4.3.0`) to admit newer releases; floors unchanged. ([#1474](https://github.com/databricks/dbt-databricks/pull/1474))
 
 ## dbt-databricks 1.12.0 (May 18, 2026)
 


### PR DESCRIPTION
Adds the missing Under-the-Hood bullet recording the ceiling bumps on `databricks-sdk` and `databricks-sql-connector[pyarrow]` that landed in #1474 but weren't called out in `CHANGELOG.md` at the time.

Pure docs change — no code touched.