### PR TITLE
fix(ci): install hatchling from wheelhouse so offline build backend resolves

### DIFF
--- a/.github/actions/setup-python-deps/action.yml
+++ b/.github/actions/setup-python-deps/action.yml
@@ -37,3 +37,4 @@ runs:
         echo "UV_INDEX_URL=https://databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple" >> "$GITHUB_ENV"
         echo "PIP_NO_INDEX=1" >> "$GITHUB_ENV"
         echo "PIP_FIND_LINKS=$HOME/.cache/pip-wheelhouse" >> "$GITHUB_ENV"
+        echo "UV_FIND_LINKS=$HOME/.cache/pip-wheelhouse" >> "$GITHUB_ENV"

--- a/.github/workflows/warmDepsCache.yml
+++ b/.github/workflows/warmDepsCache.yml
@@ -12,9 +12,6 @@
 name: Warm Python Dependency Cache
 
 on:
-  # TEMP (remove before merge): validate the offline-build fix on this PR by
-  # warming the cache into the PR merge-ref scope so the test jobs can restore it.
-  pull_request:
   push:
     branches: [main]
     paths:

--- a/.github/workflows/warmDepsCache.yml
+++ b/.github/workflows/warmDepsCache.yml
@@ -118,7 +118,7 @@ jobs:
               print(dep)
           " > /tmp/runtime-deps.txt
           hatch -e verify-min-deps run pip download --dest ~/.cache/pip-wheelhouse \
-            setuptools wheel twine check-wheel-contents \
+            hatchling setuptools wheel twine check-wheel-contents \
             -r /tmp/runtime-deps.txt
           hatch -e verify-min-deps run pip download --dest ~/.cache/pip-wheelhouse \
             --no-deps --require-hashes -r requirements.lowest-direct.txt

--- a/.github/workflows/warmDepsCache.yml
+++ b/.github/workflows/warmDepsCache.yml
@@ -12,6 +12,9 @@
 name: Warm Python Dependency Cache
 
 on:
+  # TEMP (remove before merge): validate the offline-build fix on this PR by
+  # warming the cache into the PR merge-ref scope so the test jobs can restore it.
+  pull_request:
   push:
     branches: [main]
     paths:


### PR DESCRIPTION
## Problem

All CI jobs (Code Quality, unit 3.10–3.13, Build) started failing at env setup with:

```
Failed to resolve requirements from `build-system.requires`
No solution found when resolving: `hatchling`
Because hatchling was not found in the cache and you require hatchling, ...
hint: Packages were unavailable because the network was disabled.
```

## Root cause

PR jobs restore the warm dependency cache and run with `UV_OFFLINE=true`. Installing the project (editable) invokes the build backend **`hatchling`**, which is **unpinned in `[build-system].requires` and absent from `uv.lock`**, so uv must *resolve* it against JFrog's simple index. JFrog's index responses carry a short freshness lifetime; once the cached metadata goes stale (a few hours), offline uv cannot revalidate it and errors `hatchling was not found in the cache` — breaking every job.

Locked dependencies (from `uv.lock`, pinned + hashed) install from the content-addressed wheel cache without touching the index, so they were unaffected — which is why only the unpinned build backend failed.

### Evidence: failure correlates with cache age, not PR content

| Run (UTC) | Trigger | Cache age | Result |
|---|---|---|---|
| Jun-01 07:29 | PR | fresh | ✅ |
| Jun-01 13:20 | PR | ~5.5h | ✅ |
| Jun-01 21:08 | PR | ~13h | ✅ |
| Jun-02 04:57 | **push to main** | ~21h | ❌ |
| Jun-02 05:05 | PR | ~21h | ❌ |

The `main`-branch push failing identically rules out anything PR-specific.

## Fix

Mirror how the pip-based `verify` envs already install offline (`PIP_FIND_LINKS`), but for uv's build-isolation resolution:

1. **`warmDepsCache.yml`** — add `hatchling` to the wheelhouse `pip download` (pulls hatchling + its universal-wheel deps).
2. **`setup-python-deps`** — export `UV_FIND_LINKS=$HOME/.cache/pip-wheelhouse` in the offline block, so uv installs the backend from local content-addressed wheels instead of resolving it against the (stale) index.

## Validation

Reproduced locally: with `UV_OFFLINE=true` and an unusable index, `hatch build` fails with the exact CI error; adding `UV_FIND_LINKS=<wheelhouse-with-hatchling>` makes the build succeed offline.