### PR TITLE
test: assert databricks_tags applied at create on metric views

### DIFF
--- a/tests/functional/adapter/metric_views/test_metric_view_materialization.py
+++ b/tests/functional/adapter/metric_views/test_metric_view_materialization.py
@@ -176,7 +176,7 @@ class TestMetricViewConfiguration:
         }
 
     def test_metric_view_with_tags(self, project):
-        """Test that metric view works with databricks_tags using ALTER VIEW"""
+        """databricks_tags configured on a metric view are applied at create time."""
         # Run dbt to create the models
         results = run_dbt(["run"])
         assert len(results) == 2
@@ -204,7 +204,6 @@ class TestMetricViewConfiguration:
             fetch="all",
         )
 
-        # Should have results showing tags were applied without error
         assert query_result is not None
         assert len(query_result) == 2  # completed and pending statuses
 
@@ -212,6 +211,21 @@ class TestMetricViewConfiguration:
         status_data = {row[0]: row[1] for row in query_result}
         assert status_data["completed"] == 2
         assert status_data["pending"] == 1
+
+        # The configured tags land on the view at create time, not just on update
+        tag_rows = project.run_sql(
+            f"""
+            SELECT tag_name, tag_value
+            FROM {project.database}.information_schema.table_tags
+            WHERE schema_name = '{project.test_schema}'
+              AND table_name = 'config_metrics'
+            ORDER BY tag_name
+            """,
+            fetch="all",
+        )
+        tags = {row[0]: row[1] for row in tag_rows}
+        assert tags.get("team") == "analytics"
+        assert tags.get("environment") == "test"
 
 
 @pytest.mark.skip_profile("databricks_cluster")


### PR DESCRIPTION
## Description

Strengthens the metric-view materialization test so it verifies, server-side, that `databricks_tags` configured on a `metric_view` model are applied **at create time**.

The existing `test_metric_view_with_tags` set `databricks_tags` but asserted only that the `MEASURE()` query ran, so create-time tag application was never verified — the other metric-view tests assert only the *post-update* tags. The test now queries `information_schema.table_tags` after the first build and asserts the configured `team`/`environment` tags are present.

Test-only; no runtime change.

## How verified

`hatch run pytest tests/functional/adapter/metric_views/test_metric_view_materialization.py::TestMetricViewConfiguration::test_metric_view_with_tags` → passed on `databricks_uc_sql_endpoint`.
