### PR TITLE
test: make remaining incremental functional tests rerun-safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Under the Hood
 
 - Raise the `dbt-adapters` upper bound to `<1.25.0` ([#1507](https://github.com/databricks/dbt-databricks/pull/1507))
+- Make the remaining incremental functional tests (tags, column tags, tblproperties, liquid clustering, column masks, persist_docs, replace table) rerun-safe so a `pytest --reruns` retry no longer inherits mutated state (rewritten `schema.yml`/model files, half-built relations) from the failed attempt (test-only, no runtime impact).
 
 ## dbt-databricks 1.12.1 (June 10, 2026)
 

--- a/tests/functional/adapter/incremental/test_incremental_clustering.py
+++ b/tests/functional/adapter/incremental/test_incremental_clustering.py
@@ -1,11 +1,16 @@
 import pytest
 from dbt.tests import util
 
+from tests.functional.adapter.fixtures import RerunSafeMixin
 from tests.functional.adapter.incremental import fixtures
 
 
 @pytest.mark.skip_profile("databricks_cluster")
-class TestIncrementalLiquidClustering:
+class TestIncrementalLiquidClustering(RerunSafeMixin):
+    @pytest.fixture(scope="class")
+    def relations_to_reset(self):
+        return ("merge_update_columns_sql",)
+
     @pytest.fixture(scope="class")
     def models(self):
         return {
@@ -39,7 +44,11 @@ class TestIncrementalLiquidClustering:
 
 @pytest.mark.python
 @pytest.mark.skip_profile("databricks_cluster")
-class TestIncrementalPythonLiquidClustering:
+class TestIncrementalPythonLiquidClustering(RerunSafeMixin):
+    @pytest.fixture(scope="class")
+    def relations_to_reset(self):
+        return ("simple_python_model",)
+
     @pytest.fixture(scope="class")
     def models(self):
         return {

--- a/tests/functional/adapter/incremental/test_incremental_column_masks.py
+++ b/tests/functional/adapter/incremental/test_incremental_column_masks.py
@@ -4,12 +4,17 @@ from dbt.tests import util
 from tests.functional.adapter.fixtures import (
     MaterializationV2Mixin,
     RequiresDescribeAsJsonCapabilityMixin,
+    RerunSafeMixin,
 )
 from tests.functional.adapter.incremental import fixtures
 
 
 @pytest.mark.skip_profile("databricks_cluster")
-class TestIncrementalColumnMasks(MaterializationV2Mixin):
+class TestIncrementalColumnMasks(RerunSafeMixin, MaterializationV2Mixin):
+    @pytest.fixture(scope="class")
+    def relations_to_reset(self):
+        return ("column_mask_sql",)
+
     @pytest.fixture(scope="class")
     def models(self):
         return {

--- a/tests/functional/adapter/incremental/test_incremental_column_tags.py
+++ b/tests/functional/adapter/incremental/test_incremental_column_tags.py
@@ -3,12 +3,16 @@ import os
 import pytest
 from dbt.tests import util
 
-from tests.functional.adapter.fixtures import MaterializationV2Mixin
+from tests.functional.adapter.fixtures import MaterializationV2Mixin, RerunSafeMixin
 from tests.functional.adapter.incremental import fixtures
 
 
 @pytest.mark.skip_profile("databricks_cluster")
-class TestIncrementalColumnTags(MaterializationV2Mixin):
+class TestIncrementalColumnTags(RerunSafeMixin, MaterializationV2Mixin):
+    @pytest.fixture(scope="class")
+    def relations_to_reset(self):
+        return ("merge_update_columns",)
+
     @pytest.fixture(scope="class")
     def models(self):
         return {

--- a/tests/functional/adapter/incremental/test_incremental_persist_docs.py
+++ b/tests/functional/adapter/incremental/test_incremental_persist_docs.py
@@ -1,10 +1,15 @@
 import pytest
 from dbt.tests import util
 
+from tests.functional.adapter.fixtures import RerunSafeMixin
 from tests.functional.adapter.incremental import fixtures
 
 
-class TestIncrementalPersistDocs:
+class TestIncrementalPersistDocs(RerunSafeMixin):
+    @pytest.fixture(scope="class")
+    def relations_to_reset(self):
+        return ("merge_update_columns_sql",)
+
     @pytest.fixture(scope="class")
     def models(self):
         return {

--- a/tests/functional/adapter/incremental/test_incremental_replace_table.py
+++ b/tests/functional/adapter/incremental/test_incremental_replace_table.py
@@ -1,11 +1,16 @@
 import pytest
 from dbt.tests import util
 
+from tests.functional.adapter.fixtures import RerunSafeMixin
 from tests.functional.adapter.incremental import fixtures
 
 
 @pytest.mark.skip_profile("databricks_cluster", "databricks_uc_sql_endpoint")
-class TestIncrementalReplaceTable:
+class TestIncrementalReplaceTable(RerunSafeMixin):
+    @pytest.fixture(scope="class")
+    def relations_to_reset(self):
+        return ("model",)
+
     @pytest.fixture(scope="class")
     def models(self):
         return {"model.sql": fixtures.replace_table}

--- a/tests/functional/adapter/incremental/test_incremental_tags.py
+++ b/tests/functional/adapter/incremental/test_incremental_tags.py
@@ -1,11 +1,16 @@
 import pytest
 from dbt.tests import util
 
+from tests.functional.adapter.fixtures import RerunSafeMixin
 from tests.functional.adapter.incremental import fixtures
 
 
 @pytest.mark.skip_profile("databricks_cluster")
-class TestIncrementalTags:
+class TestIncrementalTags(RerunSafeMixin):
+    @pytest.fixture(scope="class")
+    def relations_to_reset(self):
+        return ("merge_update_columns_sql",)
+
     @pytest.fixture(scope="class")
     def models(self):
         return {
@@ -35,7 +40,11 @@ class TestIncrementalTags:
 
 @pytest.mark.python
 @pytest.mark.skip_profile("databricks_cluster")
-class TestIncrementalPythonTags:
+class TestIncrementalPythonTags(RerunSafeMixin):
+    @pytest.fixture(scope="class")
+    def relations_to_reset(self):
+        return ("tags",)
+
     @pytest.fixture(scope="class")
     def models(self):
         return {

--- a/tests/functional/adapter/incremental/test_incremental_tblproperties.py
+++ b/tests/functional/adapter/incremental/test_incremental_tblproperties.py
@@ -1,10 +1,15 @@
 import pytest
 from dbt.tests import util
 
+from tests.functional.adapter.fixtures import RerunSafeMixin
 from tests.functional.adapter.incremental import fixtures
 
 
-class TestIncrementalTblproperties:
+class TestIncrementalTblproperties(RerunSafeMixin):
+    @pytest.fixture(scope="class")
+    def relations_to_reset(self):
+        return ("merge_update_columns_sql",)
+
     @pytest.fixture(scope="class")
     def models(self):
         return {
@@ -30,7 +35,11 @@ class TestIncrementalTblproperties:
 
 @pytest.mark.python
 @pytest.mark.skip_profile("databricks_cluster")
-class TestIncrementalPythonTblproperties:
+class TestIncrementalPythonTblproperties(RerunSafeMixin):
+    @pytest.fixture(scope="class")
+    def relations_to_reset(self):
+        return ("tblproperties",)
+
     @pytest.fixture(scope="class")
     def models(self):
         return {


### PR DESCRIPTION
### Description

Follow-up to #1503 (incremental constraint tests) and #1499 (column-tag tests): applies the same `RerunSafeMixin` treatment to the remaining incremental functional tests that mutate on-disk state mid-test.

These tests rewrite `schema.yml` (or `model.sql`) via `write_file` and build relations during the test body. Under `pytest --reruns 2` (used in CI integration runs), a transient failure leaves the retry running against the mutated files and the half-built relation from the failed attempt, so the retry fails deterministically and the rerun budget is wasted.

Covered files:

- `test_incremental_tags.py` (SQL + Python)
- `test_incremental_column_tags.py` (SQL + Python)
- `test_incremental_tblproperties.py` (SQL + Python)
- `test_incremental_clustering.py` (SQL + Python)
- `test_incremental_column_masks.py` (incl. DescribeJsonOn subclass via inheritance)
- `test_incremental_persist_docs.py` (incl. V2 subclass via inheritance)
- `test_incremental_replace_table.py`

Test-only change, no runtime impact.

Verified against a UC SQL warehouse and a UC all-purpose cluster: 11 passed. The two `column_tags` tests could not run in my workspace because a Unity Catalog tag policy there restricts allowed values for the `pii` tag key (the fixtures use `pii: "false"`); the unmodified tests fail identically on that workspace, so this is environmental and unrelated to the change. They are covered by the CI integration environment.

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
