### PR TITLE
test: cover persist_docs comments on the V2 materialization path

### DIFF
--- a/tests/functional/adapter/persist_docs/test_persist_docs_v2.py
+++ b/tests/functional/adapter/persist_docs/test_persist_docs_v2.py
@@ -1,0 +1,34 @@
+import pytest
+
+from tests.functional.adapter.fixtures import MaterializationV2Mixin
+from tests.functional.adapter.persist_docs.test_persist_docs import (
+    TestPersistDocs as _TestPersistDocs,
+)
+
+
+class TestPersistDocsV2(_TestPersistDocs, MaterializationV2Mixin):
+    """V2 persist_docs on the table/view model create path.
+
+    TestPersistDocs covers V1; the only pre-existing V2 coverage is
+    TestPersistDocsWithSeedsV2 (the seed path). This class reuses the V1 models,
+    properties, and assertions, adding the use_materialization_v2 flag so comments
+    flow through relations/table/create.sql and relations/view/create.sql.
+
+    project_config_update is overridden (rather than relying on
+    MaterializationV2Mixin) because the V1 base already defines it; the override
+    merges the V1 persist_docs config with the V2 flag.
+    """
+
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {
+            "flags": {"use_materialization_v2": True},
+            "models": {
+                "test": {
+                    "+persist_docs": {
+                        "relation": True,
+                        "columns": True,
+                    },
+                }
+            },
+        }


### PR DESCRIPTION
## What

Adds `TestPersistDocsV2` to the `persist_docs` functional suite.

## Why

`TestPersistDocs` exercises `persist_docs` only on the V1 (default) materialization path, and the only pre-existing V2 coverage was `TestPersistDocsWithSeedsV2` — the **seed** path. The V2 table/view **model** create path (comments flowing through `relations/table/create.sql` and `relations/view/create.sql`) had no functional coverage.

## What it does

Reuses the existing V1 models, properties, and server-observable assertions (`DatabricksPersistDocsMixin`), flipping on `use_materialization_v2`. It asserts relation- and column-level comments on both the table and view models via `DESCRIBE EXTENDED`, plus the no-`persist_docs` negative case. `project_config_update` is overridden deliberately (rather than relying on the bare `MaterializationV2Mixin` idiom, which would drop the base's `persist_docs` config).

## Verification

- `TestPersistDocsV2::test_has_comments` passes on `databricks_uc_sql_endpoint`. 
- Pre-existing `persist_docs` tests unaffected; `ruff` / `ruff format` / `mypy` clean.

Test-only change — no changelog entry (consistent with #1511).