### PR TITLE
test: add snapshot tag coverage and tighten streaming-table tag assertion

### DIFF
--- a/tests/functional/adapter/tags/fixtures.py
+++ b/tests/functional/adapter/tags/fixtures.py
@@ -65,3 +65,19 @@ models:
         c: d
         k: ""
 """
+
+snapshot_tags_sql = """
+{% snapshot tags_snapshot %}
+    {{
+        config(
+            target_database=database,
+            target_schema=schema,
+            unique_key='id',
+            strategy='check',
+            check_cols=['color'],
+            databricks_tags={'a': 'b', 'c': 'd', 'k': ''},
+        )
+    }}
+    select cast(1 as bigint) as id, 'hello' as msg, 'blue' as color
+{% endsnapshot %}
+"""

--- a/tests/functional/adapter/tags/test_databricks_tags.py
+++ b/tests/functional/adapter/tags/test_databricks_tags.py
@@ -114,6 +114,26 @@ class TestIncrementalTagsUpdateViaAlter(BaseTestTagsUpdateViaAlter):
     materialized = "incremental"
 
 
+@pytest.mark.skip_profile("databricks_cluster")
+class TestSnapshotTags:
+    @pytest.fixture(scope="class")
+    def snapshots(self):
+        return {"tags_snapshot.sql": fixtures.snapshot_tags_sql}
+
+    def test_tags(self, project):
+        util.run_dbt(["snapshot"])
+        util.run_dbt(["snapshot"])
+        results = project.run_sql(
+            "select tag_name, tag_value from `system`.`information_schema`.`table_tags`"
+            " where schema_name = '{schema}' and table_name='tags_snapshot'",
+            fetch="all",
+        )
+        assert len(results) == 3
+        expected_tags = {("a", "b"), ("c", "d"), ("k", "")}
+        actual_tags = set((row[0], row[1]) for row in results)
+        assert actual_tags == expected_tags
+
+
 @pytest.mark.dlt
 @pytest.mark.skip_profile("databricks_cluster", "databricks_uc_cluster")
 class TestMaterializedViewTags(BaseTestTags):
@@ -170,6 +190,9 @@ class TestStreamingTableTagsUpdateViaAlter:
             fetch="all",
         )
         assert len(results) == 4
+        expected_tags = {("a", "b"), ("c", "d"), ("k", ""), ("e", "f")}
+        actual_tags = set((row[0], row[1]) for row in results)
+        assert actual_tags == expected_tags
 
 
 @pytest.mark.python


### PR DESCRIPTION
## Summary

Adds functional coverage for the one untested `databricks_tags` path and strengthens a weak assertion in the existing tag suite.

### Snapshot tags (new coverage)
`snapshot.sql` applies `databricks_tags` via `apply_tags` on every `dbt snapshot`, but no functional test exercised it — table, view, incremental, materialized view, streaming table, metric view, and python models are all covered, snapshots were the gap. `TestSnapshotTags` defines a `{% snapshot %}` model with `databricks_tags`, runs `dbt snapshot` twice (also exercising the set-only re-apply on rerun), and asserts the resulting tags via `system.information_schema.table_tags`.

### Streaming-table tag assertion (strengthened)
`TestStreamingTableTagsUpdateViaAlter` previously asserted only `len(results) == 4` — a four-row result with the wrong keys or values would still pass. It now also asserts the exact tag set `{a:b, c:d, k:'', e:f}`, matching the pattern every other test in the file already uses.

## Testing
Both run green on `databricks_uc_sql_endpoint`:
- `TestSnapshotTags::test_tags` — passed (63.8s)
- `TestStreamingTableTagsUpdateViaAlter::test_updated_tags` — passed (89.9s)

Full file collects 13 tests; `ruff` / `ruff format` / `mypy` pass.