### PR TITLE
fix(ci): pre-build min-deps env and unmask prepare-shards collection errors

### DIFF
--- a/.github/workflows/integration-min-deps.yml
+++ b/.github/workflows/integration-min-deps.yml
@@ -167,6 +167,11 @@ jobs:
         with:
           version: "1.17.0"
 
+      # Build the env once, serially: otherwise the three backgrounded
+      # `hatch run min-deps:` calls below race to create it on a cold runner.
+      - name: Create min-deps env
+        run: hatch env create min-deps
+
       - name: Collect tests and assign to shards
         run: |
           set -euo pipefail
@@ -176,14 +181,28 @@ jobs:
             [databricks_uc_cluster]=${{ needs.prepare.outputs.count_uc_cluster }}
             [databricks_uc_sql_endpoint]=${{ needs.prepare.outputs.count_uc_sql_endpoint }}
           )
+          # Capture full output per profile; don't pipe through grep here, or a
+          # failure's exit code is lost and surfaces only as "no valid nodeids".
+          declare -A PIDS
           for PROFILE in "${!NUM_SHARDS[@]}"; do
-            (
-              hatch run min-deps:pytest --collect-only -q --profile "$PROFILE" tests/functional 2>&1 \
-                | grep "::" \
-                > "shard-assignments/${PROFILE}-collected.txt"
-            ) &
+            hatch run min-deps:pytest --collect-only -q --profile "$PROFILE" tests/functional \
+              > "shard-assignments/${PROFILE}-raw.log" 2>&1 &
+            PIDS[$PROFILE]=$!
           done
-          wait
+          COLLECT_FAILED=0
+          for PROFILE in "${!NUM_SHARDS[@]}"; do
+            RC=0
+            wait "${PIDS[$PROFILE]}" || RC=$?
+            if [ "$RC" -ne 0 ]; then
+              echo "::error::min-deps test collection failed for profile ${PROFILE} (exit ${RC}); output below:"
+              cat "shard-assignments/${PROFILE}-raw.log"
+              COLLECT_FAILED=1
+              continue
+            fi
+            grep "::" "shard-assignments/${PROFILE}-raw.log" \
+              > "shard-assignments/${PROFILE}-collected.txt" || true
+          done
+          [ "$COLLECT_FAILED" -eq 0 ] || exit 1
           for PROFILE in "${!NUM_SHARDS[@]}"; do
             python3 scripts/shard_assign.py \
               --profile "$PROFILE" \


### PR DESCRIPTION
## Problem

The nightly **Integration Tests (Min-Deps)** workflow intermittently fails at `prepare-shards` with:

```
ERROR: no valid nodeids in shard-assignments/databricks_cluster-collected.txt
Process completed with exit code 2.
```

Example: [run 27374846599](https://github.com/databricks/dbt-databricks/actions/runs/27374846599) (also 27164400308). Both had a dependency **cache hit**, failed fast (~30s), and showed the identical generic error. Local `pytest --collect-only` on the same `main` collects 531 tests cleanly — so the code is fine.

## Root cause

Two compounding issues in the `Collect tests and assign to shards` step:

1. **Env-creation race (the trigger).** The step backgrounds three `hatch run min-deps:pytest --collect-only` calls (`( … ) & … wait`). The `min-deps` env was never pre-built, so on a cold runner all three race to lazily create the *same* env. A lost race leaves a half-built env that collects zero node ids — intermittent by nature (some nights pass, some fail), which a deterministic dependency break could not produce.

2. **Error masking (why it was undebuggable).** Each call ran `hatch … 2>&1 | grep "::" > file` inside a backgrounded subshell joined by a bare `wait`. `wait` with no PID args always returns 0, so `set -euo pipefail` never caught the failed pipeline; the real env-build/collection error was funneled into the node-id file and stripped by `grep "::"`. Only the downstream `shard_assign.py` error ever surfaced.

## Fix

- Add a serial **`Create min-deps env`** step (`hatch env create min-deps`) so the env is built once before the parallel collection — removing the creation race and surfacing any env-build error directly.
- Rework the collect step to write each profile's full output to a raw log, **check each background job's exit code**, and **fail loudly with the real error** (`::error::` + log dump) instead of swallowing it. Node-id extraction (`grep "::"`) then runs from the raw logs.

## Verification

- Local: `hatch run pytest --collect-only` = 531 tests, clean; `hatch env create min-deps` confirmed valid; new bash logic simulated for both the success path (node ids extracted, exit 0) and the failure path (loud exit 1 with the actual error).
- E2E: triggered this workflow via `workflow_dispatch` against this branch so the modified YAML actually runs (the `/integration-test` comment path dispatches with `ref: main` and would run the old definition).