### PR TITLE
fix(ci): correct warm-cache wheelhouse creation to fix env setup bug

### DIFF
--- a/.github/workflows/warmDepsCache.yml
+++ b/.github/workflows/warmDepsCache.yml
@@ -101,10 +101,13 @@ jobs:
         run: hatch run pre-commit install-hooks
 
       - name: Create pip wheelhouse
+        # verify / verify-min-deps envs use pip (not uv), so they install
+        # offline from this wheelhouse via PIP_FIND_LINKS. Route pip-download
+        # through verify-min-deps env to use its bin/pip on Python 3.10.
         run: |
           set -euo pipefail
           mkdir -p ~/.cache/pip-wheelhouse
-          hatch run python -c "
+          hatch -e verify-min-deps run python -c "
           try:
               import tomllib
           except ImportError:
@@ -114,11 +117,30 @@ jobs:
           for dep in data['project']['dependencies']:
               print(dep)
           " > /tmp/runtime-deps.txt
-          hatch run pip download --dest ~/.cache/pip-wheelhouse \
+          hatch -e verify-min-deps run pip download --dest ~/.cache/pip-wheelhouse \
             setuptools wheel twine check-wheel-contents \
             -r /tmp/runtime-deps.txt
-          hatch run pip download --dest ~/.cache/pip-wheelhouse \
+          hatch -e verify-min-deps run pip download --dest ~/.cache/pip-wheelhouse \
             --no-deps --require-hashes -r requirements.lowest-direct.txt
+
+      - name: Verify all hatch envs can be re-created offline from the cache
+        # Prune + recreate offline mirrors what PR jobs do. Failing here
+        # means the cache is incomplete; fail warm, not the fork PR.
+        env:
+          UV_OFFLINE: "true"
+          PIP_NO_INDEX: "1"
+          PIP_FIND_LINKS: /home/runner/.cache/pip-wheelhouse
+        run: |
+          set -euo pipefail
+          hatch env prune
+          hatch env create default
+          hatch env create test.py3.10
+          hatch env create test.py3.11
+          hatch env create test.py3.12
+          hatch env create test.py3.13
+          hatch env create verify
+          hatch env create min-deps
+          hatch env create verify-min-deps
 
       - name: Build package
         run: hatch -v build

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,7 @@ dev = [
 
 [tool.hatch.envs.verify]
 detached = true
+python = "3.10"
 dependencies = ["wheel", "twine", "check-wheel-contents"]
 
 [tool.hatch.envs.verify.scripts]


### PR DESCRIPTION
`hatch run pip download` in `warmDepsCache.yml`'s wheelhouse step ran inside the default env. Default uses `installer = "uv"`, whose venvs have no `bin/pip`, so hatch fell back to its bundled pip on Python 3.12. That pip evaluated `python_version < "3.11"` as False and silently dropped conditional deps like `tomli` from the wheelhouse.

- Route the pip-download through `verify-min-deps` env (pip installer, Python 3.10).
- Pin `verify` env to Python 3.10 so its wheels match the wheelhouse ABI
- Add a post-warm "Verify all hatch envs can be re-created offline" step that prunes every just-warmed env, switches to offline mode, and recreates them from the cache alone. Catches future silent drops at warm-time.