### PR TITLE
fix: apply tblproperties to metric_view models at create time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Add catalogs.yml v2 support (requires `use_catalogs_v2: true` in dbt-core) ([1440](https://github.com/databricks/dbt-databricks/pull/1440))
 
 ### Fixes
+- Apply `tblproperties` to `metric_view` models at create time, not only on a later alter/replace run ([#1530](https://github.com/databricks/dbt-databricks/pull/1530) closes [#1527](https://github.com/databricks/dbt-databricks/issues/1527))
 - Raise a `DbtRuntimeError` when a Python model job run terminates with a non-success `result_state` (e.g. `FAILED`/`TIMEDOUT`) instead of returning silently ([#1477](https://github.com/databricks/dbt-databricks/pull/1477))
 
 ### Under the Hood

--- a/dbt/include/databricks/macros/materializations/metric_view.sql
+++ b/dbt/include/databricks/macros/materializations/metric_view.sql
@@ -31,6 +31,10 @@
       {{ get_create_metric_view_as_sql(target_relation, sql) }}
     {%- endcall %}
     {{ apply_tags(target_relation, tags) }}
+    {% set tblproperties = config.get('tblproperties') %}
+    {% if tblproperties %}
+      {{ apply_tblproperties(target_relation, tblproperties) }}
+    {% endif %}
   {% endif %}
 
   {% do apply_grants(target_relation, grant_config, should_revoke=should_revoke(existing_relation, full_refresh_mode=True)) %}

--- a/tests/functional/adapter/metric_views/fixtures.py
+++ b/tests/functional/adapter/metric_views/fixtures.py
@@ -76,3 +76,23 @@ measures:
   - name: order_count
     expr: count(1)
 """
+
+metric_view_with_tblproperties = """
+{{
+  config(
+    materialized='metric_view',
+    tblproperties={
+      'quality': 'gold'
+    }
+  )
+}}
+
+version: 1.1
+source: "{{ ref('source_orders') }}"
+dimensions:
+  - name: status
+    expr: status
+measures:
+  - name: order_count
+    expr: count(1)
+"""

--- a/tests/functional/adapter/metric_views/test_metric_view_materialization.py
+++ b/tests/functional/adapter/metric_views/test_metric_view_materialization.py
@@ -6,6 +6,7 @@ from tests.functional.adapter.metric_views.fixtures import (
     metric_view_bare_ref,
     metric_view_with_config,
     metric_view_with_filter,
+    metric_view_with_tblproperties,
     source_table,
 )
 
@@ -240,3 +241,27 @@ class TestMetricViewBareRef:
             fetch="all",
         )
         assert query_result and query_result[0][0] == 3
+
+
+@pytest.mark.skip_profile("databricks_cluster")
+class TestMetricViewCreateTblProperties:
+    """tblproperties configured on a metric view are set on the freshly created view."""
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "source_orders.sql": source_table,
+            "tblprops_metrics.sql": metric_view_with_tblproperties,
+        }
+
+    def test_tblproperties_applied_on_create(self, project):
+        results = run_dbt(["run"])
+        assert len(results) == 2
+        assert all(result.status == "success" for result in results)
+
+        rows = project.run_sql(
+            f"show tblproperties {project.database}.{project.test_schema}.tblprops_metrics",
+            fetch="all",
+        )
+        tblprops = {row[0]: row[1] for row in rows}
+        assert tblprops.get("quality") == "gold"


### PR DESCRIPTION
## Description

`tblproperties` configured on a `metric_view` model were not applied on the **first** build — `dbt run` reported success but the configured properties were absent from the created view; they only appeared on a later alter/replace run. The create branch of the metric_view materialization applied `databricks_tags` but not `tblproperties`.

This applies `tblproperties` on the create branch, mirroring the existing `replace_with_metric_view` path (`{% if tblproperties %}{{ apply_tblproperties(...) }}{% endif %}`).

Closes #1527

## Testing

- Full `tests/functional/adapter/metric_views/test_metric_view_materialization.py` → **7 passed** (no regression), on `databricks_uc_sql_endpoint`. 
- `ruff` / `ruff format` / `mypy` clean.
