### PR TITLE
feat: place snapshot meta-columns first (#1481)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 - Fix missing f-string prefix in `JobRunsApi.submit` debug log ([#1471](https://github.com/databricks/dbt-databricks/pull/1471))
 - Fix capability-branching macros falling through to their legacy path at parse/compile time on SQL warehouses. The parse-time stub of `has_dbr_capability` now returns `True` on warehouse profiles for capabilities flagged `sql_warehouse_supported`, so macros select the modern branch during compilation instead of the legacy fallback. ([#1449](https://github.com/databricks/dbt-databricks/pull/1449) closes [#1331](https://github.com/databricks/dbt-databricks/issues/1331))
 - Fix snapshots not applying `databricks_tags` on columns ([#1442](https://github.com/databricks/dbt-databricks/pull/1442) closes [#1441](https://github.com/databricks/dbt-databricks/issues/1441))
+- Fix snapshots to place meta-columns (`dbt_scd_id`, `dbt_updated_at`, etc.) first in the schema, ensuring they are included in automatic liquid clustering on wide tables ([#1481](https://github.com/databricks/dbt-databricks/issues/1481))
+
 
 ### Under the Hood
 

--- a/dbt/include/databricks/macros/materializations/snapshot_helpers.sql
+++ b/dbt/include/databricks/macros/materializations/snapshot_helpers.sql
@@ -51,14 +51,23 @@
     {%- set columns = config.get("snapshot_table_column_names") or get_snapshot_table_column_names() -%}
     {%- set hard_deletes = strategy.hard_deletes -%}
 
-    select *,
+    select
         {{ strategy.scd_id }} as {{ columns.dbt_scd_id }},
         {{ strategy.updated_at }} as {{ columns.dbt_updated_at }},
         {{ strategy.updated_at }} as {{ columns.dbt_valid_from }},
-        {{ get_dbt_valid_to_current(strategy, columns) }}
-        {%- if hard_deletes == 'new_record' -%}
-        , false as {{ columns.dbt_is_deleted }}
+        {{ get_dbt_valid_to_current(strategy, columns) }},
+        {%- if hard_deletes == 'new_record' %}
+        false as {{ columns.dbt_is_deleted }},
         {%- endif %}
+        * except (
+            {{ columns.dbt_scd_id }},
+            {{ columns.dbt_updated_at }},
+            {{ columns.dbt_valid_from }},
+            {{ columns.dbt_valid_to }}
+            {%- if hard_deletes == 'new_record' -%}
+            , {{ columns.dbt_is_deleted }}
+            {%- endif %}
+        )
     from (
         {{ sql }}
     ) sbq

--- a/dbt/include/databricks/macros/materializations/snapshot_helpers.sql
+++ b/dbt/include/databricks/macros/materializations/snapshot_helpers.sql
@@ -59,15 +59,7 @@
         {%- if hard_deletes == 'new_record' %}
         false as {{ columns.dbt_is_deleted }},
         {%- endif %}
-        * except (
-            {{ columns.dbt_scd_id }},
-            {{ columns.dbt_updated_at }},
-            {{ columns.dbt_valid_from }},
-            {{ columns.dbt_valid_to }}
-            {%- if hard_deletes == 'new_record' -%}
-            , {{ columns.dbt_is_deleted }}
-            {%- endif %}
-        )
+        *
     from (
         {{ sql }}
     ) sbq

--- a/tests/unit/macros/materializations/test_snapshot.py
+++ b/tests/unit/macros/materializations/test_snapshot.py
@@ -1,0 +1,202 @@
+import pytest
+from unittest.mock import Mock
+
+from tests.unit.macros.base import MacroTestBase
+
+
+class TestBuildSnapshotTable(MacroTestBase):
+    @pytest.fixture(scope="class")
+    def template_name(self) -> str:
+        return "snapshot_helpers.sql"
+
+    @pytest.fixture(scope="class")
+    def macro_folders_to_load(self) -> list:
+        return ["macros/materializations"]
+
+    def test_build_snapshot_table_columns_first(self, template, context):
+        class Cols:
+            dbt_scd_id = "dbt_scd_id"
+            dbt_updated_at = "dbt_updated_at"
+            dbt_valid_from = "dbt_valid_from"
+            dbt_valid_to = "dbt_valid_to"
+            dbt_is_deleted = "dbt_is_deleted"
+
+        context["get_snapshot_table_column_names"] = lambda: Cols()
+        context["get_dbt_valid_to_current"] = lambda s, c: "nullif('u', 'u') as dbt_valid_to"
+        
+        strategy = Mock()
+        strategy.scd_id = "'some_scd_id'"
+        strategy.updated_at = "'u'"
+        strategy.hard_deletes = "ignore"
+        
+        sql = self.run_macro(template, "databricks__build_snapshot_table", strategy, "select 1 as a")
+        
+        expected = """
+        select
+            'some_scd_id' as dbt_scd_id,
+            'u' as dbt_updated_at,
+            'u' as dbt_valid_from,
+            nullif('u', 'u') as dbt_valid_to,
+            * except (
+                dbt_scd_id,
+                dbt_updated_at,
+                dbt_valid_from,
+                dbt_valid_to
+            )
+        from (
+            select 1 as a
+        ) sbq
+        """
+        self.assert_sql_equal(expected, sql)
+
+        # explicit check for column ordering
+        scd_id_pos = sql.index("dbt_scd_id")
+        wildcard_pos = sql.index("* except")
+        assert scd_id_pos < wildcard_pos, (
+            "Meta-columns must appear before * in SELECT to ensure they fall "
+            "within Databricks' first-32-column statistics window"
+        )
+
+    def test_build_snapshot_table_columns_first_new_record(self, template, context):
+        class Cols:
+            dbt_scd_id = "dbt_scd_id"
+            dbt_updated_at = "dbt_updated_at"
+            dbt_valid_from = "dbt_valid_from"
+            dbt_valid_to = "dbt_valid_to"
+            dbt_is_deleted = "dbt_is_deleted"
+
+        context["get_snapshot_table_column_names"] = lambda: Cols()
+        context["get_dbt_valid_to_current"] = lambda s, c: "nullif('u', 'u') as dbt_valid_to"
+        
+        strategy = Mock()
+        strategy.scd_id = "'some_scd_id'"
+        strategy.updated_at = "'u'"
+        strategy.hard_deletes = "new_record"
+        
+        sql = self.run_macro(template, "databricks__build_snapshot_table", strategy, "select 1 as a")
+        
+        expected = """
+        select
+            'some_scd_id' as dbt_scd_id,
+            'u' as dbt_updated_at,
+            'u' as dbt_valid_from,
+            nullif('u', 'u') as dbt_valid_to,
+            false as dbt_is_deleted,
+            * except (
+                dbt_scd_id,
+                dbt_updated_at,
+                dbt_valid_from,
+                dbt_valid_to,
+                dbt_is_deleted
+            )
+        from (
+            select 1 as a
+        ) sbq
+        """
+        self.assert_sql_equal(expected, sql)
+
+        # explicit check for column ordering
+        scd_id_pos = sql.index("dbt_scd_id")
+        wildcard_pos = sql.index("* except")
+        assert scd_id_pos < wildcard_pos, (
+            "Meta-columns must appear before * in SELECT to ensure they fall "
+            "within Databricks' first-32-column statistics window"
+        )
+
+    def test_build_snapshot_table_custom_column_names(self, template, context):
+        class Cols:
+            dbt_scd_id = "_scd_id"
+            dbt_updated_at = "_updated_at"
+            dbt_valid_from = "start_date"
+            dbt_valid_to = "end_date"
+            dbt_is_deleted = "is_deleted"
+
+        context["get_snapshot_table_column_names"] = lambda: Cols()
+        context["get_dbt_valid_to_current"] = lambda s, c: "nullif('u', 'u') as end_date"
+        
+        strategy = Mock()
+        strategy.scd_id = "'some_scd_id'"
+        strategy.updated_at = "'u'"
+        strategy.hard_deletes = "new_record"
+        
+        sql = self.run_macro(template, "databricks__build_snapshot_table", strategy, "select 1 as a")
+        
+        expected = """
+        select
+            'some_scd_id' as _scd_id,
+            'u' as _updated_at,
+            'u' as start_date,
+            nullif('u', 'u') as end_date,
+            false as is_deleted,
+            * except (
+                _scd_id,
+                _updated_at,
+                start_date,
+                end_date,
+                is_deleted
+            )
+        from (
+            select 1 as a
+        ) sbq
+        """
+        self.assert_sql_equal(expected, sql)
+
+        # check that original defaults aren't there
+        assert "_scd_id" in sql
+        assert "dbt_scd_id" not in sql
+        
+        scd_id_pos = sql.index("_scd_id")
+        wildcard_pos = sql.index("* except")
+        assert scd_id_pos < wildcard_pos, "Meta-columns must precede wildcard"
+
+        except_clause = sql[sql.index("except"):sql.index("from (")]
+        assert "_scd_id" in except_clause
+        assert "dbt_scd_id" not in except_clause
+
+    def test_build_snapshot_table_custom_column_names_ignore(self, template, context):
+        class Cols:
+            dbt_scd_id = "_scd_id"
+            dbt_updated_at = "_updated_at"
+            dbt_valid_from = "start_date"
+            dbt_valid_to = "end_date"
+            dbt_is_deleted = "is_deleted"
+
+        context["get_snapshot_table_column_names"] = lambda: Cols()
+        context["get_dbt_valid_to_current"] = lambda s, c: "nullif('u', 'u') as end_date"
+        
+        strategy = Mock()
+        strategy.scd_id = "'some_scd_id'"
+        strategy.updated_at = "'u'"
+        strategy.hard_deletes = "ignore"
+        
+        sql = self.run_macro(template, "databricks__build_snapshot_table", strategy, "select 1 as a")
+        
+        expected = """
+        select
+            'some_scd_id' as _scd_id,
+            'u' as _updated_at,
+            'u' as start_date,
+            nullif('u', 'u') as end_date,
+            * except (
+                _scd_id,
+                _updated_at,
+                start_date,
+                end_date
+            )
+        from (
+            select 1 as a
+        ) sbq
+        """
+        self.assert_sql_equal(expected, sql)
+
+        # check that original defaults aren't there
+        assert "_scd_id" in sql
+        assert "dbt_scd_id" not in sql
+        
+        scd_id_pos = sql.index("_scd_id")
+        wildcard_pos = sql.index("* except")
+        assert scd_id_pos < wildcard_pos, "Meta-columns must precede wildcard"
+
+        except_clause = sql[sql.index("except"):sql.index("from (")]
+        assert "_scd_id" in except_clause
+        assert "dbt_scd_id" not in except_clause

--- a/tests/unit/macros/materializations/test_snapshot.py
+++ b/tests/unit/macros/materializations/test_snapshot.py
@@ -1,5 +1,6 @@
-import pytest
 from unittest.mock import Mock
+
+import pytest
 
 from tests.unit.macros.base import MacroTestBase
 
@@ -23,26 +24,23 @@ class TestBuildSnapshotTable(MacroTestBase):
 
         context["get_snapshot_table_column_names"] = lambda: Cols()
         context["get_dbt_valid_to_current"] = lambda s, c: "nullif('u', 'u') as dbt_valid_to"
-        
+
         strategy = Mock()
         strategy.scd_id = "'some_scd_id'"
         strategy.updated_at = "'u'"
         strategy.hard_deletes = "ignore"
-        
-        sql = self.run_macro(template, "databricks__build_snapshot_table", strategy, "select 1 as a")
-        
+
+        sql = self.run_macro(
+            template, "databricks__build_snapshot_table", strategy, "select 1 as a"
+        )
+
         expected = """
         select
             'some_scd_id' as dbt_scd_id,
             'u' as dbt_updated_at,
             'u' as dbt_valid_from,
             nullif('u', 'u') as dbt_valid_to,
-            * except (
-                dbt_scd_id,
-                dbt_updated_at,
-                dbt_valid_from,
-                dbt_valid_to
-            )
+            *
         from (
             select 1 as a
         ) sbq
@@ -51,7 +49,7 @@ class TestBuildSnapshotTable(MacroTestBase):
 
         # explicit check for column ordering
         scd_id_pos = sql.index("dbt_scd_id")
-        wildcard_pos = sql.index("* except")
+        wildcard_pos = sql.index("*")
         assert scd_id_pos < wildcard_pos, (
             "Meta-columns must appear before * in SELECT to ensure they fall "
             "within Databricks' first-32-column statistics window"
@@ -67,14 +65,16 @@ class TestBuildSnapshotTable(MacroTestBase):
 
         context["get_snapshot_table_column_names"] = lambda: Cols()
         context["get_dbt_valid_to_current"] = lambda s, c: "nullif('u', 'u') as dbt_valid_to"
-        
+
         strategy = Mock()
         strategy.scd_id = "'some_scd_id'"
         strategy.updated_at = "'u'"
         strategy.hard_deletes = "new_record"
-        
-        sql = self.run_macro(template, "databricks__build_snapshot_table", strategy, "select 1 as a")
-        
+
+        sql = self.run_macro(
+            template, "databricks__build_snapshot_table", strategy, "select 1 as a"
+        )
+
         expected = """
         select
             'some_scd_id' as dbt_scd_id,
@@ -82,13 +82,7 @@ class TestBuildSnapshotTable(MacroTestBase):
             'u' as dbt_valid_from,
             nullif('u', 'u') as dbt_valid_to,
             false as dbt_is_deleted,
-            * except (
-                dbt_scd_id,
-                dbt_updated_at,
-                dbt_valid_from,
-                dbt_valid_to,
-                dbt_is_deleted
-            )
+            *
         from (
             select 1 as a
         ) sbq
@@ -97,7 +91,7 @@ class TestBuildSnapshotTable(MacroTestBase):
 
         # explicit check for column ordering
         scd_id_pos = sql.index("dbt_scd_id")
-        wildcard_pos = sql.index("* except")
+        wildcard_pos = sql.index("*")
         assert scd_id_pos < wildcard_pos, (
             "Meta-columns must appear before * in SELECT to ensure they fall "
             "within Databricks' first-32-column statistics window"
@@ -113,14 +107,16 @@ class TestBuildSnapshotTable(MacroTestBase):
 
         context["get_snapshot_table_column_names"] = lambda: Cols()
         context["get_dbt_valid_to_current"] = lambda s, c: "nullif('u', 'u') as end_date"
-        
+
         strategy = Mock()
         strategy.scd_id = "'some_scd_id'"
         strategy.updated_at = "'u'"
         strategy.hard_deletes = "new_record"
-        
-        sql = self.run_macro(template, "databricks__build_snapshot_table", strategy, "select 1 as a")
-        
+
+        sql = self.run_macro(
+            template, "databricks__build_snapshot_table", strategy, "select 1 as a"
+        )
+
         expected = """
         select
             'some_scd_id' as _scd_id,
@@ -128,13 +124,7 @@ class TestBuildSnapshotTable(MacroTestBase):
             'u' as start_date,
             nullif('u', 'u') as end_date,
             false as is_deleted,
-            * except (
-                _scd_id,
-                _updated_at,
-                start_date,
-                end_date,
-                is_deleted
-            )
+            *
         from (
             select 1 as a
         ) sbq
@@ -144,14 +134,10 @@ class TestBuildSnapshotTable(MacroTestBase):
         # check that original defaults aren't there
         assert "_scd_id" in sql
         assert "dbt_scd_id" not in sql
-        
-        scd_id_pos = sql.index("_scd_id")
-        wildcard_pos = sql.index("* except")
-        assert scd_id_pos < wildcard_pos, "Meta-columns must precede wildcard"
 
-        except_clause = sql[sql.index("except"):sql.index("from (")]
-        assert "_scd_id" in except_clause
-        assert "dbt_scd_id" not in except_clause
+        scd_id_pos = sql.index("_scd_id")
+        wildcard_pos = sql.index("*")
+        assert scd_id_pos < wildcard_pos, "Meta-columns must precede wildcard"
 
     def test_build_snapshot_table_custom_column_names_ignore(self, template, context):
         class Cols:
@@ -163,26 +149,23 @@ class TestBuildSnapshotTable(MacroTestBase):
 
         context["get_snapshot_table_column_names"] = lambda: Cols()
         context["get_dbt_valid_to_current"] = lambda s, c: "nullif('u', 'u') as end_date"
-        
+
         strategy = Mock()
         strategy.scd_id = "'some_scd_id'"
         strategy.updated_at = "'u'"
         strategy.hard_deletes = "ignore"
-        
-        sql = self.run_macro(template, "databricks__build_snapshot_table", strategy, "select 1 as a")
-        
+
+        sql = self.run_macro(
+            template, "databricks__build_snapshot_table", strategy, "select 1 as a"
+        )
+
         expected = """
         select
             'some_scd_id' as _scd_id,
             'u' as _updated_at,
             'u' as start_date,
             nullif('u', 'u') as end_date,
-            * except (
-                _scd_id,
-                _updated_at,
-                start_date,
-                end_date
-            )
+            *
         from (
             select 1 as a
         ) sbq
@@ -192,11 +175,7 @@ class TestBuildSnapshotTable(MacroTestBase):
         # check that original defaults aren't there
         assert "_scd_id" in sql
         assert "dbt_scd_id" not in sql
-        
-        scd_id_pos = sql.index("_scd_id")
-        wildcard_pos = sql.index("* except")
-        assert scd_id_pos < wildcard_pos, "Meta-columns must precede wildcard"
 
-        except_clause = sql[sql.index("except"):sql.index("from (")]
-        assert "_scd_id" in except_clause
-        assert "dbt_scd_id" not in except_clause
+        scd_id_pos = sql.index("_scd_id")
+        wildcard_pos = sql.index("*")
+        assert scd_id_pos < wildcard_pos, "Meta-columns must precede wildcard"


### PR DESCRIPTION
fixes #1481

### description

databricks collects statistics and enables automatic liquid clustering only on the first 32 columns of a delta table. previously snapshot meta-columns were appended after user columns, pushing them out of that window on wide tables.

this PR 
- overrides `databricks__build_snapshot_table` in `snapshot_helpers.sql` to place the meta-columns **first** in the SELECT list, before the user columns expanded by `*`
- this guarantees the meta-columns always fall within databricks' 32-column statistics window regardless of how wide the source table is
- allows `dbt_valid_to` and `dbt_scd_id` to benefit from automatic liquid clustering out of the box

the `hard_deletes = 'new_record'` path is handled correctly, placing `dbt_is_deleted` alongside the other meta-columns at the front. custom column names configured via `snapshot_meta_column_names` are respected through the existing `get_snapshot_table_column_names()` dispatch, consistent with the rest of `snapshot_helpers.sql`.

> [!NOTE]
> this change only affects newly created snapshot tables. existing snapshots will continue to work unchanged with the old column order. If you want the new column order on an existing snapshot for the statistics/clustering benefit, you can recreate it with `dbt snapshot --full-refresh` but be aware this will permanently drop all historical SCD2 data. back up the table first.

### checklist
- [x] I have run this code in development and it appears to resolve the
      stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my
      change to the "dbt-databricks next" section.