### PR TITLE
test: disable connector telemetry in test runs to remove CI ERROR-log noise

### DIFF
--- a/tests/profiles.py
+++ b/tests/profiles.py
@@ -40,13 +40,17 @@ def _build_databricks_cluster_target(
         profile["schema"] = schema
     if session_properties is not None:
         profile["session_properties"] = session_properties
-    if os.getenv("DBT_DATABRICKS_PORT"):
-        profile["connection_parameters"] = {
-            "_port": os.getenv("DBT_DATABRICKS_PORT"),
-            # If you are specifying a port for running tests, assume Docker
-            # is being used and disable TLS verification
-            "_tls_no_verify": True,
-        }
+    # Test runs gain nothing from connector telemetry, and when its background
+    # POSTs fail in CI they spam ERROR logs on otherwise-green runs. Turn it off
+    # here so the connector uses its NoopTelemetryClient.
+    connection_parameters: dict[str, Any] = {"enable_telemetry": False}
+    port = os.getenv("DBT_DATABRICKS_PORT")
+    if port:
+        connection_parameters["_port"] = port
+        # If you are specifying a port for running tests, assume Docker
+        # is being used and disable TLS verification
+        connection_parameters["_tls_no_verify"] = True
+    profile["connection_parameters"] = connection_parameters
     return profile
 
 


### PR DESCRIPTION
## Problem

On fully successful CI runs, the integration-test logs are flooded with ERROR-level noise — `--- Logging error ---` + traceback blocks and literal `HTTP request error: %s` lines — that buries real failures and inflates log artifacts (~4,000 of ~9,200 lines were noise in a sample green job, [`78949595712`](https://github.com/databricks/dbt-databricks/actions/runs/26782205113/job/78949595712)).

Root cause of the bulk of it: the `databricks-sql-connector` (4.2.6, our locked version) enables telemetry by default and runs its POSTs on a background `ThreadPoolExecutor`. When those POSTs fail in CI (runner egress to the telemetry endpoint), the connector logs retry-exhaustion at ERROR on a background thread. Under pytest those records hit a capture handler whose stream has been closed at teardown, degrading into the `--- Logging error ---` blocks.

## Fix

Test runs gain nothing from connector telemetry. Pass `enable_telemetry=False` through the test profiles' `connection_parameters` (which flows to `dbsql.connect`), so the connector uses its `NoopTelemetryClient` and emits no telemetry POSTs — removing the noise at the source.

This is scoped to `tests/profiles.py` only; no product code changes.

## Verification

- Confirmed against the locked connector (4.2.6): a dbt connection opened through the test profile reports `telemetry_enabled is False` and uses `NoopTelemetryClient`.
- **Verified against a real integration run on this PR head** ([`27020859727`](https://github.com/databricks/dbt-databricks/actions/runs/27020859727)): across all 8 e2e shards (cluster / uc-cluster / sqlwarehouse), the logs contained **zero** stray telemetry lines — no `--- Logging error ---` blocks, no `ERROR:databricks.sql…` lines, no `I/O operation on closed file`, no `HTTP request error: %s`. (The original sample job carried ~4,000 such lines.)
- One unrelated test failed on that run (`test_remove_foreign_key_constraint`) due to a transient server-side `Database Error [INTERNAL_ERROR]` creating a foreign-key model — not related to telemetry or this change.

## Follow-up (separate PR)

There is a related, independent user-facing bug — the logging bridge in `dbt/adapters/databricks/logging.py` forwards the raw `%s` template instead of the rendered message, so connector logs with placeholders render a literal `%s` on real dbt runs (e.g. `Token exchange failed, using external token: %s`, still visible in the run above). That fix (`record.getMessage()`, plus stopping `databricks.sql` records from propagating to the root logger) is deferred to its own PR.