### PR TITLE
test: add functional test for incremental column mask removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Under the Hood
 
+- Add a functional test for incremental column-mask removal: dropping a `column_mask` from a model with an existing incremental relation issues `ALTER COLUMN ... DROP MASK` and leaves the column unmasked (test-only, no runtime impact). ([#1514](https://github.com/databricks/dbt-databricks/pull/1514))
 - Raise the `dbt-adapters` upper bound to `<1.25.0` ([#1507](https://github.com/databricks/dbt-databricks/pull/1507))
 
 ## dbt-databricks 1.12.1 (June 10, 2026)

--- a/tests/functional/adapter/column_masks/fixtures.py
+++ b/tests/functional/adapter/column_masks/fixtures.py
@@ -43,3 +43,14 @@ models:
           function: weird_mask
           using_columns: "id, 'literal_string', 333, true, null, INTERVAL 2 DAYS"
 """
+
+model_no_mask = """
+version: 2
+models:
+  - name: base_model
+    columns:
+      - name: id
+        data_type: string
+      - name: password
+        data_type: string
+"""

--- a/tests/functional/adapter/column_masks/test_column_mask_changes.py
+++ b/tests/functional/adapter/column_masks/test_column_mask_changes.py
@@ -1,0 +1,59 @@
+import pytest
+from dbt.tests.util import run_dbt, write_file
+
+from tests.functional.adapter.column_masks.fixtures import (
+    base_model_sql,
+    model,
+    model_no_mask,
+)
+from tests.functional.adapter.fixtures import MaterializationV2Mixin, RerunSafeMixin
+
+
+@pytest.mark.skip_profile("databricks_cluster")
+class TestIncrementalColumnMaskRemoval(RerunSafeMixin, MaterializationV2Mixin):
+    """Removing a column_mask on an existing incremental relation issues
+    ALTER COLUMN ... DROP MASK (the get_diff unset branch), leaving the column
+    unmasked."""
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "base_model.sql": base_model_sql.replace("table", "incremental"),
+            "schema.yml": model,
+        }
+
+    @pytest.fixture(scope="class")
+    def relations_to_reset(self):
+        return ("base_model",)
+
+    def _column_masks(self, project):
+        return project.run_sql(
+            f"""
+            SELECT column_name, mask_name
+            FROM {project.database}.information_schema.column_masks
+            WHERE table_schema = '{project.test_schema}'
+              AND table_name = 'base_model'
+            """,
+            fetch="all",
+        )
+
+    def test_removing_column_mask_drops_it(self, project):
+        project.run_sql(
+            f"CREATE OR REPLACE FUNCTION {project.database}.{project.test_schema}."
+            "password_mask(password STRING) RETURNS STRING RETURN '*****';"
+        )
+
+        # First run: the mask is applied to the column at create time.
+        run_dbt(["run"])
+        masks = self._column_masks(project)
+        assert len(masks) == 1
+        assert masks[0][0] == "password"
+        assert project.run_sql("SELECT password FROM base_model", fetch="one")[0] == "*****"
+
+        # Drop the column_mask from the model and re-run against the existing relation.
+        write_file(model_no_mask, "models", "schema.yml")
+        run_dbt(["run"])
+
+        masks_after = self._column_masks(project)
+        assert masks_after == []
+        assert project.run_sql("SELECT password FROM base_model", fetch="one")[0] == "password123"


### PR DESCRIPTION
### Description

Adds a functional test covering the column-mask **removal** path. When a `column_mask` is removed from a model that already has an existing incremental relation, the next `dbt run` reconciles config and issues `ALTER COLUMN ... DROP MASK` (the `get_diff` *unset* branch), leaving the column unmasked.

`TestIncrementalColumnMaskRemoval`:
1. Creates the mask function, runs the model with the mask applied, and asserts the column is masked via `information_schema.column_masks` and a `SELECT` (reads `*****`).
2. Rewrites `schema.yml` to drop the `column_mask` (new `model_no_mask` fixture) and re-runs.
3. Asserts the mask row is gone and the column now returns its raw value (`password123`).

Built on the existing `RerunSafeMixin` + `MaterializationV2Mixin`; asserts server-observable state only. Skipped on `databricks_cluster`.

Test-only; no adapter/runtime changes.

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
