### PR TITLE
fix: ignore server-set delta.parquet.compression.codec tblproperty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Fixes
 
+- Ignore the server-set `delta.parquet.compression.codec` tblproperty when diffing relation configs, so streaming tables and materialized views are not flagged as changed after the backend started stamping it automatically ([#1489](https://github.com/databricks/dbt-databricks/pull/1489))
 - Fix missing f-string prefix in `JobRunsApi.submit` debug log ([#1471](https://github.com/databricks/dbt-databricks/pull/1471))
 - Fix capability-branching macros falling through to their legacy path at parse/compile time on SQL warehouses. The parse-time stub of `has_dbr_capability` now returns `True` on warehouse profiles for capabilities flagged `sql_warehouse_supported`, so macros select the modern branch during compilation instead of the legacy fallback. ([#1449](https://github.com/databricks/dbt-databricks/pull/1449) closes [#1331](https://github.com/databricks/dbt-databricks/issues/1331))
 - Fix snapshots not applying `databricks_tags` on columns ([#1442](https://github.com/databricks/dbt-databricks/pull/1442) closes [#1441](https://github.com/databricks/dbt-databricks/issues/1441))

--- a/dbt/adapters/databricks/relation_configs/tblproperties.py
+++ b/dbt/adapters/databricks/relation_configs/tblproperties.py
@@ -46,6 +46,7 @@ class TblPropertiesConfig(DatabricksComponentConfig):
         "spark.sql.internal.pipelines.parentTableId",
         "delta.enableDeletionVectors",
         "delta.feature.deletionVectors",
+        "delta.parquet.compression.codec",
     ]
 
     def __eq__(self, __value: Any) -> bool:

--- a/tests/unit/relation_configs/test_tblproperties.py
+++ b/tests/unit/relation_configs/test_tblproperties.py
@@ -30,6 +30,17 @@ class TestTblPropertiesProcessor:
         spec = TblPropertiesProcessor.from_relation_results(results)
         assert spec == TblPropertiesConfig(tblproperties={"prop": "1", "other": "other"})
 
+    def test_from_results__drops_ignored_properties(self):
+        # Properties set by Databricks (e.g. the server-default parquet compression codec)
+        # must be dropped so they don't show up as spurious configuration changes.
+        results = {
+            "show_tblproperties": fixtures.gen_tblproperties(
+                [["prop", "1"], ["delta.parquet.compression.codec", "zstd"]]
+            )
+        }
+        spec = TblPropertiesProcessor.from_relation_results(results)
+        assert spec == TblPropertiesConfig(tblproperties={"prop": "1"})
+
     def test_from_model_node__without_tblproperties(self):
         model = Mock()
         model.config.extra = {}


### PR DESCRIPTION
### Summary

A recent server-side change began stamping the non-user-configurable property `delta.parquet.compression.codec=zstd` onto streaming tables and materialized views. Because it was absent from `TblPropertiesConfig.ignore_list`, it leaked into the existing-relation config but never the desired (model) config — so `get_changeset` reported a **phantom configuration change on every run of an otherwise-unchanged relation**.

Impact by `on_configuration_change`:
- `fail` → idempotent `dbt run`s now **error out** (regression)
- `apply` → spurious `ALTER … SET TBLPROPERTIES` every run
- `continue` → spurious "configuration changes were identified" warning every run

This surfaced fleet-wide on 2026-05-28 (both `main` nightly and feature-branch CI); the same tests passed on 2026-05-27 with no intervening code change, pinning the cause to the backend.

### Fix

Add `delta.parquet.compression.codec` to `TblPropertiesConfig.ignore_list` so it is dropped during config comparison, matching the existing pattern for other Databricks-set properties (e.g. `delta.enableDeletionVectors`, `delta.columnMapping.maxColumnId`).

### Testing

- **Unit:** added `test_from_results__drops_ignored_properties` to lock the filter behavior; full unit suite passes (1116 passed).
- **Functional:** `TestStreamingTableChangesApply::test_change_is_applied_via_alter` passes against a live SQL warehouse (was failing in CI). The other 6 failures — including `test_idempotent_run_does_not_fail`, which exercises the regression directly — route through the same comparison and are covered by the same filter.