### PR TITLE
test: assert streaming table partitioning survives non-full-refresh alter

### DIFF
--- a/tests/functional/adapter/streaming_tables/test_st_changes.py
+++ b/tests/functional/adapter/streaming_tables/test_st_changes.py
@@ -143,6 +143,11 @@ class TestStreamingTableChangesApply(StreamingTableChanges):
 
         self.check_state_alter_change_is_applied(project, my_streaming_table)
 
+        # An alter-only change must leave the existing partitioning intact.
+        with util.get_connection(project.adapter):
+            results = project.adapter.get_relation_config(my_streaming_table)
+        assert results.config["partition_by"].partition_by == ["id"]
+
         util.assert_message_in_logs(f"Applying ALTER to: {my_streaming_table}", logs)
         util.assert_message_in_logs(f"Applying REPLACE to: {my_streaming_table}", logs, False)
 


### PR DESCRIPTION
## Summary

Streaming-table config changes that don't touch `partition_by` take the **alter** path, which issues `CREATE OR REFRESH STREAMING TABLE ... PARTITIONED BY (...)` rather than a full replace. There was no functional assertion that the existing partitioning actually survives that path: `check_state_alter_change_is_applied` verifies the refresh schedule, comment, and tblproperties, but never re-reads `partition_by`.

This adds a server-observable assertion to `TestStreamingTableChangesApply::test_change_is_applied_via_alter`: after a metadata-only alter, it re-reads the relation config and asserts `partition_by == ["id"]`. 

## Testing

- `TestStreamingTableChangesApply::test_change_is_applied_via_alter` — passed
- `TestStreamingTableChangesApply::test_change_is_applied_via_replace` (regression; shares the helper) — passed
- `pre-commit run` (ruff / ruff format / mypy) — passed
