### PR TITLE
feat: Add instrumentation for recording `add_query`, `get_relation_config`, `is_uniform`, `has_dbr_capability`, and `is_cluster` methods

### DIFF
--- a/dbt/adapters/databricks/impl.py
+++ b/dbt/adapters/databricks/impl.py
@@ -412,6 +412,7 @@ class DatabricksAdapter(SparkAdapter):
         return conn.has_capability(capability)
 
     @available.parse(lambda *a, **k: False)
+    @auto_record_function("AdapterHasDbrCapability", group="Available")
     def has_dbr_capability(self, capability_name: str) -> bool:
         """
         Check if a DBR capability is available for current compute.

--- a/dbt/adapters/databricks/impl.py
+++ b/dbt/adapters/databricks/impl.py
@@ -57,7 +57,7 @@ from dbt.adapters.databricks.dbr_capabilities import DBRCapabilities, DBRCapabil
 from dbt.adapters.databricks.global_state import GlobalState
 from dbt.adapters.databricks.handle import SqlUtils
 from dbt.adapters.databricks.logging import logger
-from dbt.adapters.databricks.record.record_types import DatabricksAdapterIsUniformRecord, DatabricksAdapterGetRelationConfigRecord
+from dbt.adapters.databricks.record.record_types import DatabricksAdapterAddQueryRecord, DatabricksAdapterIsUniformRecord, DatabricksAdapterGetRelationConfigRecord
 from dbt.adapters.databricks.python_models.python_submissions import (
     AllPurposeClusterPythonJobHelper,
     JobClusterPythonJobHelper,
@@ -884,6 +884,13 @@ class DatabricksAdapter(SparkAdapter):
         behavior_flag = getattr(self.behavior, behavior_flag_name)
         return behavior_flag.no_warn
 
+    @available.parse(lambda *a, **k: (None, None))
+    @record_function(
+        DatabricksAdapterAddQueryRecord,
+        method=True,
+        index_on_thread_id=True,
+        id_field_name="thread_id",
+    )
     def add_query(
         self,
         sql: str,

--- a/dbt/adapters/databricks/impl.py
+++ b/dbt/adapters/databricks/impl.py
@@ -57,12 +57,16 @@ from dbt.adapters.databricks.dbr_capabilities import DBRCapabilities, DBRCapabil
 from dbt.adapters.databricks.global_state import GlobalState
 from dbt.adapters.databricks.handle import SqlUtils
 from dbt.adapters.databricks.logging import logger
-from dbt.adapters.databricks.record.record_types import DatabricksAdapterAddQueryRecord, DatabricksAdapterIsUniformRecord, DatabricksAdapterGetRelationConfigRecord
 from dbt.adapters.databricks.python_models.python_submissions import (
     AllPurposeClusterPythonJobHelper,
     JobClusterPythonJobHelper,
     ServerlessClusterPythonJobHelper,
     WorkflowPythonJobHelper,
+)
+from dbt.adapters.databricks.record.record_types import (
+    DatabricksAdapterAddQueryRecord,
+    DatabricksAdapterGetRelationConfigRecord,
+    DatabricksAdapterIsUniformRecord,
 )
 from dbt.adapters.databricks.relation import (
     KEY_TABLE_PROVIDER,

--- a/dbt/adapters/databricks/impl.py
+++ b/dbt/adapters/databricks/impl.py
@@ -32,7 +32,7 @@ from dbt.adapters.spark.impl import (
 from dbt_common.behavior_flags import BehaviorFlag
 from dbt_common.contracts.config.base import BaseConfig, MergeBehavior
 from dbt_common.exceptions import DbtConfigError, DbtInternalError, DbtRuntimeError
-from dbt_common.record import auto_record_function
+from dbt_common.record import auto_record_function, record_function
 from dbt_common.utils import executor
 from dbt_common.utils.dict import AttrDict
 from packaging import version
@@ -57,6 +57,7 @@ from dbt.adapters.databricks.dbr_capabilities import DBRCapabilities, DBRCapabil
 from dbt.adapters.databricks.global_state import GlobalState
 from dbt.adapters.databricks.handle import SqlUtils
 from dbt.adapters.databricks.logging import logger
+from dbt.adapters.databricks.record.record_types import DatabricksAdapterIsUniformRecord
 from dbt.adapters.databricks.python_models.python_submissions import (
     AllPurposeClusterPythonJobHelper,
     JobClusterPythonJobHelper,
@@ -319,6 +320,12 @@ class DatabricksAdapter(SparkAdapter):
         return quote(identifier)
 
     @available.parse(lambda *a, **k: 0)
+    @record_function(
+        DatabricksAdapterIsUniformRecord,
+        method=True,
+        index_on_thread_id=True,
+        id_field_name="thread_id",
+    )
     def is_uniform(self, config: BaseConfig) -> bool:
         catalog_relation: DatabricksCatalogRelation = self.build_catalog_relation(config.model)  # type:ignore
         if catalog_relation.table_format == constants.ICEBERG_TABLE_FORMAT:

--- a/dbt/adapters/databricks/impl.py
+++ b/dbt/adapters/databricks/impl.py
@@ -57,7 +57,7 @@ from dbt.adapters.databricks.dbr_capabilities import DBRCapabilities, DBRCapabil
 from dbt.adapters.databricks.global_state import GlobalState
 from dbt.adapters.databricks.handle import SqlUtils
 from dbt.adapters.databricks.logging import logger
-from dbt.adapters.databricks.record.record_types import DatabricksAdapterIsUniformRecord
+from dbt.adapters.databricks.record.record_types import DatabricksAdapterIsUniformRecord, DatabricksAdapterGetRelationConfigRecord
 from dbt.adapters.databricks.python_models.python_submissions import (
     AllPurposeClusterPythonJobHelper,
     JobClusterPythonJobHelper,
@@ -1054,6 +1054,12 @@ class DatabricksAdapter(SparkAdapter):
         return enriched_columns, parsed_constraints
 
     @available.parse(lambda *a, **k: {})
+    @record_function(
+        DatabricksAdapterGetRelationConfigRecord,
+        method=True,
+        index_on_thread_id=True,
+        id_field_name="thread_id",
+    )
     def get_relation_config(
         self,
         relation: DatabricksRelation,

--- a/dbt/adapters/databricks/impl.py
+++ b/dbt/adapters/databricks/impl.py
@@ -32,6 +32,7 @@ from dbt.adapters.spark.impl import (
 from dbt_common.behavior_flags import BehaviorFlag
 from dbt_common.contracts.config.base import BaseConfig, MergeBehavior
 from dbt_common.exceptions import DbtConfigError, DbtInternalError, DbtRuntimeError
+from dbt_common.record import auto_record_function
 from dbt_common.utils import executor
 from dbt_common.utils.dict import AttrDict
 from packaging import version
@@ -1083,6 +1084,7 @@ class DatabricksAdapter(SparkAdapter):
             )
 
     @available
+    @auto_record_function("AdapterIsCluster", group="Available")
     def is_cluster(self) -> bool:
         """Check if the current connection is a cluster."""
         return self.connections.is_cluster()

--- a/dbt/adapters/databricks/record/record_types.py
+++ b/dbt/adapters/databricks/record/record_types.py
@@ -89,7 +89,16 @@ class DatabricksAdapterGetRelationConfigParams:
         return {
             "thread_id": self.thread_id,
             "relation": serialize_base_relation(self.relation),
-            "model_config": self.model_config.model_dump() if self.model_config else None,
+            "model_config": (
+                {
+                    "config": {
+                        k: v.model_dump(mode="json")
+                        for k, v in self.model_config.config.items()
+                    }
+                }
+                if self.model_config
+                else None
+            ),
         }
 
 

--- a/dbt/adapters/databricks/record/record_types.py
+++ b/dbt/adapters/databricks/record/record_types.py
@@ -3,7 +3,50 @@ from typing import Any, Optional
 
 from dbt.adapters.databricks.relation import DatabricksRelation
 from dbt.adapters.databricks.relation_configs.base import DatabricksRelationConfigBase
+from dbt.adapters.record.serialization import serialize_bindings
 from dbt_common.record import Record, Recorder
+
+
+@dataclasses.dataclass
+class DatabricksAdapterAddQueryParams:
+    thread_id: str
+    sql: str
+    auto_begin: bool = True
+    bindings: Optional[Any] = None
+    abridge_sql_log: bool = False
+    close_cursor: bool = False
+
+    def _to_dict(self):
+        return {
+            "thread_id": self.thread_id,
+            "sql": self.sql,
+            "auto_begin": self.auto_begin,
+            "bindings": serialize_bindings(self.bindings),
+            "abridge_sql_log": self.abridge_sql_log,
+            "close_cursor": self.close_cursor,
+        }
+
+
+@dataclasses.dataclass
+class DatabricksAdapterAddQueryResult:
+    return_val: tuple
+
+    def _to_dict(self):
+        return {
+            "return_val": {
+                "conn": "conn",
+                "cursor": "cursor",
+            }
+        }
+
+
+@Recorder.register_record_type
+class DatabricksAdapterAddQueryRecord(Record):
+    """Implements record/replay support for the DatabricksAdapter.add_query() method."""
+
+    params_cls = DatabricksAdapterAddQueryParams
+    result_cls = DatabricksAdapterAddQueryResult
+    group = "Available"
 
 
 @dataclasses.dataclass

--- a/dbt/adapters/databricks/record/record_types.py
+++ b/dbt/adapters/databricks/record/record_types.py
@@ -1,6 +1,8 @@
 import dataclasses
-from typing import Any
+from typing import Any, Optional
 
+from dbt.adapters.databricks.relation import DatabricksRelation
+from dbt.adapters.databricks.relation_configs.base import DatabricksRelationConfigBase
 from dbt_common.record import Record, Recorder
 
 
@@ -28,4 +30,50 @@ class DatabricksAdapterIsUniformRecord(Record):
 
     params_cls = DatabricksAdapterIsUniformParams
     result_cls = DatabricksAdapterIsUniformResult
+    group = "Available"
+
+
+@dataclasses.dataclass
+class DatabricksAdapterGetRelationConfigParams:
+    thread_id: str
+    relation: DatabricksRelation
+    model_config: Optional[DatabricksRelationConfigBase]
+
+    def _to_dict(self):
+        from dbt.adapters.record.serialization import serialize_base_relation
+
+        return {
+            "thread_id": self.thread_id,
+            "relation": serialize_base_relation(self.relation),
+            "model_config": self.model_config.model_dump() if self.model_config else None,
+        }
+
+
+@dataclasses.dataclass
+class DatabricksAdapterGetRelationConfigResult:
+    return_val: Optional[dict]  # DatabricksRelationConfigBase serialized as dict, or None
+
+    def _to_dict(self):
+        # return_val is already converted to dict by the constructor
+        return {
+            "return_val": self.return_val,
+        }
+
+    def __init__(self, return_val):
+        if return_val is not None and not isinstance(return_val, dict):
+            self.return_val = return_val.model_dump()
+        else:
+            self.return_val = return_val
+
+    @classmethod
+    def _from_dict(cls, data):
+        return cls(return_val=data.get("return_val"))
+
+
+@Recorder.register_record_type
+class DatabricksAdapterGetRelationConfigRecord(Record):
+    """Implements record/replay support for the DatabricksAdapter.get_relation_config() method."""
+
+    params_cls = DatabricksAdapterGetRelationConfigParams
+    result_cls = DatabricksAdapterGetRelationConfigResult
     group = "Available"

--- a/dbt/adapters/databricks/record/record_types.py
+++ b/dbt/adapters/databricks/record/record_types.py
@@ -1,10 +1,11 @@
 import dataclasses
 from typing import Any, Optional
 
-from dbt.adapters.databricks.relation import DatabricksRelation
-from dbt.adapters.databricks.relation_configs.base import DatabricksRelationConfigBase
 from dbt.adapters.record.serialization import serialize_bindings
 from dbt_common.record import Record, Recorder
+
+from dbt.adapters.databricks.relation import DatabricksRelation
+from dbt.adapters.databricks.relation_configs.base import DatabricksRelationConfigBase
 
 
 @dataclasses.dataclass
@@ -16,7 +17,7 @@ class DatabricksAdapterAddQueryParams:
     abridge_sql_log: bool = False
     close_cursor: bool = False
 
-    def _to_dict(self):
+    def _to_dict(self) -> dict[str, Any]:
         return {
             "thread_id": self.thread_id,
             "sql": self.sql,
@@ -31,7 +32,7 @@ class DatabricksAdapterAddQueryParams:
 class DatabricksAdapterAddQueryResult:
     return_val: tuple
 
-    def _to_dict(self):
+    def _to_dict(self) -> dict[str, Any]:
         return {
             "return_val": {
                 "conn": "conn",
@@ -54,7 +55,7 @@ class DatabricksAdapterIsUniformParams:
     thread_id: str
     config: Any
 
-    def _to_dict(self):
+    def _to_dict(self) -> dict[str, Any]:
         return {
             "thread_id": self.thread_id,
             "config_model": self.config.model.to_dict(),
@@ -82,7 +83,7 @@ class DatabricksAdapterGetRelationConfigParams:
     relation: DatabricksRelation
     model_config: Optional[DatabricksRelationConfigBase]
 
-    def _to_dict(self):
+    def _to_dict(self) -> dict[str, Any]:
         from dbt.adapters.record.serialization import serialize_base_relation
 
         return {
@@ -96,20 +97,20 @@ class DatabricksAdapterGetRelationConfigParams:
 class DatabricksAdapterGetRelationConfigResult:
     return_val: Optional[dict]  # DatabricksRelationConfigBase serialized as dict, or None
 
-    def _to_dict(self):
+    def _to_dict(self) -> dict[str, Any]:
         # return_val is already converted to dict by the constructor
         return {
             "return_val": self.return_val,
         }
 
-    def __init__(self, return_val):
+    def __init__(self, return_val: Optional[Any]) -> None:
         if return_val is not None and not isinstance(return_val, dict):
             self.return_val = return_val.model_dump()
         else:
             self.return_val = return_val
 
     @classmethod
-    def _from_dict(cls, data):
+    def _from_dict(cls, data: dict[str, Any]) -> "DatabricksAdapterGetRelationConfigResult":
         return cls(return_val=data.get("return_val"))
 
 

--- a/dbt/adapters/databricks/record/record_types.py
+++ b/dbt/adapters/databricks/record/record_types.py
@@ -106,9 +106,7 @@ class DatabricksAdapterGetRelationConfigResult:
     def __init__(self, return_val: Optional[Any]) -> None:
         if return_val is not None and not isinstance(return_val, dict):
             self.return_val = {
-                "config": {
-                    k: v.model_dump(mode="json") for k, v in return_val.config.items()
-                }
+                "config": {k: v.model_dump(mode="json") for k, v in return_val.config.items()}
             }
         else:
             self.return_val = return_val

--- a/dbt/adapters/databricks/record/record_types.py
+++ b/dbt/adapters/databricks/record/record_types.py
@@ -92,8 +92,7 @@ class DatabricksAdapterGetRelationConfigParams:
             "model_config": (
                 {
                     "config": {
-                        k: v.model_dump(mode="json")
-                        for k, v in self.model_config.config.items()
+                        k: v.model_dump(mode="json") for k, v in self.model_config.config.items()
                     }
                 }
                 if self.model_config

--- a/dbt/adapters/databricks/record/record_types.py
+++ b/dbt/adapters/databricks/record/record_types.py
@@ -105,7 +105,11 @@ class DatabricksAdapterGetRelationConfigResult:
 
     def __init__(self, return_val: Optional[Any]) -> None:
         if return_val is not None and not isinstance(return_val, dict):
-            self.return_val = return_val.model_dump()
+            self.return_val = {
+                "config": {
+                    k: v.model_dump(mode="json") for k, v in return_val.config.items()
+                }
+            }
         else:
             self.return_val = return_val
 

--- a/dbt/adapters/databricks/record/record_types.py
+++ b/dbt/adapters/databricks/record/record_types.py
@@ -1,4 +1,5 @@
 import dataclasses
+import json
 from typing import Any, Optional
 
 from dbt.adapters.record.serialization import serialize_bindings
@@ -6,6 +7,21 @@ from dbt_common.record import Record, Recorder
 
 from dbt.adapters.databricks.relation import DatabricksRelation
 from dbt.adapters.databricks.relation_configs.base import DatabricksRelationConfigBase
+
+
+def _serialize_component(component: Any) -> dict[str, Any]:
+    """Serialize a relation config component to a JSON-native dict.
+
+    pydantic v2 exposes ``model_dump(mode="json")``; v1 only has ``json()``,
+    which is round-tripped to coerce tuples, sets, and enums to JSON types.
+    Under v1 the ``model_config`` ConfigDict is treated as a regular field and
+    leaks into the output, so it is dropped to match the v2 shape.
+    """
+    if hasattr(component, "model_dump"):
+        return component.model_dump(mode="json")
+    serialized = json.loads(component.json())
+    serialized.pop("model_config", None)
+    return serialized
 
 
 @dataclasses.dataclass
@@ -92,7 +108,7 @@ class DatabricksAdapterGetRelationConfigParams:
             "model_config": (
                 {
                     "config": {
-                        k: v.model_dump(mode="json") for k, v in self.model_config.config.items()
+                        k: _serialize_component(v) for k, v in self.model_config.config.items()
                     }
                 }
                 if self.model_config
@@ -114,7 +130,7 @@ class DatabricksAdapterGetRelationConfigResult:
     def __init__(self, return_val: Optional[Any]) -> None:
         if return_val is not None and not isinstance(return_val, dict):
             self.return_val = {
-                "config": {k: v.model_dump(mode="json") for k, v in return_val.config.items()}
+                "config": {k: _serialize_component(v) for k, v in return_val.config.items()}
             }
         else:
             self.return_val = return_val

--- a/dbt/adapters/databricks/record/record_types.py
+++ b/dbt/adapters/databricks/record/record_types.py
@@ -1,0 +1,31 @@
+import dataclasses
+from typing import Any
+
+from dbt_common.record import Record, Recorder
+
+
+@dataclasses.dataclass
+class DatabricksAdapterIsUniformParams:
+    thread_id: str
+    config: Any
+
+    def _to_dict(self):
+        return {
+            "thread_id": self.thread_id,
+            "config_model": self.config.model.to_dict(),
+            "materialized": self.config.get("materialized"),
+        }
+
+
+@dataclasses.dataclass
+class DatabricksAdapterIsUniformResult:
+    return_val: bool
+
+
+@Recorder.register_record_type
+class DatabricksAdapterIsUniformRecord(Record):
+    """Implements record/replay support for the DatabricksAdapter.is_uniform() method."""
+
+    params_cls = DatabricksAdapterIsUniformParams
+    result_cls = DatabricksAdapterIsUniformResult
+    group = "Available"

--- a/tests/unit/record/fixtures/is_uniform_config_model.json
+++ b/tests/unit/record/fixtures/is_uniform_config_model.json
@@ -1,0 +1,122 @@
+{
+  "database": "test_schema",
+  "schema": "test_schema",
+  "name": "m_table",
+  "resource_type": "model",
+  "package_name": "test_project",
+  "path": "m_table.sql",
+  "original_file_path": "models/m_table.sql",
+  "unique_id": "model.test_project.m_table",
+  "fqn": [
+    "test_project",
+    "m_table"
+  ],
+  "alias": "m_table",
+  "checksum": {
+    "name": "sha256",
+    "checksum": ""
+  },
+  "config": {
+    "enabled": true,
+    "alias": null,
+    "schema": null,
+    "database": null,
+    "tags": [],
+    "meta": {},
+    "group": null,
+    "materialized": "table",
+    "incremental_strategy": null,
+    "batch_size": null,
+    "lookback": 1,
+    "begin": null,
+    "persist_docs": {},
+    "post-hook": [],
+    "pre-hook": [],
+    "quoting": {},
+    "column_types": {},
+    "full_refresh": null,
+    "unique_key": null,
+    "on_schema_change": "ignore",
+    "on_configuration_change": "apply",
+    "grants": {},
+    "packages": [],
+    "docs": {
+      "show": true,
+      "node_color": null
+    },
+    "contract": {
+      "enforced": false,
+      "alias_types": true
+    },
+    "event_time": null,
+    "concurrent_batches": null,
+    "access": "protected",
+    "freshness": null
+  },
+  "tags": [],
+  "description": "",
+  "columns": {
+    "id": {
+      "name": "id",
+      "description": "",
+      "meta": {},
+      "data_type": null,
+      "constraints": [],
+      "quote": null,
+      "config": {
+        "meta": {},
+        "tags": []
+      },
+      "tags": [],
+      "granularity": null,
+      "doc_blocks": []
+    }
+  },
+  "meta": {},
+  "group": null,
+  "docs": {
+    "show": true,
+    "node_color": null
+  },
+  "patch_path": "test_project://models/schema.yml",
+  "build_path": null,
+  "unrendered_config": {
+    "materialized": "table"
+  },
+  "created_at": 0,
+  "config_call_dict": {
+    "materialized": "table"
+  },
+  "unrendered_config_call_dict": {},
+  "relation_name": "`test_schema`.`test_schema`.`m_table`",
+  "raw_code": "{{ config(materialized='table') }}\nselect 1 as id, 'a' as val",
+  "doc_blocks": [],
+  "language": "sql",
+  "refs": [],
+  "sources": [],
+  "metrics": [],
+  "functions": [],
+  "depends_on": {
+    "macros": [],
+    "nodes": []
+  },
+  "compiled_path": "target/compiled/test_project/models/m_table.sql",
+  "compiled": true,
+  "compiled_code": "\nselect 1 as id, 'a' as val",
+  "extra_ctes_injected": true,
+  "extra_ctes": [],
+  "contract": {
+    "enforced": false,
+    "alias_types": true,
+    "checksum": null
+  },
+  "access": "protected",
+  "constraints": [],
+  "version": null,
+  "latest_version": null,
+  "deprecation_date": null,
+  "defer_relation": null,
+  "primary_key": [],
+  "time_spine": null,
+  "batch": null
+}

--- a/tests/unit/record/test_record_types.py
+++ b/tests/unit/record/test_record_types.py
@@ -1,0 +1,553 @@
+"""Unit tests for the record/replay instrumentation on DatabricksAdapter.
+
+Each test drives a real, decorated adapter method under a RECORD-mode recorder
+and asserts on the record that lands in the recorder. Every method is tested the
+same way:
+
+  1. A recorder is installed on the invocation context (the decorator reads it
+     from there; without it the call would not be recorded).
+  2. The method's Databricks interaction is mocked, so the body runs offline.
+  3. The real decorated method is called with real arguments.
+  4. The captured record is serialized via Record.to_dict() and its "params"
+     and "result" dicts are asserted against the expected shape. This is the
+     exact dict the recorder would write to a recording.
+"""
+
+import json
+from decimal import Decimal
+from multiprocessing import get_context
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import pytest
+from dbt_common.context import get_invocation_context, set_invocation_context
+from dbt_common.record import Recorder, RecorderMode
+
+from dbt.adapters.databricks.impl import (
+    DatabricksAdapter,
+    IncrementalTableAPI,
+    MaterializedViewAPI,
+    MetricViewAPI,
+    StreamingTableAPI,
+    ViewAPI,
+)
+from dbt.adapters.databricks.relation import DatabricksRelation, DatabricksRelationType
+from dbt.adapters.databricks.relation_configs.column_comments import ColumnCommentsConfig
+from dbt.adapters.databricks.relation_configs.column_mask import ColumnMaskConfig
+from dbt.adapters.databricks.relation_configs.column_tags import ColumnTagsConfig
+from dbt.adapters.databricks.relation_configs.comment import CommentConfig
+from dbt.adapters.databricks.relation_configs.constraints import (
+    CheckConstraint,
+    ConstraintsConfig,
+    ConstraintType,
+    ForeignKeyConstraint,
+    PrimaryKeyConstraint,
+)
+from dbt.adapters.databricks.relation_configs.incremental import IncrementalTableConfig
+from dbt.adapters.databricks.relation_configs.liquid_clustering import LiquidClusteringConfig
+from dbt.adapters.databricks.relation_configs.materialized_view import MaterializedViewConfig
+from dbt.adapters.databricks.relation_configs.metric_view import (
+    MetricViewConfig,
+    MetricViewQueryConfig,
+)
+from dbt.adapters.databricks.relation_configs.partitioning import PartitionedByConfig
+from dbt.adapters.databricks.relation_configs.query import QueryConfig
+from dbt.adapters.databricks.relation_configs.refresh import RefreshConfig
+from dbt.adapters.databricks.relation_configs.row_filter import RowFilterConfig
+from dbt.adapters.databricks.relation_configs.streaming_table import StreamingTableConfig
+from dbt.adapters.databricks.relation_configs.tags import TagsConfig
+from dbt.adapters.databricks.relation_configs.tblproperties import TblPropertiesConfig
+from dbt.adapters.databricks.relation_configs.view import ViewConfig
+from tests.unit.utils import config_from_parts_or_dicts
+
+THREAD_NAME = "test_thread"
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def load_fixture(name: str) -> dict:
+    """Load a recorded fixture captured from a real dbt-databricks run."""
+    return json.loads((FIXTURES / name).read_text())
+
+
+def get_record(recorder: Recorder, record_name: str) -> dict:
+    records = recorder._records_by_type[record_name]
+    assert len(records) == 1
+    return records[0].to_dict()
+
+
+def sort_constraints(result_config: dict) -> dict:
+    """Sort the set-derived lists in a constraints component in place.
+
+    These are serialized from Python sets, so their list order is not
+    deterministic across runs; sorting makes exact-dict assertions stable.
+    """
+    c = result_config.get("constraints")
+    if c:
+        c["set_non_nulls"] = sorted(c["set_non_nulls"])
+        c["unset_non_nulls"] = sorted(c["unset_non_nulls"])
+        c["set_constraints"] = sorted(c["set_constraints"], key=lambda x: x["name"])
+        c["unset_constraints"] = sorted(c["unset_constraints"], key=lambda x: x["name"])
+    return result_config
+
+
+class TestRecordTypes:
+    @pytest.fixture
+    def adapter(self) -> DatabricksAdapter:
+        project_cfg = {
+            "name": "test_project",
+            "version": "0.1",
+            "profile": "test",
+            "project-root": "/tmp/dbt/does-not-exist",
+            "config-version": 2,
+        }
+        profile_cfg = {
+            "outputs": {
+                "test": {
+                    "type": "databricks",
+                    "catalog": "main",
+                    "schema": "analytics",
+                    "host": "test.databricks.com",
+                    "http_path": "sql/protocolv1/o/1234567890123456/1234-567890-test123",
+                    "token": "dapi" + "X" * 32,
+                }
+            },
+            "target": "test",
+        }
+        config = config_from_parts_or_dicts(project_cfg, profile_cfg)
+        return DatabricksAdapter(config, get_context("spawn"))
+
+    @pytest.fixture
+    def recorder(self) -> Recorder:
+        # Install an in-memory RECORD recorder on the invocation context. The
+        # known name makes the decorator-injected thread_id deterministic.
+        set_invocation_context({})
+        ctx = get_invocation_context()
+        ctx.name = THREAD_NAME
+        recorder = Recorder(RecorderMode.RECORD, None, in_memory=True)
+        ctx.recorder = recorder
+        return recorder
+
+    def test_record_is_cluster(self, adapter: DatabricksAdapter, recorder: Recorder) -> None:
+        adapter.connections.is_cluster = Mock(return_value=True)
+
+        adapter.is_cluster()
+
+        record = get_record(recorder, "AdapterIsClusterRecord")
+        assert record["params"] == {"thread_id": THREAD_NAME}
+        assert record["result"] == {"return_val": True}
+
+    def test_record_has_dbr_capability(
+        self, adapter: DatabricksAdapter, recorder: Recorder
+    ) -> None:
+        adapter.has_capability = Mock(return_value=True)
+
+        adapter.has_dbr_capability("insert_by_name")
+
+        record = get_record(recorder, "AdapterHasDbrCapabilityRecord")
+        assert record["params"] == {
+            "thread_id": THREAD_NAME,
+            "capability_name": "insert_by_name",
+        }
+        assert record["result"] == {"return_val": True}
+
+    def test_record_add_query(self, adapter: DatabricksAdapter, recorder: Recorder) -> None:
+        adapter.connections.add_query = Mock()
+
+        sql = "insert overwrite `db`.`sch`.`s_data` values\n          (%s,%s),(%s,%s)"
+        adapter.add_query(
+            sql,
+            auto_begin=True,
+            bindings=[Decimal("1"), "a", Decimal("2"), "b"],
+            abridge_sql_log=True,
+            close_cursor=True,
+        )
+
+        # The add_query result just gets discarded from recordings.
+        record = get_record(recorder, "DatabricksAdapterAddQueryRecord")
+        assert record["params"] == {
+            "thread_id": THREAD_NAME,
+            "sql": sql,
+            "auto_begin": True,
+            "bindings": [1.0, "a", 2.0, "b"],
+            "abridge_sql_log": True,
+            "close_cursor": True,
+        }
+
+    def test_record_is_uniform(self, adapter: DatabricksAdapter, recorder: Recorder) -> None:
+        config_model = load_fixture("is_uniform_config_model.json")
+        adapter.build_catalog_relation = Mock(return_value=Mock(table_format="default"))
+        config = Mock()
+        config.model.to_dict.return_value = config_model
+        config.get.side_effect = lambda key, default=None: {
+            "materialized": config_model["config"]["materialized"],
+        }.get(key, default)
+
+        adapter.is_uniform(config)
+
+        record = get_record(recorder, "DatabricksAdapterIsUniformRecord")
+        assert record["params"] == {
+            "thread_id": THREAD_NAME,
+            "config_model": config_model,
+            "materialized": "table",
+        }
+        assert record["result"] == {"return_val": False}
+
+    # get_relation_config dispatches on relation.type.
+    #
+    # Each test below builds a real relation of one type plus a fully-populated
+    # config, passes that config as model_config, and mocks the matching API to
+    # return the same config as the result.
+    #
+    # We use patch.object to override the internal call to the *API method.
+
+    def test_record_get_relation_config_materialized_view(
+        self, adapter: DatabricksAdapter, recorder: Recorder
+    ) -> None:
+        relation = DatabricksRelation.create(
+            identifier="my_mv",
+            schema="analytics",
+            database="main",
+            type=DatabricksRelationType.MaterializedView,
+            metadata={"Provider": "delta"},
+        )
+        config = MaterializedViewConfig(
+            config={
+                "partition_by": PartitionedByConfig(partition_by=["region", "dt"]),
+                "liquid_clustering": LiquidClusteringConfig(
+                    auto_cluster=True, cluster_by=["id", "region"]
+                ),
+                "comment": CommentConfig(comment="rich mv", persist=True),
+                "tblproperties": TblPropertiesConfig(
+                    tblproperties={"delta.autoOptimize.optimizeWrite": "true", "team": "data"},
+                    pipeline_id="pid-1",
+                ),
+                "refresh": RefreshConfig(
+                    cron="0 5 * * *", time_zone_value="America/Los_Angeles", is_altered=True
+                ),
+                "query": QueryConfig(query="select * from src"),
+                "tags": TagsConfig(set_tags={"team": "data", "tier": "gold"}),
+                "row_filter": RowFilterConfig(
+                    function="cat.sch.filt", columns=("region", "tenant"), is_change=True
+                ),
+            }
+        )
+
+        expected_config = {
+            "partition_by": {"partition_by": ["region", "dt"]},
+            "liquid_clustering": {"auto_cluster": True, "cluster_by": ["id", "region"]},
+            "comment": {"comment": "rich mv", "persist": True},
+            "tblproperties": {
+                "tblproperties": {"delta.autoOptimize.optimizeWrite": "true", "team": "data"},
+                "pipeline_id": "pid-1",
+            },
+            "refresh": {
+                "cron": "0 5 * * *",
+                "time_zone_value": "America/Los_Angeles",
+                "every": None,
+                "on_update": False,
+                "at_most_every": None,
+                "is_altered": True,
+            },
+            "query": {"query": "select * from src"},
+            "tags": {"set_tags": {"team": "data", "tier": "gold"}},
+            "row_filter": {
+                "function": "cat.sch.filt",
+                "columns": ["region", "tenant"],
+                "should_unset": False,
+                "is_change": True,
+            },
+        }
+
+        with patch.object(MaterializedViewAPI, "get_from_relation", return_value=config):
+            adapter.get_relation_config(relation, config)
+
+        record = get_record(recorder, "DatabricksAdapterGetRelationConfigRecord")
+        assert record["params"] == {
+            "thread_id": THREAD_NAME,
+            "relation": relation.to_dict(omit_none=True),
+            "model_config": {"config": expected_config},
+        }
+        assert record["result"] == {"return_val": {"config": expected_config}}
+
+    def test_record_get_relation_config_streaming_table(
+        self, adapter: DatabricksAdapter, recorder: Recorder
+    ) -> None:
+        relation = DatabricksRelation.create(
+            identifier="my_st",
+            schema="analytics",
+            database="main",
+            type=DatabricksRelationType.StreamingTable,
+            metadata={"Provider": "delta"},
+        )
+        config = StreamingTableConfig(
+            config={
+                "partition_by": PartitionedByConfig(partition_by=["region"]),
+                "liquid_clustering": LiquidClusteringConfig(auto_cluster=False, cluster_by=["id"]),
+                "comment": CommentConfig(comment="rich st", persist=True),
+                "tblproperties": TblPropertiesConfig(
+                    tblproperties={"team": "data"}, pipeline_id="pid-2"
+                ),
+                "refresh": RefreshConfig(every="2 HOURS"),
+                "tags": TagsConfig(set_tags={"team": "data"}),
+                "query": QueryConfig(query="select * from stream(src)"),
+                "row_filter": RowFilterConfig(function="cat.sch.filt", columns=("region",)),
+            }
+        )
+
+        expected_config = {
+            "partition_by": {"partition_by": ["region"]},
+            "liquid_clustering": {"auto_cluster": False, "cluster_by": ["id"]},
+            "comment": {"comment": "rich st", "persist": True},
+            "tblproperties": {"tblproperties": {"team": "data"}, "pipeline_id": "pid-2"},
+            "refresh": {
+                "cron": None,
+                "time_zone_value": None,
+                "every": "2 HOURS",
+                "on_update": False,
+                "at_most_every": None,
+                "is_altered": False,
+            },
+            "tags": {"set_tags": {"team": "data"}},
+            "query": {"query": "select * from stream(src)"},
+            "row_filter": {
+                "function": "cat.sch.filt",
+                "columns": ["region"],
+                "should_unset": False,
+                "is_change": False,
+            },
+        }
+
+        with patch.object(StreamingTableAPI, "get_from_relation", return_value=config):
+            adapter.get_relation_config(relation, config)
+
+        record = get_record(recorder, "DatabricksAdapterGetRelationConfigRecord")
+        assert record["params"] == {
+            "thread_id": THREAD_NAME,
+            "relation": relation.to_dict(omit_none=True),
+            "model_config": {"config": expected_config},
+        }
+        assert record["result"] == {"return_val": {"config": expected_config}}
+
+    def test_record_get_relation_config_table(
+        self, adapter: DatabricksAdapter, recorder: Recorder
+    ) -> None:
+        relation = DatabricksRelation.create(
+            identifier="my_table",
+            schema="analytics",
+            database="main",
+            type=DatabricksRelationType.Table,
+            is_delta=True,
+            metadata={"Provider": "delta"},
+        )
+        config = IncrementalTableConfig(
+            config={
+                "comment": CommentConfig(comment="rich inc", persist=True),
+                "column_comments": ColumnCommentsConfig(
+                    comments={"id": "the id", "email": "user email"}, persist=True
+                ),
+                "column_masks": ColumnMaskConfig(
+                    set_column_masks={
+                        "ssn": {"function": "cat.sch.mask_ssn", "using_columns": "region"}
+                    },
+                    unset_column_masks=["old_col"],
+                ),
+                "column_tags": ColumnTagsConfig(
+                    set_column_tags={"email": {"pii": "true"}, "id": {"pk": "true"}}
+                ),
+                "constraints": ConstraintsConfig(
+                    set_non_nulls={"id", "email"},
+                    unset_non_nulls={"legacy"},
+                    set_constraints={
+                        CheckConstraint(
+                            type=ConstraintType.check,
+                            name="chk_len",
+                            expression="length(name) >= 1",
+                        ),
+                        PrimaryKeyConstraint(
+                            type=ConstraintType.primary_key, name="pk_id", columns=["id"]
+                        ),
+                        ForeignKeyConstraint(
+                            type=ConstraintType.foreign_key,
+                            name="fk_org",
+                            columns=["org_id"],
+                            to="cat.sch.orgs",
+                            to_columns=["id"],
+                        ),
+                    },
+                    unset_constraints={
+                        CheckConstraint(
+                            type=ConstraintType.check, name="old_chk", expression="x > 0"
+                        )
+                    },
+                ),
+                "row_filter": RowFilterConfig(function="cat.sch.filt", columns=("region",)),
+                "tags": TagsConfig(set_tags={"team": "data"}),
+                "tblproperties": TblPropertiesConfig(tblproperties={"delta.appendOnly": "false"}),
+                "liquid_clustering": LiquidClusteringConfig(auto_cluster=False, cluster_by=["id"]),
+            }
+        )
+
+        expected_config = {
+            "comment": {"comment": "rich inc", "persist": True},
+            "column_comments": {
+                "comments": {"id": "the id", "email": "user email"},
+                "persist": True,
+            },
+            "column_masks": {
+                "set_column_masks": {
+                    "ssn": {"function": "cat.sch.mask_ssn", "using_columns": "region"}
+                },
+                "unset_column_masks": ["old_col"],
+            },
+            "column_tags": {"set_column_tags": {"email": {"pii": "true"}, "id": {"pk": "true"}}},
+            "constraints": {
+                "set_non_nulls": ["email", "id"],
+                "unset_non_nulls": ["legacy"],
+                "set_constraints": [
+                    {
+                        "type": "check",
+                        "name": "chk_len",
+                        "expression": "length(name) >= 1",
+                        "warn_unenforced": True,
+                        "warn_unsupported": True,
+                        "to": None,
+                        "to_columns": [],
+                        "columns": [],
+                    },
+                    {
+                        "type": "foreign_key",
+                        "name": "fk_org",
+                        "expression": None,
+                        "warn_unenforced": True,
+                        "warn_unsupported": True,
+                        "to": "cat.sch.orgs",
+                        "to_columns": ["id"],
+                        "columns": ["org_id"],
+                    },
+                    {
+                        "type": "primary_key",
+                        "name": "pk_id",
+                        "expression": None,
+                        "warn_unenforced": True,
+                        "warn_unsupported": True,
+                        "to": None,
+                        "to_columns": [],
+                        "columns": ["id"],
+                    },
+                ],
+                "unset_constraints": [
+                    {
+                        "type": "check",
+                        "name": "old_chk",
+                        "expression": "x > 0",
+                        "warn_unenforced": True,
+                        "warn_unsupported": True,
+                        "to": None,
+                        "to_columns": [],
+                        "columns": [],
+                    }
+                ],
+            },
+            "row_filter": {
+                "function": "cat.sch.filt",
+                "columns": ["region"],
+                "should_unset": False,
+                "is_change": False,
+            },
+            "tags": {"set_tags": {"team": "data"}},
+            "tblproperties": {"tblproperties": {"delta.appendOnly": "false"}, "pipeline_id": None},
+            "liquid_clustering": {"auto_cluster": False, "cluster_by": ["id"]},
+        }
+
+        with patch.object(IncrementalTableAPI, "get_from_relation", return_value=config):
+            adapter.get_relation_config(relation, config)
+
+        record = get_record(recorder, "DatabricksAdapterGetRelationConfigRecord")
+        # Sort the set-derived constraint lists (serialized from sets) for determinism.
+        sort_constraints(record["params"]["model_config"]["config"])
+        sort_constraints(record["result"]["return_val"]["config"])
+        assert record["params"] == {
+            "thread_id": THREAD_NAME,
+            "relation": relation.to_dict(omit_none=True),
+            "model_config": {"config": expected_config},
+        }
+        assert record["result"] == {"return_val": {"config": expected_config}}
+
+    def test_record_get_relation_config_view(
+        self, adapter: DatabricksAdapter, recorder: Recorder
+    ) -> None:
+        relation = DatabricksRelation.create(
+            identifier="my_view",
+            schema="analytics",
+            database="main",
+            type=DatabricksRelationType.View,
+            metadata={"Provider": "delta"},
+        )
+        config = ViewConfig(
+            config={
+                "tags": TagsConfig(set_tags={"team": "data", "tier": "silver"}),
+                "tblproperties": TblPropertiesConfig(tblproperties={"team": "data"}),
+                "query": QueryConfig(query="select * from src"),
+                "comment": CommentConfig(comment="rich view", persist=True),
+                "column_comments": ColumnCommentsConfig(comments={"id": "the id"}, persist=True),
+                "column_tags": ColumnTagsConfig(set_column_tags={"id": {"pii": "false"}}),
+            }
+        )
+
+        expected_config = {
+            "tags": {"set_tags": {"team": "data", "tier": "silver"}},
+            "tblproperties": {"tblproperties": {"team": "data"}, "pipeline_id": None},
+            "query": {"query": "select * from src"},
+            "comment": {"comment": "rich view", "persist": True},
+            "column_comments": {"comments": {"id": "the id"}, "persist": True},
+            "column_tags": {"set_column_tags": {"id": {"pii": "false"}}},
+        }
+
+        with patch.object(ViewAPI, "get_from_relation", return_value=config):
+            adapter.get_relation_config(relation, config)
+
+        record = get_record(recorder, "DatabricksAdapterGetRelationConfigRecord")
+        assert record["params"] == {
+            "thread_id": THREAD_NAME,
+            "relation": relation.to_dict(omit_none=True),
+            "model_config": {"config": expected_config},
+        }
+        assert record["result"] == {"return_val": {"config": expected_config}}
+
+    def test_record_get_relation_config_metric_view(
+        self, adapter: DatabricksAdapter, recorder: Recorder
+    ) -> None:
+        relation = DatabricksRelation.create(
+            identifier="my_metric_view",
+            schema="analytics",
+            database="main",
+            type=DatabricksRelationType.MetricView,
+        )
+        config = MetricViewConfig(
+            config={
+                "tags": TagsConfig(set_tags={"team": "metrics"}),
+                "tblproperties": TblPropertiesConfig(tblproperties={"team": "data"}),
+                "query": MetricViewQueryConfig(
+                    query="version: 0.1\nsource: orders\nmeasures:\n  - name: n\n    expr: count(1)"
+                ),
+            }
+        )
+
+        expected_config = {
+            "tags": {"set_tags": {"team": "metrics"}},
+            "tblproperties": {"tblproperties": {"team": "data"}, "pipeline_id": None},
+            "query": {
+                "query": "version: 0.1\nsource: orders\nmeasures:\n  - name: n\n    expr: count(1)"
+            },
+        }
+
+        with patch.object(MetricViewAPI, "get_from_relation", return_value=config):
+            adapter.get_relation_config(relation, config)
+
+        record = get_record(recorder, "DatabricksAdapterGetRelationConfigRecord")
+        assert record["params"] == {
+            "thread_id": THREAD_NAME,
+            "relation": relation.to_dict(omit_none=True),
+            "model_config": {"config": expected_config},
+        }
+        assert record["result"] == {"return_val": {"config": expected_config}}

--- a/tests/unit/record/test_record_types.py
+++ b/tests/unit/record/test_record_types.py
@@ -127,7 +127,7 @@ class TestRecordTypes:
         ctx.recorder = recorder
         return recorder
 
-    def test_record_is_cluster(self, adapter: DatabricksAdapter, recorder: Recorder) -> None:
+    def test_record_is_cluster(self, adapter, recorder):
         adapter.connections.is_cluster = Mock(return_value=True)
 
         adapter.is_cluster()
@@ -136,9 +136,7 @@ class TestRecordTypes:
         assert record["params"] == {"thread_id": THREAD_NAME}
         assert record["result"] == {"return_val": True}
 
-    def test_record_has_dbr_capability(
-        self, adapter: DatabricksAdapter, recorder: Recorder
-    ) -> None:
+    def test_record_has_dbr_capability(self, adapter, recorder):
         adapter.has_capability = Mock(return_value=True)
 
         adapter.has_dbr_capability("insert_by_name")
@@ -150,7 +148,7 @@ class TestRecordTypes:
         }
         assert record["result"] == {"return_val": True}
 
-    def test_record_add_query(self, adapter: DatabricksAdapter, recorder: Recorder) -> None:
+    def test_record_add_query(self, adapter, recorder):
         adapter.connections.add_query = Mock()
 
         sql = "insert overwrite `db`.`sch`.`s_data` values\n          (%s,%s),(%s,%s)"
@@ -173,7 +171,7 @@ class TestRecordTypes:
             "close_cursor": True,
         }
 
-    def test_record_is_uniform(self, adapter: DatabricksAdapter, recorder: Recorder) -> None:
+    def test_record_is_uniform(self, adapter, recorder):
         config_model = load_fixture("is_uniform_config_model.json")
         adapter.build_catalog_relation = Mock(return_value=Mock(table_format="default"))
         config = Mock()
@@ -200,9 +198,7 @@ class TestRecordTypes:
     #
     # We use patch.object to override the internal call to the *API method.
 
-    def test_record_get_relation_config_materialized_view(
-        self, adapter: DatabricksAdapter, recorder: Recorder
-    ) -> None:
+    def test_record_get_relation_config_materialized_view(self, adapter, recorder):
         relation = DatabricksRelation.create(
             identifier="my_mv",
             schema="analytics",
@@ -269,9 +265,7 @@ class TestRecordTypes:
         }
         assert record["result"] == {"return_val": {"config": expected_config}}
 
-    def test_record_get_relation_config_streaming_table(
-        self, adapter: DatabricksAdapter, recorder: Recorder
-    ) -> None:
+    def test_record_get_relation_config_streaming_table(self, adapter, recorder):
         relation = DatabricksRelation.create(
             identifier="my_st",
             schema="analytics",
@@ -328,9 +322,7 @@ class TestRecordTypes:
         }
         assert record["result"] == {"return_val": {"config": expected_config}}
 
-    def test_record_get_relation_config_table(
-        self, adapter: DatabricksAdapter, recorder: Recorder
-    ) -> None:
+    def test_record_get_relation_config_table(self, adapter, recorder):
         relation = DatabricksRelation.create(
             identifier="my_table",
             schema="analytics",
@@ -473,9 +465,7 @@ class TestRecordTypes:
         }
         assert record["result"] == {"return_val": {"config": expected_config}}
 
-    def test_record_get_relation_config_view(
-        self, adapter: DatabricksAdapter, recorder: Recorder
-    ) -> None:
+    def test_record_get_relation_config_view(self, adapter, recorder):
         relation = DatabricksRelation.create(
             identifier="my_view",
             schema="analytics",
@@ -514,9 +504,7 @@ class TestRecordTypes:
         }
         assert record["result"] == {"return_val": {"config": expected_config}}
 
-    def test_record_get_relation_config_metric_view(
-        self, adapter: DatabricksAdapter, recorder: Recorder
-    ) -> None:
+    def test_record_get_relation_config_metric_view(self, adapter, recorder):
         relation = DatabricksRelation.create(
             identifier="my_metric_view",
             schema="analytics",


### PR DESCRIPTION
<!-- Please review our pull request review process in CONTRIBUTING.md before your proceed. -->

Resolves #N/A.

<!---
  Include the number of the issue addressed by this PR above if applicable.

  Example:
    resolves #1234

  Please review our pull request review process in CONTRIBUTING.md before your proceed.
-->

### Description

Instruments the following adapter functions for recording:
- `has_dbr_capability` and `is_cluster` (via the auto record decorator)
- `add_query`
- `get_relation_config`
- `is_uniform`

### Checklist

- [X] I have run this code in development and it appears to resolve the stated issue
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
