### PR TITLE
test: cover query-component change handling for streaming tables and materialized views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Under the Hood
 
+- Add functional tests for the `query` relation-config component's change handling: a streaming table's defining-query change is applied in place via `CREATE OR REFRESH`, and re-running a materialized view with an unchanged query leaves the existing relation in place instead of rebuilding it (test-only, no runtime impact).
 - Add a functional test for incremental column-mask removal: dropping a `column_mask` from a model with an existing incremental relation issues `ALTER COLUMN ... DROP MASK` and leaves the column unmasked (test-only, no runtime impact). ([#1514](https://github.com/databricks/dbt-databricks/pull/1514))
 - Raise the `dbt-adapters` upper bound to `<1.25.0` ([#1507](https://github.com/databricks/dbt-databricks/pull/1507))
 - Make the remaining incremental functional tests (tags, column tags, tblproperties, liquid clustering, column masks, persist_docs, replace table) rerun-safe so a `pytest --reruns` retry no longer inherits mutated state (rewritten `schema.yml`/model files, half-built relations) from the failed attempt (test-only, no runtime impact).

--- a/tests/functional/adapter/materialized_view_tests/test_basic.py
+++ b/tests/functional/adapter/materialized_view_tests/test_basic.py
@@ -138,6 +138,29 @@ class TestMaterializedViews(TestMaterializedViewsMixin, MaterializedViewBasic):
         )
         assert results[0][1] == expected_struct_type
 
+    def test_unchanged_query_does_not_recreate(self, project, my_materialized_view):
+        # A false-positive query diff would force a full refresh, rebuilding the MV and moving its
+        # creation timestamp. Re-running with an unchanged query must leave the timestamp stable.
+        def created_time():
+            return project.run_sql(
+                f"""
+                SELECT created
+                FROM {project.database}.information_schema.tables
+                WHERE table_catalog = '{project.database}'
+                  AND table_schema = '{project.test_schema}'
+                  AND table_name = '{my_materialized_view.identifier}'""",
+                fetch="one",
+            )[0]
+
+        assert self.query_relation_type(project, my_materialized_view) == "materialized_view"
+        created_before = created_time()
+        assert created_before is not None
+
+        util.run_dbt(["run", "--models", my_materialized_view.identifier])
+
+        assert self.query_relation_type(project, my_materialized_view) == "materialized_view"
+        assert created_time() == created_before
+
 
 @pytest.mark.dlt
 @pytest.mark.skip_profile("databricks_cluster", "databricks_uc_cluster")

--- a/tests/functional/adapter/streaming_tables/test_st_changes.py
+++ b/tests/functional/adapter/streaming_tables/test_st_changes.py
@@ -158,6 +158,28 @@ class TestStreamingTableChangesApply(StreamingTableChanges):
 
         util.assert_message_in_logs(f"Applying REPLACE to: {my_streaming_table}", logs)
 
+    def test_query_change_is_applied(self, project, my_streaming_table):
+        self.check_start_state(project, my_streaming_table)
+
+        # A filter changes the defining query while keeping the output schema, so the new
+        # definition is applied in place rather than triggering a full rebuild.
+        initial_model = util.get_model_file(project, my_streaming_table)
+        new_model = initial_model.replace(
+            "select * from stream {{ ref('my_seed') }}",
+            "select * from stream {{ ref('my_seed') }} where id > 1",
+        )
+        assert new_model != initial_model
+        util.set_model_file(project, my_streaming_table, new_model)
+
+        util.run_dbt(["run", "--models", my_streaming_table.name])
+
+        with util.get_connection(project.adapter):
+            results = project.adapter.get_relation_config(my_streaming_table)
+        assert isinstance(results, StreamingTableConfig)
+        assert "where" in results.config["query"].query.lower()
+        # the in-place update must not drop the rest of the config
+        assert results.config["partition_by"].partition_by == ["id"]
+
 
 @pytest.mark.dlt
 @pytest.mark.skip_profile("databricks_cluster", "databricks_uc_cluster")


### PR DESCRIPTION
### Description

Adds functional coverage for the `query` relation_config component (`relation_configs/query.py` + `relations/components/query.sql`), which detects and applies changes to the SQL that defines a relation. Two change-handling paths were previously unexercised by `tests/functional/`:

- **Streaming table — defining-query change.** No existing test mutated a streaming table's `AS <select>`. `TestStreamingTableChangesApply::test_query_change_is_applied` adds a `WHERE` filter to the model query and asserts the change is reflected in the server-side relation config (`get_relation_config().config["query"]`), with partitioning preserved — i.e. the new definition is applied in place via `CREATE OR REFRESH` rather than a full rebuild.
- **Materialized view — unchanged-query no-op.** The existing idempotency test only re-checked the relation type, not that the MV avoided a rebuild. `TestMaterializedViews::test_unchanged_query_does_not_recreate` asserts the MV's `information_schema.tables.created` timestamp is non-null and stable across a second run with an unchanged query (a false-positive query diff would force `requires_full_refresh` and move the timestamp).

Both are new methods on existing test classes (no new files or fixtures), reuse the surrounding conventions (`get_model_file`/`set_model_file`, `get_relation_config`, `information_schema` assertions), and are rerun-safe.

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
