### PR TITLE
ci: weekly workflow to purge accumulated Python-model notebook folders

### DIFF
--- a/.github/workflows/cleanup-python-model-dirs.yml
+++ b/.github/workflows/cleanup-python-model-dirs.yml
@@ -1,0 +1,101 @@
+# Weekly purge of the test service principal's accumulated dbt Python-model
+# notebooks.
+#
+# dbt uploads each Python model as a workspace notebook under
+# /Users/<sp>/dbt_python_models/<catalog>/<schema>/ and never deletes it. The
+# integration suites mint a unique schema per run, so the catalog folders accrue
+# one child per run until they hit Databricks' 10,000-child folder cap — at which
+# point workspace.mkdirs fails with "Size limit exceeded" and every Python-model
+# test errors. A weekly sweep is plenty: the folder takes months to approach the
+# cap, so a week's accumulation stays far under it. Deleting the whole tree also
+# covers integration.yml AND integration-min-deps.yml, which share this SP folder.
+#
+# Runs Saturday 10:00 UTC (a quiet weekend slot) — but the calendar slot is NOT
+# the safety mechanism: /integration-test PR comments dispatch the integration
+# workflows on demand at any hour. The load-bearing guard is the step right before
+# the delete: it asks the Actions API whether any integration run is active
+# (in_progress OR still queued/waiting for a runner) and skips the purge if so. It
+# fails CLOSED — an active run or an unreadable API skips the delete. A skipped
+# week is harmless; the next run purges.
+name: Cleanup Python Model Dirs
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 10 * * 6"   # Saturday 10:00 UTC
+
+permissions:
+  contents: read
+  actions: read
+
+jobs:
+  cleanup:
+    runs-on:
+      group: databricks-protected-runner-group
+      labels: linux-ubuntu-latest
+    environment: azure-prod
+    env:
+      DBT_DATABRICKS_HOST_NAME: ${{ secrets.DATABRICKS_HOST }}
+      DBT_DATABRICKS_CLIENT_ID: ${{ secrets.TEST_PECO_SP_ID }}
+      DBT_DATABRICKS_CLIENT_SECRET: ${{ secrets.TEST_PECO_SP_SECRET }}
+      UV_FROZEN: "1"
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+      - name: Setup Python Dependencies
+        id: deps
+        uses: ./.github/actions/setup-python-deps
+
+      - name: Setup JFrog PyPI Proxy (fallback)
+        if: steps.deps.outputs.cache-hit != 'true'
+        uses: ./.github/actions/setup-jfrog-pypi
+
+      - name: Set up python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
+        with:
+          python-version: "3.10"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a  # v4
+        with:
+          version: "0.11.18"
+          cache-local-path: ~/.cache/uv
+
+      - name: Install Hatch
+        uses: pypa/hatch@257e27e51a6a5616ed08a39a408a21c35c9931bc  # install
+        with:
+          version: "1.17.0"
+
+      # Guard immediately before the delete so the check->delete gap is a single
+      # workspace.delete call. Fail CLOSED: an active run or an unreadable API
+      # leaves proceed=false and the purge is skipped.
+      - name: Skip the purge if an integration run is active
+        id: guard
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -uo pipefail
+          active=0
+          for wf in integration.yml integration-min-deps.yml integration-spog.yml; do
+            # Count non-terminal runs (in_progress AND queued/waiting for a runner);
+            # status=in_progress alone misses a queued run about to upload notebooks.
+            n=$(curl -fsS \
+              -H "Authorization: Bearer $GH_TOKEN" \
+              -H "Accept: application/vnd.github+json" \
+              "https://api.github.com/repos/$GITHUB_REPOSITORY/actions/workflows/$wf/runs?per_page=100" \
+              | jq '[.workflow_runs[] | select(.status != "completed")] | length') \
+              || { echo "::warning::Could not read run status for $wf; treating as active."; n=1; }
+            echo "$wf: $n active run(s)"
+            active=$((active + n))
+          done
+          if [ "$active" -gt 0 ]; then
+            echo "::notice::$active integration run(s) active; skipping purge (next run purges)."
+            echo "proceed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "proceed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Purge accumulated Python-model notebook folders
+        if: steps.guard.outputs.proceed == 'true'
+        run: hatch run python scripts/cleanup_python_model_dirs.py

--- a/scripts/cleanup_python_model_dirs.py
+++ b/scripts/cleanup_python_model_dirs.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Delete the test service principal's accumulated dbt Python-model notebooks.
+
+dbt writes a notebook per Python model under `/Users/{user}/dbt_python_models/`
+and never deletes it, so per-run test schemas accrete until the folder hits
+Databricks' 10,000-child cap and `mkdirs` fails. Deletes the whole tree for the
+run's principal (dbt recreates what it needs); auth reuses the adapter's
+`DatabricksCredentialManager` via the `DBT_DATABRICKS_*` env vars.
+
+Best-effort: always exits 0 (real failures print a `::error::` annotation) so it
+never blocks CI. `--dry-run` lists what would be deleted.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+from databricks.sdk import WorkspaceClient
+from databricks.sdk.errors import ResourceDoesNotExist
+
+from dbt.adapters.databricks.credentials import DatabricksCredentialManager
+
+SUBDIR = "dbt_python_models"
+
+
+def normalize_host(host: str) -> str:
+    """Accept either a bare hostname or a full URL; return a full https URL."""
+    return host if host.startswith("http") else f"https://{host}"
+
+
+def python_models_root(user_name: str) -> str:
+    return f"/Users/{user_name}/{SUBDIR}"
+
+
+def build_client() -> WorkspaceClient:
+    """WorkspaceClient authenticated exactly as the adapter authenticates."""
+    return DatabricksCredentialManager(
+        host=normalize_host(os.environ["DBT_DATABRICKS_HOST_NAME"]),
+        client_id=os.environ["DBT_DATABRICKS_CLIENT_ID"],
+        client_secret=os.environ["DBT_DATABRICKS_CLIENT_SECRET"],
+    ).api_client
+
+
+def purge(client: WorkspaceClient, dry_run: bool = False) -> None:
+    """Delete the Python-model notebook tree for the authenticated principal."""
+    user_name = client.current_user.me().user_name
+    folder = python_models_root(user_name)
+
+    if dry_run:
+        try:
+            children = list(client.workspace.list(folder))
+            # Top-level only (the per-catalog dirs), not a recursive notebook count.
+            print(f"[dry-run] would delete {folder} ({len(children)} top-level entries)")
+        except ResourceDoesNotExist:
+            print(f"[dry-run] {folder} does not exist — nothing to delete")
+        return
+
+    print(f"Purging Python-model notebook folder: {folder}")
+    try:
+        client.workspace.delete(folder, recursive=True)
+        print(f"Deleted {folder}")
+    except ResourceDoesNotExist:
+        print(f"{folder} does not exist — nothing to clean")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="List the folder and report what would be deleted, without deleting.",
+    )
+    args = parser.parse_args()
+
+    try:
+        purge(build_client(), dry_run=args.dry_run)
+    except Exception as e:  # noqa: BLE001 — best-effort; never block the suite
+        print(f"::error::Python-model folder cleanup failed (non-fatal): {e}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/test_cleanup_python_model_dirs.py
+++ b/tests/unit/test_cleanup_python_model_dirs.py
@@ -1,0 +1,90 @@
+"""Unit tests for scripts/cleanup_python_model_dirs.py.
+
+The script lives in scripts/ (not the importable package), so load it by path.
+"""
+
+import importlib.util
+from pathlib import Path
+from unittest.mock import Mock
+
+from databricks.sdk.errors import ResourceDoesNotExist
+
+_SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "cleanup_python_model_dirs.py"
+_spec = importlib.util.spec_from_file_location("cleanup_python_model_dirs", _SCRIPT)
+assert _spec is not None and _spec.loader is not None
+cleanup = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(cleanup)
+
+
+class TestNormalizeHost:
+    def test_bare_hostname_gets_https(self):
+        assert cleanup.normalize_host("adb-123.4.azuredatabricks.net") == (
+            "https://adb-123.4.azuredatabricks.net"
+        )
+
+    def test_full_url_unchanged(self):
+        assert cleanup.normalize_host("https://adb-123.4.azuredatabricks.net") == (
+            "https://adb-123.4.azuredatabricks.net"
+        )
+
+
+class TestPythonModelsRoot:
+    def test_builds_user_scoped_path(self):
+        # Mirrors UserFolderApi.get_folder's /Users/{user}/dbt_python_models prefix.
+        assert (
+            cleanup.python_models_root("c2108ab0-1c66-4fa0-ae95-3baa5e160017")
+            == "/Users/c2108ab0-1c66-4fa0-ae95-3baa5e160017/dbt_python_models"
+        )
+
+
+def _client(user_name="sp@example.com"):
+    client = Mock()
+    client.current_user.me.return_value.user_name = user_name
+    return client
+
+
+class TestPurge:
+    def test_deletes_whole_tree_recursively(self):
+        client = _client("me@example.com")
+        cleanup.purge(client)
+        client.workspace.delete.assert_called_once_with(
+            "/Users/me@example.com/dbt_python_models", recursive=True
+        )
+
+    def test_missing_folder_is_a_noop(self):
+        client = _client()
+        client.workspace.delete.side_effect = ResourceDoesNotExist("not found")
+        # Must not raise — a not-yet-created folder is expected on first run.
+        cleanup.purge(client)
+
+    def test_dry_run_lists_and_does_not_delete(self):
+        client = _client()
+        client.workspace.list.return_value = [Mock(), Mock(), Mock()]
+        cleanup.purge(client, dry_run=True)
+        client.workspace.list.assert_called_once_with(
+            f"/Users/{client.current_user.me.return_value.user_name}/dbt_python_models"
+        )
+        client.workspace.delete.assert_not_called()
+
+    def test_dry_run_missing_folder_is_a_noop(self):
+        client = _client()
+        client.workspace.list.side_effect = ResourceDoesNotExist("not found")
+        # Must not raise — folder may not exist yet on a first run.
+        cleanup.purge(client, dry_run=True)
+        client.workspace.delete.assert_not_called()
+
+
+class TestMain:
+    def test_returns_zero_and_annotates_on_failure(self, monkeypatch, capsys):
+        # Best-effort contract: any failure is surfaced loudly but never blocks.
+        monkeypatch.setattr(cleanup, "build_client", Mock(side_effect=RuntimeError("auth boom")))
+        monkeypatch.setattr("sys.argv", ["cleanup_python_model_dirs.py"])
+        assert cleanup.main() == 0
+        out = capsys.readouterr().out
+        assert "::error::" in out
+        assert "auth boom" in out
+
+    def test_returns_zero_on_success(self, monkeypatch):
+        monkeypatch.setattr(cleanup, "build_client", Mock(return_value=_client()))
+        monkeypatch.setattr("sys.argv", ["cleanup_python_model_dirs.py"])
+        assert cleanup.main() == 0


### PR DESCRIPTION
## Problem

The nightly `Integration Tests` started failing with **every Python-model test erroring** across all UC-cluster and SQL-warehouse shards (e.g. run [27723123256](https://github.com/databricks/dbt-databricks/actions/runs/27723123256)); non-Python tests were unaffected.

Root cause: dbt uploads each Python model as a workspace notebook under `/Users/<sp>/dbt_python_models/<catalog>/<schema>/` and never deletes it. Each functional-test run mints a unique timestamped schema, so the catalog folders accrue one child per run. Databricks caps a workspace folder at **10,000 children**; once the `peco` catalog folder crossed it, `workspace.mkdirs` began failing with `Size limit exceeded`. This is CI hygiene — only CI's unique-per-run schemas accumulate (real users reuse a bounded set).

## Fix

A **standalone weekly workflow** (`cleanup-python-model-dirs.yml`, Saturday 10:00 UTC + manual dispatch) that deletes the test service principal's whole `dbt_python_models` tree. dbt recreates what it needs, so the folder stays small.

- **One sweep covers both** `integration.yml` and `integration-min-deps.yml` — they share the SP folder.
- **Weekly is plenty**: the folder takes months to approach the cap, so a week's accumulation is far under it (even a multi-week outage of this job stays safe).
- **Decoupled**: the integration workflows are untouched — no per-run cleanup overhead, no markers, no cross-workflow coordination.

### Not clobbering in-flight runs

`/integration-test` can dispatch the integration workflows at any hour, so the quiet weekend slot isn't the safety mechanism. Right before the delete, a guard step queries the Actions API for any **active** integration run (`in_progress` *or* still `queued`/waiting for a runner) across `integration.yml` / `integration-min-deps.yml` / `integration-spog.yml` and **skips the purge** if any is found. It **fails closed** (unreadable API or active run ⇒ no delete) and runs immediately before the delete to minimise the check→delete window. A skipped week is harmless — the next run purges.

## Testing

- `scripts/cleanup_python_model_dirs.py` deletes the tree (auth via the adapter's `DatabricksCredentialManager`), best-effort (always exits 0), with `--dry-run`.
- Unit tests in `tests/unit/test_cleanup_python_model_dirs.py` (9).
- Validated the script live against the test workspace (dry-run); guard jq logic sanity-checked; pre-commit (ruff/format/mypy) clean.

> The already-saturated `peco` folder was cleared manually to unblock the nightly; this workflow prevents recurrence.
