### PR TITLE
test: raise dbt-tests-adapter floor to >=1.20.0 for persist_docs fixture rename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Under the Hood
 
+- Raise the `dbt-tests-adapter` test-dependency floor to `>=1.20.0` to pick up its `persist_docs` fixture typo fix (test-only, no runtime impact) ([#1490](https://github.com/databricks/dbt-databricks/pull/1490))
 - Defer SDK `Config` construction to connection-open time so offline paths (`dbt parse`/`list`/`compile`) don't trigger the host-metadata probe introduced in `databricks-sdk>=0.103`; as a side effect, auth errors now surface at first connection rather than during profile parsing. ([#1474](https://github.com/databricks/dbt-databricks/pull/1474))
 - Bump ceilings on `databricks-sdk` (now `<0.105.0`) and `databricks-sql-connector[pyarrow]` (now `<4.3.0`) to admit newer releases; floors unchanged. ([#1474](https://github.com/databricks/dbt-databricks/pull/1474))
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ include = ["/dbt"]
 
 [dependency-groups]
 test = [
-    "dbt-tests-adapter>=1.19.0",
+    "dbt-tests-adapter>=1.20.0",
     "pytest>=8.3.5",
     "pytest-xdist>=3.6.1",
     "pytest-rerunfailures>=14.0",

--- a/requirements.lowest-direct.txt
+++ b/requirements.lowest-direct.txt
@@ -441,13 +441,13 @@ dbt-common==1.37.2 \
     #   dbt-adapters
     #   dbt-core
     #   dbt-spark
+    #   dbt-tests-adapter
 dbt-core==1.11.2 \
     --hash=sha256:3306fee149b9f4e648071f2c9a46c0551100e1c829f13ad7ce026eb7226ad454 \
     --hash=sha256:ac332fd61a4494494f48e1bbdc0696e309e79036b94eb0a929233bb71f4b3898
     # via
     #   dbt-databricks (pyproject.toml)
     #   dbt-spark
-    #   dbt-tests-adapter
 dbt-extractor==0.6.0 \
     --hash=sha256:05bcfab7ebd70296ceb31742e8333ba66a2c939de44e61a7088bebafa939aaf6 \
     --hash=sha256:080fd1edf123926ed97929c65a75874d0fea687ccd5d3ebbc9e81b339f099604 \
@@ -481,9 +481,9 @@ dbt-spark==1.10.0 \
     --hash=sha256:5d3755d832476ad5d4e3c2fe55247fa39763e990e186673fd88da7be989f0048 \
     --hash=sha256:95f4af4b5647553115eb6ca02539a3a1ad50b34bf2c6f3a766371f7de164578c
     # via dbt-databricks (pyproject.toml)
-dbt-tests-adapter==1.19.0 \
-    --hash=sha256:25ccdefbf31164d2af76745edc245385e4bc7081d23836c5986bdd91e773deb6 \
-    --hash=sha256:5cbd4b6acff4534adc38cfd61d1892c3bc259378657904ce42773588c3be8e34
+dbt-tests-adapter==1.20.0 \
+    --hash=sha256:333d0d08c1690278a8cf681989f6359a7a8a5b3da464f14430c3ea3ea32fa5ff \
+    --hash=sha256:91562371852790a647c59270136a4461bfda7e7484f349fcd3473f0a1d6059c6
     # via dbt-databricks (pyproject.toml:test)
 deepdiff==8.6.2 \
     --hash=sha256:186dcbd181e4d76cef11ab05f802d0056c5d6083c5a6748c1473e9d7481e183e \

--- a/tests/functional/adapter/persist_docs/test_persist_docs.py
+++ b/tests/functional/adapter/persist_docs/test_persist_docs.py
@@ -169,7 +169,7 @@ class TestPersistDocsColumnMissing(DatabricksPersistDocsMixin):
 
     @pytest.fixture(scope="class")
     def properties(self):
-        return {"schema.yml": fixtures._PROPERITES__SCHEMA_MISSING_COL}
+        return {"schema.yml": fixtures._PROPERTIES__SCHEMA_MISSING_COL}
 
     @pytest.fixture(scope="class")
     def table_relation(self, project):

--- a/uv.lock
+++ b/uv.lock
@@ -650,7 +650,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "dbt-tests-adapter", specifier = ">=1.19.0" },
+    { name = "dbt-tests-adapter", specifier = ">=1.20.0" },
     { name = "debugpy" },
     { name = "freezegun", specifier = ">=1.5.1" },
     { name = "mypy", specifier = ">=1.18.2" },
@@ -664,7 +664,7 @@ dev = [
     { name = "types-requests" },
 ]
 test = [
-    { name = "dbt-tests-adapter", specifier = ">=1.19.0" },
+    { name = "dbt-tests-adapter", specifier = ">=1.20.0" },
     { name = "freezegun", specifier = ">=1.5.1" },
     { name = "pytest", specifier = ">=8.3.5" },
     { name = "pytest-cov", specifier = ">=6.0.0" },
@@ -745,18 +745,17 @@ wheels = [
 
 [[package]]
 name = "dbt-tests-adapter"
-version = "1.19.7"
+version = "1.20.0"
 source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "dbt-adapters" },
     { name = "dbt-common" },
-    { name = "dbt-core" },
     { name = "freezegun" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/38/84/308803bda5fea9f9ee914d4bdd5016bb01b716254ec8d01a4cf61f1b76ed/dbt_tests_adapter-1.19.7.tar.gz", hash = "sha256:d8c80d0fba32a7c86396a4a34f4b0cef676c742f92628fe6b347859308a523b4", size = 170716, upload-time = "2026-03-03T17:25:08.17Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/83/ede118214addb99e8c45338d8b18e30a22872fc8c3043f429a538232e529/dbt_tests_adapter-1.20.0.tar.gz", hash = "sha256:91562371852790a647c59270136a4461bfda7e7484f349fcd3473f0a1d6059c6", size = 175324, upload-time = "2026-05-22T09:23:56.379Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d1/06/fe0a1d46e2bee6ca463abc483ce6a39112eea4eb0ff0a3243c3a3f973971/dbt_tests_adapter-1.19.7-py3-none-any.whl", hash = "sha256:5220e3545bbc0136e00fe8e1a70d85b7c0311547d763737d7ce38641efc7bac1", size = 244411, upload-time = "2026-03-03T17:25:06.335Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/53/860853817edbc50168af0e4520f6c203270e92e20f9edb2ca82c62116f3d/dbt_tests_adapter-1.20.0-py3-none-any.whl", hash = "sha256:333d0d08c1690278a8cf681989f6359a7a8a5b3da464f14430c3ea3ea32fa5ff", size = 250410, upload-time = "2026-05-22T09:23:54.353Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
`dbt-tests-adapter` 1.20.0 fixed a typo in a `persist_docs` fixture name (`_PROPERITES__SCHEMA_MISSING_COL` → `_PROPERTIES__SCHEMA_MISSING_COL`) and dropped the old spelling, breaking our test as CI resolved `1.12.0`

Raise the test-dep floor to `>=1.20.0` (regenerating `requirements.lowest-direct.txt` + `uv.lock`) and use the corrected name. 

Test-only — `dbt-tests-adapter` isn't a runtime dependency. Verified: live `test_missing_column` passes; pre-commit clean.