### PR TITLE
test: make incremental constraint functional tests rerun-safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 ### Under the Hood
 
+- Make the incremental constraint functional tests rerun-safe so a `pytest --reruns` retry no longer inherits mutated state (rewritten `schema.yml`, half-built relations) from the failed attempt (test-only, no runtime impact). ([#1503](https://github.com/databricks/dbt-databricks/pull/1503))
 - Make the column-tag functional tests rerun-safe so a `pytest --reruns` retry no longer inherits mutated state (updated `schema.yml`, leftover column tags, a running streaming-table query) from the failed attempt (test-only, no runtime impact). ([#1499](https://github.com/databricks/dbt-databricks/pull/1499))
 - Raise the `dbt-tests-adapter` test-dependency floor to `>=1.20.0` to pick up its `persist_docs` fixture typo fix (test-only, no runtime impact) ([#1490](https://github.com/databricks/dbt-databricks/pull/1490))
 - Defer SDK `Config` construction to connection-open time so offline paths (`dbt parse`/`list`/`compile`) don't trigger the host-metadata probe introduced in `databricks-sdk>=0.103`; as a side effect, auth errors now surface at first connection rather than during profile parsing. ([#1474](https://github.com/databricks/dbt-databricks/pull/1474))

--- a/tests/functional/adapter/incremental/test_incremental_constraints.py
+++ b/tests/functional/adapter/incremental/test_incremental_constraints.py
@@ -2,12 +2,19 @@ import pytest
 from dbt.contracts.results import RunStatus
 from dbt.tests import util
 
-from tests.functional.adapter.fixtures import RequiresDescribeAsJsonCapabilityMixin
+from tests.functional.adapter.fixtures import (
+    RequiresDescribeAsJsonCapabilityMixin,
+    RerunSafeMixin,
+)
 from tests.functional.adapter.incremental import fixtures
 
 
 @pytest.mark.skip_profile("databricks_cluster")
-class TestIncrementalSetNonNullConstraint:
+class TestIncrementalSetNonNullConstraint(RerunSafeMixin):
+    @pytest.fixture(scope="class")
+    def relations_to_reset(self):
+        return ("non_null_constraint_sql",)
+
     @pytest.fixture(scope="class")
     def project_config_update(self):
         return {
@@ -46,7 +53,11 @@ class TestIncrementalSetNonNullConstraintDescribeJsonOn(
 
 
 @pytest.mark.skip_profile("databricks_cluster")
-class TestIncrementalUnsetNonNullConstraint:
+class TestIncrementalUnsetNonNullConstraint(RerunSafeMixin):
+    @pytest.fixture(scope="class")
+    def relations_to_reset(self):
+        return ("non_null_constraint_sql",)
+
     @pytest.fixture(scope="class")
     def project_config_update(self):
         return {
@@ -82,7 +93,11 @@ class TestIncrementalUnsetNonNullConstraint:
 
 
 @pytest.mark.skip_profile("databricks_cluster")
-class TestIncrementalSetCheckConstraint:
+class TestIncrementalSetCheckConstraint(RerunSafeMixin):
+    @pytest.fixture(scope="class")
+    def relations_to_reset(self):
+        return ("check_constraint_sql",)
+
     @pytest.fixture(scope="class")
     def project_config_update(self):
         return {
@@ -107,7 +122,11 @@ class TestIncrementalSetCheckConstraint:
 
 
 @pytest.mark.skip_profile("databricks_cluster")
-class TestIncrementalRemoveCheckConstraint:
+class TestIncrementalRemoveCheckConstraint(RerunSafeMixin):
+    @pytest.fixture(scope="class")
+    def relations_to_reset(self):
+        return ("check_constraint_sql",)
+
     @pytest.fixture(scope="class")
     def project_config_update(self):
         return {
@@ -146,13 +165,17 @@ class TestIncrementalRemoveCheckConstraint:
 
 
 @pytest.mark.skip_profile("databricks_cluster")
-class TestIncrementalUpdatePrimaryKeyConstraint:
+class TestIncrementalUpdatePrimaryKeyConstraint(RerunSafeMixin):
     primary_key_constraint_sql = """
         SELECT constraint_name, column_name
         FROM {database}.information_schema.key_column_usage
         WHERE constraint_schema = '{schema}'
         ORDER BY ordinal_position
     """
+
+    @pytest.fixture(scope="class")
+    def relations_to_reset(self):
+        return ("primary_key_constraint_sql",)
 
     @pytest.fixture(scope="class")
     def project_config_update(self):
@@ -205,7 +228,12 @@ class TestIncrementalUpdatePrimaryKeyConstraintDescribeJsonOn(
 
 
 @pytest.mark.skip_profile("databricks_cluster")
-class TestCascadingConstraintDrop:
+class TestCascadingConstraintDrop(RerunSafeMixin):
+    @pytest.fixture(scope="class")
+    def relations_to_reset(self):
+        # ref_table holds the FK to primary_key_constraint_sql, so drop it first.
+        return ("ref_table", "primary_key_constraint_sql")
+
     @pytest.fixture(scope="class")
     def project_config_update(self):
         return {
@@ -258,7 +286,12 @@ referential_constraint_sql = """
 
 
 @pytest.mark.skip_profile("databricks_cluster")
-class TestIncrementalSetForeignKeyConstraint:
+class TestIncrementalSetForeignKeyConstraint(RerunSafeMixin):
+    @pytest.fixture(scope="class")
+    def relations_to_reset(self):
+        # fk_referenced_from_table holds the FKs, so drop it before its parents.
+        return ("fk_referenced_from_table", "fk_referenced_to_table", "fk_referenced_to_table_2")
+
     @pytest.fixture(scope="class")
     def project_config_update(self):
         return {
@@ -323,7 +356,12 @@ class TestIncrementalDiff:
 
 
 @pytest.mark.skip_profile("databricks_cluster")
-class TestIncrementalRemoveForeignKeyConstraint:
+class TestIncrementalRemoveForeignKeyConstraint(RerunSafeMixin):
+    @pytest.fixture(scope="class")
+    def relations_to_reset(self):
+        # fk_referenced_from_table holds the FKs, so drop it before its parents.
+        return ("fk_referenced_from_table", "fk_referenced_to_table", "fk_referenced_to_table_2")
+
     @pytest.fixture(scope="class")
     def project_config_update(self):
         return {


### PR DESCRIPTION
## Problem

The constraint tests in `tests/functional/adapter/incremental/test_incremental_constraints.py` rewrite `schema.yml` in place mid-test (via `util.write_file`) and build relations, but they aren't safe under `pytest --reruns`. pytest-rerunfailures retries a failed test **without** tearing down the class-scoped `project` fixture, so the mutated `schema.yml` and the relations created by the failed attempt leak into the retry and fail it deterministically — meaning a single intermittent error burns all retries.

Observed on `TestIncrementalRemoveForeignKeyConstraint::test_remove_foreign_key_constraint` in a nightly: an intermittent server `INTERNAL_ERROR` failed the initial attempt, and **both** `--reruns 2` retries then failed because they ran against the un-reset, half-built state (only the corrupted FK-parent kept failing; its siblings kept succeeding).

## Change

Apply the existing `RerunSafeMixin` (added in #1499) to the `schema.yml`-mutating constraint classes. Before each attempt its autouse fixture restores the initial model files and drops the relations the test builds (named via `relations_to_reset`). FK-holding relations are listed before their parents so the drop order respects the constraint. The two `...DescribeJsonOn` subclasses inherit the mixin from their parents. Test-only; no adapter/runtime changes.

## Verification

- Full `test_incremental_constraints.py` on `databricks_uc_cluster`: **15 passed, 0 failed**.
- Deterministic rerun-recovery proof (throwaway): a class that mutates `schema.yml` then fails its first attempt **recovers on rerun with the mixin (`RERUN → PASSED`)** and **fails without it (`RERUN → FAILED`)** — the mixin restores `schema.yml` and drops the relations before the retry. Mirrors #1499's forced-rerun repro.
- ruff / ruff-format / mypy pass.