### PR TITLE
fix(ci): pin warm-cache pip to setup-python 3.10, not hatch's bundled pip

### DIFF
--- a/.github/workflows/warmDepsCache.yml
+++ b/.github/workflows/warmDepsCache.yml
@@ -101,10 +101,19 @@ jobs:
         run: hatch run pre-commit install-hooks
 
       - name: Create pip wheelhouse
+        # Use setup-python's Python 3.10 directly, NOT `hatch run pip`.
+        # With `installer = "uv"` on the default env, uv-created venvs have
+        # no pip, so `hatch run pip` falls back to hatch's bundled pip
+        # running on hatch's own Python 3.12. That pip evaluates
+        # `python_version < "3.11"` as False and silently drops conditional
+        # deps (e.g. tomli) — breaking offline env recreation in PR jobs.
         run: |
           set -euo pipefail
           mkdir -p ~/.cache/pip-wheelhouse
-          hatch run python -c "
+          # Bootstrap tomli for the pyproject.toml parser below (Python 3.10
+          # has no stdlib tomllib). One-shot install into the runner Python.
+          python -m pip install --quiet tomli
+          python -c "
           try:
               import tomllib
           except ImportError:
@@ -114,11 +123,21 @@ jobs:
           for dep in data['project']['dependencies']:
               print(dep)
           " > /tmp/runtime-deps.txt
-          hatch run pip download --dest ~/.cache/pip-wheelhouse \
+          python -m pip download --dest ~/.cache/pip-wheelhouse \
             setuptools wheel twine check-wheel-contents \
             -r /tmp/runtime-deps.txt
-          hatch run pip download --dest ~/.cache/pip-wheelhouse \
+          python -m pip download --dest ~/.cache/pip-wheelhouse \
             --no-deps --require-hashes -r requirements.lowest-direct.txt
+
+      - name: Verify wheelhouse covers verify-min-deps offline install
+        # Guard against silent dep drops: confirm pip can install the
+        # verify-min-deps env's dependency set from the wheelhouse alone
+        # (no index). If this step fails, fork PRs would fail offline.
+        run: |
+          set -euo pipefail
+          python -m pip install --dry-run --no-index \
+            --find-links ~/.cache/pip-wheelhouse \
+            wheel twine check-wheel-contents
 
       - name: Build package
         run: hatch -v build


### PR DESCRIPTION
## Summary

`hatch run pip` in `warmDepsCache.yml`'s wheelhouse step resolves to hatch's bundled pip running on **Python 3.12** (because the default env has `installer = "uv"` and uv-created venvs have no pip, so `hatch run pip` falls back to the hatch installer's pip). That pip evaluates `python_version < "3.11"` as False and silently drops conditional deps like `tomli` from the wheelhouse — breaking offline env recreation on fork PRs whose `verify-min-deps` env transitively needs tomli on Python 3.10.

Surfaced on fork PR #1482: `verify-min-deps:check-all` failed with `ERROR: Could not find a version that satisfies the requirement tomli<3.0,>=1.2; python_version < "3.11" (from check-wheel-contents)` during offline env creation.

Switch the wheelhouse step to setup-python's Python 3.10 directly. Add a guard step that fails the warm job if the wheelhouse can't satisfy `verify-min-deps` offline — so future silent drops are caught here, not on fork PRs.

## Test plan

- [x] Diagnostic run on `sd-db/chore/warmcache-diagnose` proved `hatch run pip` → `pip 24.0 (python 3.12)` and marker eval False under the bundled pip.
- [x] Local replication: `python3.10 -m pip download check-wheel-contents` correctly collected tomli + all 10 transitives.
- [x] Fix-branch warm-cache run (`26440181725`): `Collecting tomli<3.0,>=1.2 (from check-wheel-contents)` + guard step green.