### PR TITLE
test: assert streaming table create applies configured clustering columns

### DIFF
--- a/tests/functional/adapter/streaming_tables/test_st_basic.py
+++ b/tests/functional/adapter/streaming_tables/test_st_basic.py
@@ -266,10 +266,7 @@ class TestStreamingTablesBasic(TestStreamingTablesMixin):
 @pytest.mark.dlt
 @pytest.mark.skip_profile("databricks_cluster", "databricks_uc_cluster")
 class TestStreamingTableLiquidClustering:
-    """
-    Test liquid clustering support for streaming tables.
-    Note: These are smoke tests that verify models can be created with liquid_clustered_by config.
-    """
+    """Liquid clustering on streaming tables created with a liquid_clustered_by config."""
 
     @pytest.fixture(scope="class")
     def seeds(self):
@@ -283,23 +280,24 @@ class TestStreamingTableLiquidClustering:
         }
 
     def test_create_with_liquid_clustering_config(self, project):
-        """Test STs can be created with liquid clustering config without errors."""
+        """A liquid_clustered_by config applies the configured clustering columns on create."""
         # Run seed to create test data (project fixture doesn't run seeds automatically)
         util.run_dbt(["seed"])
 
         util.run_dbt(["run", "--models", "liquid_clustered_st"])
 
-        # Verify the ST was created successfully by checking the relation type
-        relation_type = fixtures.query_relation_type(
-            project,
-            project.adapter.Relation.create(
-                identifier="liquid_clustered_st",
-                schema=project.test_schema,
-                database=project.database,
-                type=DatabricksRelationType.StreamingTable,
-            ),
+        relation = project.adapter.Relation.create(
+            identifier="liquid_clustered_st",
+            schema=project.test_schema,
+            database=project.database,
+            type=DatabricksRelationType.StreamingTable,
         )
-        assert relation_type == "streaming_table"
+        assert fixtures.query_relation_type(project, relation) == "streaming_table"
+
+        with util.get_connection(project.adapter):
+            config = project.adapter.get_relation_config(relation)
+        assert isinstance(config, StreamingTableConfig)
+        assert config.config["liquid_clustering"].cluster_by == ["id"]
 
 
 @pytest.mark.dlt


### PR DESCRIPTION
### Description

`TestStreamingTableLiquidClustering.test_create_with_liquid_clustering_config` was a smoke test: it created a streaming table with `liquid_clustered_by: id` but asserted only that the relation came back as a `streaming_table`, never that the clustering column was actually applied.

This strengthens it to assert the server-observable effect — after the run, `get_relation_config` reports `config["liquid_clustering"].cluster_by == ["id"]` (read from `clusteringColumns` in `SHOW TBLPROPERTIES`), mirroring the existing sibling test `TestStreamingTableLiquidClusteringChanges.test_liquid_clustering_change_is_applied`. The relation lookup is flattened to a local and the now-stale "smoke tests" docstring updated.

Test-only; no adapter/runtime changes.

Verified live on `databricks_uc_sql_endpoint`: `1 passed in ~95s`; the `streaming_tables/` section collects clean (26 tests); ruff / ruff-format / mypy pass.

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] Test-only change with no runtime impact; no `CHANGELOG.md` entry required.