### PR TITLE
fix(deps): raise databricks-sdk ceiling to <0.118.0 to resolve #1252 on Spark Connect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 - Add a functional test for incremental column-mask removal: dropping a `column_mask` from a model with an existing incremental relation issues `ALTER COLUMN ... DROP MASK` and leaves the column unmasked (test-only, no runtime impact). ([#1514](https://github.com/databricks/dbt-databricks/pull/1514))
 - Raise the `dbt-adapters` upper bound to `<1.25.0` ([#1507](https://github.com/databricks/dbt-databricks/pull/1507))
+- Raise the `databricks-sdk` upper bound to `<0.118.0` to pick up 0.117.0, which fixes `WorkspaceClient` construction failing with `CONTEXT_UNAVAILABLE_FOR_REMOTE_CLIENT` on Spark Connect clusters ([#1517](https://github.com/databricks/dbt-databricks/pull/1517) closes [#1252](https://github.com/databricks/dbt-databricks/issues/1252))
 - Make the remaining incremental functional tests (tags, column tags, tblproperties, liquid clustering, column masks, persist_docs, replace table) rerun-safe so a `pytest --reruns` retry no longer inherits mutated state (rewritten `schema.yml`/model files, half-built relations) from the failed attempt (test-only, no runtime impact).
 
 ## dbt-databricks 1.12.1 (June 10, 2026)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 ]
 dependencies = [
     "click>=8.2.0, <9.0.0",
-    "databricks-sdk>=0.68.0, <0.105.0",
+    "databricks-sdk>=0.68.0, <0.118.0",
     "databricks-sql-connector[pyarrow]>=4.1.1, <4.2.7",
     "dbt-adapters>=1.22.0, <1.25.0",
     "dbt-common>=1.37.0, <1.38.0",

--- a/uv.lock
+++ b/uv.lock
@@ -479,16 +479,17 @@ wheels = [
 
 [[package]]
 name = "databricks-sdk"
-version = "0.104.0"
+version = "0.117.0"
 source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "google-auth" },
     { name = "protobuf" },
     { name = "requests" },
+    { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/71/ac/8e541337e36c4bb10811a57b505530d996c2c760391b08b275cc04858f62/databricks_sdk-0.104.0.tar.gz", hash = "sha256:527c35aac3a28665a7933f34b7dd0c1bd6e9450a487f2c02fcfb6dce72ca82c9", size = 910975, upload-time = "2026-04-23T07:53:09.117Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/95/86/fe149c523a9181deb3a90ae4e83708f54a6ee80c40ca392cf66ffdf425df/databricks_sdk-0.117.0.tar.gz", hash = "sha256:30a6fc21a8f9c4a41830c43332ae63b38c3679a83ac1bda4734ce7ced114faf1", size = 989404, upload-time = "2026-06-11T18:19:29.034Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ea/7b/5a82875dc4b92b60cdc233b153dda3a0d599e4fc169753c3e351850ebd5b/databricks_sdk-0.104.0-py3-none-any.whl", hash = "sha256:37d1b7b123c027ca4a2e6c783036f932956a354ca92d26076a4fcfab9a58caa7", size = 858519, upload-time = "2026-04-23T07:53:07.476Z" },
+    { url = "https://files.pythonhosted.org/packages/92/4d/3e28a5a1ae9aa42237bd0f4e6b34867b554c046a0f3e7c2ef49fa74800f6/databricks_sdk-0.117.0-py3-none-any.whl", hash = "sha256:bafd588c067ee353c905e56cd2eb37c7eca7a56a4c1b57656621b77208c32f86", size = 936854, upload-time = "2026-06-11T18:19:27.395Z" },
 ]
 
 [[package]]
@@ -637,7 +638,7 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "click", specifier = ">=8.2.0,<9.0.0" },
-    { name = "databricks-sdk", specifier = ">=0.68.0,<0.105.0" },
+    { name = "databricks-sdk", specifier = ">=0.68.0,<0.118.0" },
     { name = "databricks-sql-connector", extras = ["pyarrow"], specifier = ">=4.1.1,<4.2.7" },
     { name = "dbt-adapters", specifier = ">=1.22.0,<1.25.0" },
     { name = "dbt-common", specifier = ">=1.37.0,<1.38.0" },


### PR DESCRIPTION
## Summary

Raises the `databricks-sdk` upper bound to `<0.118.0` so installs pick up `databricks-sdk` 0.117.0, which fixes `WorkspaceClient` construction crashing with `CONTEXT_UNAVAILABLE_FOR_REMOTE_CLIENT` on Spark Connect (shared-access-mode) clusters. Closes #1252.

## What changed

- `pyproject.toml`: `databricks-sdk` ceiling `<0.105.0` → `<0.118.0`.
- `uv.lock`: refreshed — `databricks-sdk` 0.104.0 → 0.117.0 (and its new `urllib3` dependency).

## How is this tested?

- Unit suite: `1182 passed, 6 skipped` against `databricks-sdk` 0.117.0.
- Functional: a Python-model test on a UC cluster (`TestPythonModel`) passes against 0.117.0 — exercises the SDK job/command-submission path.Reproduced the fix directly: `WorkspaceClient` construction crashes on 0.104.0 and succeeds on 0.117.0.
