### PR TITLE
test: add incremental full-refresh recreate and strategy-validation functional tests

### DIFF
--- a/tests/functional/adapter/incremental/test_incremental_replace_table.py
+++ b/tests/functional/adapter/incremental/test_incremental_replace_table.py
@@ -25,3 +25,50 @@ class TestIncrementalReplaceTable(RerunSafeMixin):
         util.write_file(fixtures.replace_incremental, "models", "model.sql")
         util.run_dbt(["run", "--full-refresh"])
         util.check_relations_equal(project.adapter, ["model", "seed"])
+
+
+class FullRefreshRecreateBase(RerunSafeMixin):
+    """`--full-refresh` recreates an existing incremental relation from its create
+    branch. Append accumulates extra rows first, so the erased rows prove the recreate."""
+
+    @pytest.fixture(scope="class")
+    def relations_to_reset(self):
+        return ("full_refresh_recreate",)
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"full_refresh_recreate.sql": fixtures.base_model}
+
+    def test_full_refresh_recreates_existing_relation(self, project):
+        # Create {1: hello, 2: goodbye}.
+        util.run_dbt(["run"])
+        # Incremental (append) run accumulates {2: yo, 3: anyway}.
+        util.run_dbt(["run"])
+        accumulated = project.run_sql(
+            "select id, msg from full_refresh_recreate order by id, msg", fetch="all"
+        )
+        # Four rows incl. duplicate id=2 — there is real state for a recreate to erase.
+        assert accumulated == [(1, "hello"), (2, "goodbye"), (2, "yo"), (3, "anyway")]
+
+        # --full-refresh renders the non-incremental branch and recreates the table.
+        util.run_dbt(["run", "--full-refresh"])
+        recreated = project.run_sql(
+            "select id, msg from full_refresh_recreate order by id, msg", fetch="all"
+        )
+        # Only the create-branch rows remain; the accumulated rows are gone.
+        assert recreated == [(1, "hello"), (2, "goodbye")]
+
+
+class TestIncrementalFullRefreshRecreate(FullRefreshRecreateBase):
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {"models": {"+incremental_strategy": "append"}}
+
+
+class TestIncrementalFullRefreshRecreateV2(FullRefreshRecreateBase):
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {
+            "flags": {"use_materialization_v2": True},
+            "models": {"+incremental_strategy": "append"},
+        }

--- a/tests/functional/adapter/incremental/test_incremental_validation_errors.py
+++ b/tests/functional/adapter/incremental/test_incremental_validation_errors.py
@@ -1,0 +1,79 @@
+"""Incremental-strategy validation errors raised by validate.sql / strategies.sql.
+
+Each fires as a compiler error during the run; the proof is the asserted run failure.
+"""
+
+import pytest
+from dbt.tests import util
+
+from tests.functional.adapter.fixtures import RerunSafeMixin
+from tests.functional.adapter.incremental import fixtures
+
+
+class TestMergeOnNonDeltaFormatRaises:
+    """merge on a non-delta/hudi file_format -> dbt_databricks_validate_get_incremental_strategy
+    raises before any DDL (validate.sql, the merge branch)."""
+
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {
+            "models": {
+                "+incremental_strategy": "merge",
+                "+unique_key": "id",
+                "+file_format": "parquet",
+            }
+        }
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"merge_non_delta.sql": fixtures.base_model}
+
+    def test_merge_on_parquet_raises(self, project):
+        util.run_dbt(["run"], expect_pass=False)
+
+
+class TestDeleteInsertWithoutUniqueKeyRaises:
+    """delete+insert without unique_key -> validate.sql raises the missing-unique_key error
+    on the first run (file_format stays delta so only the unique_key branch fires)."""
+
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {"models": {"+incremental_strategy": "delete+insert"}}
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"delete_insert_no_key.sql": fixtures.base_model}
+
+    def test_delete_insert_without_unique_key_raises(self, project):
+        util.run_dbt(["run"], expect_pass=False)
+
+
+class TestMergeUpdateAndExcludeColumnsRaises(RerunSafeMixin):
+    """merge with BOTH merge_update_columns and merge_exclude_columns ->
+    databricks__get_merge_update_columns (strategies.sql) raises. The raise lives on
+    the merge build path, so it fires on the second (incremental) run."""
+
+    @pytest.fixture(scope="class")
+    def relations_to_reset(self):
+        return ("merge_update_exclude",)
+
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {
+            "models": {
+                "+incremental_strategy": "merge",
+                "+unique_key": "id",
+                "+merge_update_columns": ["msg"],
+                "+merge_exclude_columns": ["msg"],
+            }
+        }
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"merge_update_exclude.sql": fixtures.base_model}
+
+    def test_both_merge_column_configs_raise(self, project):
+        # First run creates the relation (no merge yet) and must succeed.
+        util.run_dbt(["run"])
+        # Second run takes the merge path and the mutual-exclusion guard fires.
+        util.run_dbt(["run"], expect_pass=False)


### PR DESCRIPTION
Adds functional coverage for two incremental-materialization behaviors on the `databricks_uc_sql_endpoint` profile.

1. **`--full-refresh` recreate of an existing incremental relation** (appended to `test_incremental_replace_table.py`, V1 + V2). The existing full-refresh-over-existing test is `skip_profile`'d off the SQL-warehouse profile and has no V2 variant. The new tests use the append strategy so the second run accumulates rows the create branch never emits; `--full-refresh` erases them, proving the relation is recreated (server-observable via the resulting row set).
2. **Incremental-strategy validation errors** (new `test_incremental_validation_errors.py`): merge on a non-delta `file_format`, `delete+insert` without `unique_key`, and `merge_update_columns` + `merge_exclude_columns` together — each asserts the run fails. These validation paths had no functional or unit coverage.

All 5 tests pass on `databricks_uc_sql_endpoint`; no existing test was changed (the only edit to a pre-existing file is an additive append).
