### PR TITLE
test: stabilize TestChangingSchema* python-model tests under min-deps (dbt-core 1.11.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 - Defer SDK `Config` construction to connection-open time so offline paths (`dbt parse`/`list`/`compile`) don't trigger the host-metadata probe introduced in `databricks-sdk>=0.103`; as a side effect, auth errors now surface at first connection rather than during profile parsing. ([#1474](https://github.com/databricks/dbt-databricks/pull/1474))
 - Bump ceilings on `databricks-sdk` (now `<0.105.0`) and `databricks-sql-connector[pyarrow]` (now `<4.3.0`) to admit newer releases; floors unchanged. ([#1474](https://github.com/databricks/dbt-databricks/pull/1474))
+- Stabilize the `TestChangingSchema*` Python-model functional tests under min-deps (dbt-core 1.11.2), where a sibling class's source schema.yml could leak into their parse and fail with `EnvVarMissingError`. ([#1488](https://github.com/databricks/dbt-databricks/pull/1488))
 
 ## dbt-databricks 1.12.0 (May 18, 2026)
 

--- a/tests/functional/adapter/python_model/test_python_model.py
+++ b/tests/functional/adapter/python_model/test_python_model.py
@@ -1,3 +1,4 @@
+import json
 import os
 
 import pytest
@@ -27,6 +28,31 @@ def verify_temp_table_cleaned(project, suffix):
         "SHOW TABLES IN {database}.{schema} LIKE '" + f"{suffix}'", fetch="all"
     )
     assert len(tmp_tables) == 0
+
+
+class SchemaNameVarMixin:
+    """Make the schema-change tests resilient to dbt-core test-isolation leakage.
+
+    These classes don't inherit ``BasePythonModelTests`` and run plain ``dbt run``. On
+    dbt-core 1.11.2 a sibling class's ``test_source`` schema.yml -- whose ``schema``
+    renders ``var(env_var('DBT_TEST_SCHEMA_NAME_VARIABLE'))`` -- can bleed into these
+    classes' parse when they run after one in the same xdist worker (``--dist=loadfile``),
+    failing with ``EnvVarMissingError``. Rendering that source needs both the env var
+    (read from the invocation context) and the ``test_run_schema`` var. Schema-yaml
+    rendering resolves ``var()`` from CLI vars only, so the var must be passed via
+    ``--vars`` -- exactly as dbt-core's ``BasePythonModelTests`` does -- not via
+    project-level ``vars``.
+    """
+
+    @pytest.fixture(scope="class", autouse=True)
+    def schema_name_env_var(self):
+        os.environ["DBT_TEST_SCHEMA_NAME_VARIABLE"] = "test_run_schema"
+        yield
+        os.environ.pop("DBT_TEST_SCHEMA_NAME_VARIABLE", None)
+
+    @staticmethod
+    def schema_name_vars(project):
+        return ["--vars", json.dumps({"test_run_schema": project.test_schema})]
 
 
 @pytest.mark.python
@@ -84,7 +110,7 @@ class TestPythonIncrementalModel(BasePythonIncrementalTests):
 
 @pytest.mark.python
 @pytest.mark.skip_profile("databricks_cluster")
-class TestChangingSchema:
+class TestChangingSchema(SchemaNameVarMixin):
     """Test Python model schema changes using serverless compute."""
 
     @pytest.fixture(scope="class")
@@ -96,13 +122,14 @@ class TestChangingSchema:
         return {"models": {"+create_notebook": "true"}}
 
     def test_changing_schema_with_log_validation(self, project, logs_dir):
-        util.run_dbt(["run"])
+        schema_vars = self.schema_name_vars(project)
+        util.run_dbt(["run", *schema_vars])
         util.write_file(
             override_fixtures.simple_python_model_v2,
             project.project_root + "/models",
             "simple_python_model.py",
         )
-        util.run_dbt(["run"])
+        util.run_dbt(["run", *schema_vars])
         log_file = os.path.join(logs_dir, "dbt.log")
         with open(log_file) as f:
             log = f.read()
@@ -113,7 +140,7 @@ class TestChangingSchema:
 
 @pytest.mark.python
 @pytest.mark.skip_profile("databricks_cluster")
-class TestChangingSchemaIncremental:
+class TestChangingSchemaIncremental(SchemaNameVarMixin):
     """Test Python incremental schema changes using serverless compute."""
 
     @pytest.fixture(scope="class")
@@ -129,9 +156,10 @@ class TestChangingSchemaIncremental:
         return {"models": {"+create_notebook": "true"}}
 
     def test_changing_schema_via_incremental(self, project):
-        util.run_dbt(["seed"])
-        util.run_dbt(["run"])
-        util.run_dbt(["run"])
+        schema_vars = self.schema_name_vars(project)
+        util.run_dbt(["seed", *schema_vars])
+        util.run_dbt(["run", *schema_vars])
+        util.run_dbt(["run", *schema_vars])
 
         util.check_relations_equal(project.adapter, ["incremental_model", "expected_incremental"])
 
@@ -412,7 +440,7 @@ class TestPythonModelAccessControlList:
 
 
 @pytest.mark.skip_profile("databricks_cluster")
-class TestChangingSchemaV2(MaterializationV2Mixin):
+class TestChangingSchemaV2(SchemaNameVarMixin, MaterializationV2Mixin):
     """Test Python model schema changes with V2 materialization using serverless compute."""
 
     @pytest.fixture(scope="class")
@@ -424,19 +452,20 @@ class TestChangingSchemaV2(MaterializationV2Mixin):
         return {"models": {"+create_notebook": "true"}}
 
     def test_changing_unique_tmp_table_suffix(self, project):
-        util.run_dbt(["run"])
+        schema_vars = self.schema_name_vars(project)
+        util.run_dbt(["run", *schema_vars])
         util.write_file(
             override_fixtures.simple_python_model_v2,
             project.project_root + "/models",
             "simple_python_model.py",
         )
-        util.run_dbt(["run"])
+        util.run_dbt(["run", *schema_vars])
         verify_temp_tables_cleaned(project)
 
 
 @pytest.mark.python
 @pytest.mark.skip_profile("databricks_cluster")
-class TestChangingSchemaIncrementalV2(MaterializationV2Mixin):
+class TestChangingSchemaIncrementalV2(SchemaNameVarMixin, MaterializationV2Mixin):
     """Test Python incremental schema changes with V2 materialization using serverless compute."""
 
     @pytest.fixture(scope="class")
@@ -448,13 +477,14 @@ class TestChangingSchemaIncrementalV2(MaterializationV2Mixin):
         return {"models": {"+create_notebook": "true"}}
 
     def test_changing_unique_tmp_table_suffix(self, project):
-        util.run_dbt(["run"])
+        schema_vars = self.schema_name_vars(project)
+        util.run_dbt(["run", *schema_vars])
         util.write_file(
             override_fixtures.simple_incremental_python_model_v2,
             project.project_root + "/models",
             "incremental_model.py",
         )
-        util.run_dbt(["run"])
+        util.run_dbt(["run", *schema_vars])
         verify_temp_tables_cleaned(project)
 
 


### PR DESCRIPTION
## Problem

The nightly **Integration Tests (Min-Deps)** workflow fails on the SQL-warehouse shard ([run 26536340109](https://github.com/databricks/dbt-databricks/actions/runs/26536340109)):

```
FAILED tests/functional/adapter/python_model/test_python_model.py::TestChangingSchemaV2::test_changing_unique_tmp_table_suffix
FAILED tests/functional/adapter/python_model/test_python_model.py::TestChangingSchemaIncrementalV2::test_changing_unique_tmp_table_suffix
  dbt.exceptions.ParsingError: Failed to render models/schema.yml ...
    dbt.exceptions.EnvVarMissingError: Env var required but not provided: 'DBT_TEST_SCHEMA_NAME_VARIABLE'
```

The same `main` commit **passes** these tests on latest-deps (dbt-core 1.11.8) the same night — this is specific to **dbt-core 1.11.2**, newly exercised since min-deps became first-class CI (#1480, #1476).

## Root cause

Under `--dist=loadfile`, every `test_python_model.py` class runs in one xdist worker. On dbt-core 1.11.2, a sibling `BasePythonModelTests` class's `test_source` schema.yml — whose `schema` renders `{{ var(env_var('DBT_TEST_SCHEMA_NAME_VARIABLE')) }}` — leaks into the parse of a *following* class. The `TestChangingSchema*` classes don't inherit `BasePythonModelTests`, so they supply neither thing that leaked source needs:

- `env_var('DBT_TEST_SCHEMA_NAME_VARIABLE')` resolves from the per-class invocation-context snapshot → needs the env var set.
- `var('test_run_schema')` is resolved by `ConfiguredVar` during schema rendering, which reads **only `config.cli_vars`** (`dbt/context/configured.py`) → needs `--vars`, not project-level `vars:`.

It is position-dependent: `TestChangingSchema` (V1) passes only because its predecessor has no source; the V2 classes run right after `TestServerlessCluster*`. dbt-core 1.11.8 isolates parses correctly, so latest-deps is unaffected.

## Fix

Test-only. A `SchemaNameVarMixin` that (a) sets `DBT_TEST_SCHEMA_NAME_VARIABLE` via an autouse fixture and (b) passes `test_run_schema` via `--vars` on `run_dbt` — exactly mirroring dbt-core's own `BasePythonModelTests`. Applied to all four `TestChangingSchema*` classes (the two failing V2 classes plus the two V1 classes, which pass only by ordering luck today). Inert on dbt-core 1.11.8.

## Verification

Against the live SQL warehouse under min-deps (dbt-core 1.11.2), full file with `-n 2 --dist=loadfile --reruns 1` (faithful to CI):

- Before: **2 failed** (`EnvVarMissingError`) — reproduces CI.
- After: **11 passed, 9 skipped, 0 failed** (both V2 classes pass).