### PR TITLE
test(ci): verify offline build-backend fix against warmed cache

### DIFF
--- a/.github/workflows/warmDepsCache.yml
+++ b/.github/workflows/warmDepsCache.yml
@@ -12,9 +12,6 @@
 name: Warm Python Dependency Cache
 
 on:
-  # TEMP (remove before merge): validate the offline-build fix on this PR by
-  # warming the cache into the PR merge-ref scope so the test jobs can restore it.
-  pull_request:
   push:
     branches: [main]
     paths:


### PR DESCRIPTION
Validation-only PR for #1492. **Do not merge.**

Base is the fix branch (`sd-db/ci/fix-offline-build-backend`), so this PR's CI restores the fix branch's warmed cache (which now contains `hatchling` in the wheelhouse). The only diff vs the base is removing the temporary `pull_request` warm trigger, so the CI here runs the exact clean-fix state that #1492 will merge.

Green here ⇒ the `UV_FIND_LINKS` + wheelhouse fix resolves the build backend offline.