### PR TITLE
test: make constraints tests server-observable (add assertions, drop generated-SQL checks)

### DIFF
--- a/tests/functional/adapter/constraints/fixtures.py
+++ b/tests/functional/adapter/constraints/fixtures.py
@@ -1,31 +1,5 @@
 from dbt.tests.adapter.constraints import fixtures
 
-# constraints are enforced via 'alter' statements that run after table creation
-expected_sql = """
-create or replace table <model_identifier>
-    using delta
-    as
-select
-  id,
-  color,
-  date_day
-from
-( select
-    'blue' as color,
-    1 as id,
-    '2019-01-01' as date_day ) as model_subq
-"""
-
-expected_sql_v2 = """
-create or replace table <model_identifier> (
-  `color` string,
-  `id` integer not null comment 'hello',
-  `date_day` string,
-  PRIMARY KEY (id),
-  FOREIGN KEY (id) REFERENCES <foreign_key_model_identifier> (id)
-  ) using delta
-"""
-
 constraints_yml = fixtures.model_schema_yml.replace("text", "string").replace("primary key", "")
 
 model_fk_constraint_schema_yml = """

--- a/tests/functional/adapter/constraints/fixtures.py
+++ b/tests/functional/adapter/constraints/fixtures.py
@@ -318,3 +318,73 @@ models:
             to: ref('parent_table')
             to_columns: [id]
 """
+
+
+# Contract-enforced table child carrying PRIMARY KEY + FOREIGN KEY + NOT NULL, so all
+# three constraint kinds can be observed in information_schema after create. Reuses the
+# column_constraint_gate parent (a table with a PK to satisfy the FK reference).
+v1_contract_child_table_sql = """
+{{ config(materialized='table') }}
+select
+  cast(1 as int) as id,
+  cast('name' as string) as name,
+  cast(1 as int) as parent_id
+"""
+
+v1_contract_child_table_schema_yml = f"""
+version: 2
+models:
+{_column_constraint_gate_parent_model_yml}  - name: v1_contract_child
+    config:
+      materialized: table
+      contract:
+        enforced: true
+    constraints:
+      - type: primary_key
+        name: pk_v1_contract_child
+        columns: ["id"]
+      - type: foreign_key
+        name: fk_v1_contract_child_parent
+        columns: ["parent_id"]
+        to: ref('parent_table')
+        to_columns: ["id"]
+    columns:
+      - name: id
+        data_type: int
+        constraints:
+          - type: not_null
+      - name: name
+        data_type: string
+        constraints:
+          - type: not_null
+      - name: parent_id
+        data_type: int
+        constraints:
+          - type: not_null
+"""
+
+
+# Contract-enforced `type: custom` constraint, rendered verbatim as
+# `add constraint <name> <expression>` and observable as a delta.constraints.* property.
+custom_constraint_model_sql = """
+{{ config(materialized="table") }}
+select 1 as id, 'blue' as color
+"""
+
+custom_constraint_schema_yml = """
+version: 2
+models:
+  - name: custom_constraint_model
+    config:
+      contract:
+        enforced: true
+    constraints:
+      - type: custom
+        name: custom_id_positive
+        expression: "CHECK (id > 0)"
+    columns:
+      - name: id
+        data_type: int
+      - name: color
+        data_type: string
+"""

--- a/tests/functional/adapter/constraints/test_column_constraint_gate.py
+++ b/tests/functional/adapter/constraints/test_column_constraint_gate.py
@@ -2,7 +2,11 @@ import pytest
 from dbt.tests import util
 
 from tests.functional.adapter.constraints import fixtures
-from tests.functional.adapter.fixtures import MaterializationV2Mixin
+from tests.functional.adapter.fixtures import (
+    MaterializationV1Mixin,
+    MaterializationV2Mixin,
+    RerunSafeMixin,
+)
 
 
 def _constraint_rows(project, table_name, constraint_type):
@@ -128,3 +132,40 @@ class TestConstraintsApplyWithContractEnforced(MaterializationV2Mixin):
         assert len(fk_rows_after) == 1, (
             f"Expected FOREIGN KEY to survive the second run, found {fk_rows_after}"
         )
+
+
+@pytest.mark.skip_profile("databricks_cluster")
+class TestV1ContractConstraintsApplied(RerunSafeMixin, MaterializationV1Mixin):
+    @pytest.fixture(scope="class")
+    def relations_to_reset(self):
+        # child holds the FK to parent_table, so drop it first.
+        return ("v1_contract_child", "parent_table")
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "parent_table.sql": fixtures.column_constraint_gate_parent_sql,
+            "v1_contract_child.sql": fixtures.v1_contract_child_table_sql,
+            "schema.yml": fixtures.v1_contract_child_table_schema_yml,
+        }
+
+    def _assert_all_constraints_present(self, project):
+        pk_rows = _constraint_rows(project, "v1_contract_child", "PRIMARY KEY")
+        assert len(pk_rows) == 1, f"Expected one PRIMARY KEY, found {pk_rows}"
+        assert _pk_columns(project, "v1_contract_child") == ["id"]
+
+        fk_rows = _constraint_rows(project, "v1_contract_child", "FOREIGN KEY")
+        assert len(fk_rows) == 1, f"Expected one FOREIGN KEY, found {fk_rows}"
+
+        not_null_cols = set(_not_null_columns(project, "v1_contract_child"))
+        assert {"id", "name", "parent_id"}.issubset(not_null_cols), (
+            f"Expected id/name/parent_id NOT NULL, got {sorted(not_null_cols)}"
+        )
+
+    def test_v1_contract_constraints_in_information_schema(self, project):
+        util.run_dbt(["run"])
+        self._assert_all_constraints_present(project)
+
+        # V1 tables recreate on every run, so the constraints must be re-applied.
+        util.run_dbt(["run"])
+        self._assert_all_constraints_present(project)

--- a/tests/functional/adapter/constraints/test_constraints.py
+++ b/tests/functional/adapter/constraints/test_constraints.py
@@ -200,6 +200,45 @@ class TestIncrementalForeignKeyExpressionConstraint:
         util.run_dbt(["run", "--select", "stg_numbers"])
         util.run_dbt(["run", "--select", "stg_numbers"])
 
+        # Verify the expression-form foreign key is registered in information_schema.
+        referential_constraints = project.run_sql(
+            """
+            SELECT constraint_name
+            FROM {database}.information_schema.referential_constraints
+            WHERE constraint_schema = '{schema}'
+            """,
+            fetch="all",
+        )
+        assert any(row[0] == "fk_n" for row in referential_constraints), (
+            f"expected FK 'fk_n' from the expression-form constraint, got {referential_constraints}"
+        )
+
+
+@pytest.mark.skip_profile("databricks_cluster")
+class TestCustomConstraint:
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {"flags": {"use_materialization_v2": False}}
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "custom_constraint_model.sql": override_fixtures.custom_constraint_model_sql,
+            "schema.yml": override_fixtures.custom_constraint_schema_yml,
+        }
+
+    def test_custom_constraint_applied(self, project):
+        util.run_dbt(["run"])
+        rows = project.run_sql(
+            "show tblproperties {database}.{schema}.custom_constraint_model", fetch="all"
+        )
+        constraints = {
+            row.key: row.value for row in rows if row.key.startswith("delta.constraints.")
+        }
+        assert constraints.get("delta.constraints.custom_id_positive") == "id > 0", (
+            f"custom constraint not persisted as expected; delta.constraints = {constraints}"
+        )
+
 
 @pytest.mark.skip_profile("databricks_cluster")
 class TestForeignKeyParentConstraint:

--- a/tests/functional/adapter/constraints/test_constraints.py
+++ b/tests/functional/adapter/constraints/test_constraints.py
@@ -2,12 +2,9 @@ import pytest
 from dbt.tests import util
 from dbt.tests.adapter.constraints import fixtures
 from dbt.tests.adapter.constraints.test_constraints import (
-    BaseConstraintQuotedColumn,
     BaseConstraintsRollback,
-    BaseConstraintsRuntimeDdlEnforcement,
     BaseIncrementalConstraintsColumnsEqual,
     BaseIncrementalConstraintsRollback,
-    BaseIncrementalConstraintsRuntimeDdlEnforcement,
     BaseTableConstraintsColumnsEqual,
     BaseViewConstraintsColumnsEqual,
 )
@@ -82,41 +79,6 @@ class TestIncrementalConstraintsColumnsEqual(
         return {
             "my_model_wrong_order.sql": fixtures.my_model_incremental_wrong_order_sql,
             "my_model_wrong_name.sql": fixtures.my_model_incremental_wrong_name_sql,
-            "constraints_schema.yml": override_fixtures.constraints_yml,
-        }
-
-
-class BaseConstraintsDdlEnforcementSetup:
-    @pytest.fixture(scope="class")
-    def project_config_update(self):
-        return {"flags": {"use_materialization_v2": False}}
-
-    @pytest.fixture(scope="class")
-    def expected_sql(self):
-        return override_fixtures.expected_sql
-
-
-@pytest.mark.skip_profile("databricks_cluster")
-class TestTableConstraintsDdlEnforcement(
-    BaseConstraintsDdlEnforcementSetup, BaseConstraintsRuntimeDdlEnforcement
-):
-    @pytest.fixture(scope="class")
-    def models(self):
-        return {
-            "my_model.sql": fixtures.my_model_wrong_order_sql,
-            "constraints_schema.yml": override_fixtures.constraints_yml,
-        }
-
-
-@pytest.mark.skip_profile("databricks_cluster")
-class TestIncrementalConstraintsDdlEnforcement(
-    BaseConstraintsDdlEnforcementSetup,
-    BaseIncrementalConstraintsRuntimeDdlEnforcement,
-):
-    @pytest.fixture(scope="class")
-    def models(self):
-        return {
-            "my_model.sql": fixtures.my_model_incremental_wrong_order_sql,
             "constraints_schema.yml": override_fixtures.constraints_yml,
         }
 
@@ -256,36 +218,3 @@ class TestForeignKeyParentConstraint:
 
     def test_foreign_key_constraint(self, project):
         util.run_dbt(["build"])
-
-
-class TestConstraintQuotedColumn(BaseConstraintQuotedColumn):
-    @pytest.fixture(scope="class")
-    def project_config_update(self):
-        return {"flags": {"use_materialization_v2": False}}
-
-    @pytest.fixture(scope="class")
-    def models(self):
-        return {
-            "my_model.sql": fixtures.my_model_with_quoted_column_name_sql,
-            "constraints_schema.yml": fixtures.model_quoted_column_schema_yml.replace(
-                "text", "string"
-            ).replace('"from"', "`from`"),
-        }
-
-    @pytest.fixture(scope="class")
-    def expected_sql(self):
-        return """create or replace table <model_identifier>
-    using delta
-    as
-select
-  id,
-  `from`,
-  date_day
-from
-
-(
-    select
-    'blue' as `from`,
-    1 as id,
-    '2019-01-01' as date_day ) as model_subq
-"""

--- a/tests/functional/adapter/constraints/test_constraints_v2.py
+++ b/tests/functional/adapter/constraints/test_constraints_v2.py
@@ -1,10 +1,6 @@
 import pytest
 from dbt.tests import util
 from dbt.tests.adapter.constraints import fixtures
-from dbt.tests.adapter.constraints.test_constraints import (
-    _find_and_replace,
-    _normalize_whitespace,
-)
 
 from tests.functional.adapter.constraints import fixtures as override_fixtures
 from tests.functional.adapter.constraints.test_constraints import (
@@ -14,55 +10,12 @@ from tests.functional.adapter.constraints.test_constraints import (
     BaseViewConstraintsColumnsEqual,
     DatabricksConstraintsBase,
 )
-from tests.functional.adapter.fixtures import MaterializationV2Mixin
 
 
 class DatabricksConstraintsBaseV2(DatabricksConstraintsBase):
     @pytest.fixture(scope="class")
     def project_config_update(self):
         return {"flags": {"use_materialization_v2": True}}
-
-
-class BaseV2ConstraintSetup:
-    @pytest.fixture(scope="class")
-    def override_config(self):
-        return {}
-
-    @pytest.fixture(scope="class")
-    def project_config_update(self, override_config):
-        config = {"flags": {"use_materialization_v2": True}}
-        config.update(override_config)
-        return config
-
-    @pytest.fixture(scope="class")
-    def expected_sql(self):
-        return override_fixtures.expected_sql_v2
-
-    @pytest.fixture(scope="class")
-    def models(self):
-        return {
-            "my_model.sql": fixtures.my_model_wrong_order_depends_on_fk_sql,
-            "foreign_key_model.sql": fixtures.foreign_key_model_sql,
-            "constraints_schema.yml": fixtures.model_fk_constraint_schema_yml.replace(
-                "text", "string"
-            ).replace("- type: unique", ""),
-        }
-
-    def test__constraints_ddl(self, project, expected_sql):
-        results = util.run_dbt(["run", "-s", "+my_model"])
-        assert len(results) >= 1
-
-        # Read from the generated SQL files instead of parsing logs
-        generated_sql = util.read_file("target", "run", "test", "models", "my_model.sql")
-        generated_sql_generic = _find_and_replace(generated_sql, "my_model", "<model_identifier>")
-        generated_sql_generic = _find_and_replace(
-            generated_sql_generic, "foreign_key_model", "<foreign_key_model_identifier>"
-        )
-
-        normalized = _normalize_whitespace(generated_sql_generic)
-        assert _normalize_whitespace(expected_sql) in normalized
-        # V2 materialization includes constraints inline in CREATE TABLE,
-        # not as separate ALTER statements
 
 
 @pytest.mark.skip_profile("databricks_cluster")
@@ -99,63 +52,6 @@ class TestIncrementalConstraintsColumnsEqual(
             "my_model_wrong_order.sql": fixtures.my_model_incremental_wrong_order_sql,
             "my_model_wrong_name.sql": fixtures.my_model_incremental_wrong_name_sql,
             "constraints_schema.yml": override_fixtures.constraints_yml,
-        }
-
-
-class TestConstraintQuotedColumn(MaterializationV2Mixin):
-    @pytest.fixture(scope="class")
-    def models(self):
-        return {
-            "my_model.sql": fixtures.my_model_with_quoted_column_name_sql,
-            "constraints_schema.yml": fixtures.model_quoted_column_schema_yml.replace(
-                "text", "string"
-            ).replace('"from"', "`from`"),
-        }
-
-    @pytest.fixture(scope="class")
-    def expected_sql(self):
-        return """
-create or replace table <model_identifier> (
-    `from` string not null,
-    `id` integer not null comment 'hello',
-    `date_day` string
-)
-    using delta
-"""
-
-    def test__constraints_ddl(self, project, expected_sql):
-        results = util.run_dbt(["run", "-s", "+my_model"])
-        assert len(results) >= 1
-
-        # For materialization v2, read the generated SQL from file instead of logs
-        # This is more reliable than parsing logs which may not contain the DDL
-        generated_sql = util.read_file("target", "run", "test", "models", "my_model.sql")
-        generated_sql_generic = _find_and_replace(generated_sql, "my_model", "<model_identifier>")
-        generated_sql_generic = _find_and_replace(
-            generated_sql_generic, "foreign_key_model", "<foreign_key_model_identifier>"
-        )
-
-        # Check that the expected CREATE TABLE DDL is present
-        assert _normalize_whitespace(expected_sql) in _normalize_whitespace(generated_sql_generic)
-
-        # For v2, also verify that constraints are properly applied by running additional checks
-        # We can't always rely on ALTER TABLE statements being in the same file
-        # but we should verify that the table was created with the expected structure
-
-
-@pytest.mark.skip_profile("databricks_cluster")
-class TestTableConstraintsDdlEnforcement(BaseV2ConstraintSetup):
-    pass
-
-
-@pytest.mark.skip_profile("databricks_cluster")
-class TestIncrementalConstraintsDdlEnforcement(BaseV2ConstraintSetup):
-    @pytest.fixture(scope="class")
-    def models(self):
-        return {
-            "my_model.sql": fixtures.my_model_incremental_wrong_order_depends_on_fk_sql,
-            "foreign_key_model.sql": fixtures.foreign_key_model_sql,
-            "constraints_schema.yml": override_fixtures.model_fk_constraint_schema_yml,
         }
 
 

--- a/tests/functional/adapter/incremental/test_incremental_constraints.py
+++ b/tests/functional/adapter/incremental/test_incremental_constraints.py
@@ -88,8 +88,21 @@ class TestIncrementalUnsetNonNullConstraint(RerunSafeMixin):
 
         # Remove the non-null constraint
         util.write_file(fixtures.schema_without_non_null_constraint, "models", "schema.yml")
-        # This would fail if the constraint was not removed
         util.run_dbt(["run"])
+
+        # The column should now be nullable (DROP NOT NULL applied, not a no-op).
+        columns_after = project.run_sql(
+            """
+            SELECT column_name
+            FROM {database}.information_schema.columns
+            WHERE table_schema = '{schema}'
+            AND is_nullable = 'NO'
+            """,
+            fetch="all",
+        )
+        assert columns_after == [], (
+            f"Expected no NOT NULL columns after removal, found {columns_after}"
+        )
 
 
 @pytest.mark.skip_profile("databricks_cluster")
@@ -151,17 +164,28 @@ class TestIncrementalRemoveCheckConstraint(RerunSafeMixin):
             """,
             fetch="all",
         )
-        constraint = None
-        for row in tbl_properties:
-            if str(row[0]).startswith("delta.constraints."):
-                constraint = row
-                break
-        assert constraint is not None
+        constraints = [
+            row for row in tbl_properties if str(row[0]).startswith("delta.constraints.")
+        ]
+        assert constraints != []
 
         # Remove check constraint
         util.write_file(fixtures.schema_without_check_constraint, "models", "schema.yml")
-        # This would fail if the constraint was not removed
         util.run_dbt(["run"])
+
+        # The delta.constraints.* property should be gone (DROP applied, not a no-op).
+        tbl_properties_after = project.run_sql(
+            """
+            SHOW TBLPROPERTIES {database}.{schema}.check_constraint_sql
+            """,
+            fetch="all",
+        )
+        remaining = [
+            row for row in tbl_properties_after if str(row[0]).startswith("delta.constraints.")
+        ]
+        assert remaining == [], (
+            f"Expected delta.constraints.* to be gone after removal, found {remaining}"
+        )
 
 
 @pytest.mark.skip_profile("databricks_cluster")

--- a/tests/functional/adapter/persist_constraints/test_persist_constraints.py
+++ b/tests/functional/adapter/persist_constraints/test_persist_constraints.py
@@ -158,7 +158,7 @@ class TestInvalidCheckConstraints(TestConstraints):
 
 
 class TestInvalidColumnConstraints(TestConstraints):
-    def _test_invalid_column_constraints(self, project):
+    def test_invalid_column_constraints(self, project):
         model_name = "invalid_column_constraint"
         util.run_dbt(["seed"])
         self.run_and_check_failure(


### PR DESCRIPTION
Make the constraints functional tests assert **server-observable state** rather than generated-SQL text or run-succeeded.

## Adds server-observable assertions
- **V1 contract-enforced table create** asserts PRIMARY KEY + FOREIGN KEY + NOT NULL land in information_schema (`TestV1ContractConstraintsApplied`). The V1 path was previously only generated-SQL-tested.
- **type: custom** model constraint asserts delta.constraints.* via SHOW TBLPROPERTIES (`TestCustomConstraint`).
- **Expression-form foreign key** asserts the referential constraint is actually created (`TestIncrementalForeignKeyExpressionConstraint` was previously assertion-free).
- **Incremental NOT NULL / CHECK removal** assert the after-state (column nullable again / delta.constraints.* gone), not just that the rerun succeeds.
- Enabled the previously-uncollected `TestInvalidColumnConstraints` (the test method had a leading underscore, so pytest never ran it).

## Removes brittle generated-SQL checks
The `*DdlEnforcement` and quoted-column tests string-matched the generated CREATE TABLE / ALTER SQL (reading target/run/*.sql), which is brittle and outside the spirit of integration tests. Constraint SQL generation is already unit-pinned in tests/unit/macros/relations/test_constraint_macros.py, and the server effect is now covered above. Removed `TestTableConstraintsDdlEnforcement` / `TestIncrementalConstraintsDdlEnforcement` / `TestConstraintQuotedColumn` (V1 + V2), `BaseV2ConstraintSetup`, and the `expected_sql` / `expected_sql_v2` fixtures. Kept the ColumnsEqual (contract column matching) and rollback (server-observable enforcement) tests.

No product code changes; tests only.

## Test plan
All new/strengthened assertions verified live on databricks_uc_sql_endpoint; pre-commit (ruff / ruff-format / mypy) clean.