### PR TITLE
test: cover UniForm iceberg tblproperties injection and incremental property removal

### DIFF
--- a/tests/functional/adapter/incremental/test_incremental_tblproperties.py
+++ b/tests/functional/adapter/incremental/test_incremental_tblproperties.py
@@ -31,6 +31,9 @@ class TestIncrementalTblproperties(RerunSafeMixin):
             results_dict[result.key] = result.value
         assert results_dict["c"] == "e"
         assert results_dict["d"] == "f"
+        # Dropping a property from config does not unset it on the table; the
+        # original value is left in place.
+        assert results_dict["a"] == "b"
 
 
 @pytest.mark.python
@@ -64,3 +67,4 @@ class TestIncrementalPythonTblproperties(RerunSafeMixin):
             results_dict[result.key] = result.value
         assert results_dict["c"] == "e"
         assert results_dict["d"] == "f"
+        assert results_dict["a"] == "b"

--- a/tests/functional/adapter/tblproperties/fixtures.py
+++ b/tests/functional/adapter/tblproperties/fixtures.py
@@ -39,6 +39,15 @@ seed_csv = """id,msg
 3,anyway
 """
 
+uniform_iceberg_sql = """
+{{ config(
+    materialized = 'table',
+    table_format = 'iceberg'
+) }}
+
+select cast(1 as bigint) as id, 'hello' as msg
+"""
+
 snapshot_sql = """
 {% snapshot my_snapshot %}
 

--- a/tests/functional/adapter/tblproperties/test_set_tblproperties.py
+++ b/tests/functional/adapter/tblproperties/test_set_tblproperties.py
@@ -60,3 +60,26 @@ class TestTblproperties:
 
         self.check_snapshot_results(project.adapter, num_rows=3)
         self.check_tblproperties(project, "my_snapshot", ["tblproperties_to_snapshot"])
+
+
+@pytest.mark.skip_profile("databricks_cluster")
+class TestUniformIcebergTblproperties:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"uniform_iceberg.sql": fixtures.uniform_iceberg_sql}
+
+    def test_uniform_properties_applied(self, project):
+        # With use_managed_iceberg off (the default), an iceberg table is a Delta
+        # table in UniForm mode, so the Delta->Iceberg compatibility properties are
+        # added automatically rather than being declared in the model config.
+        util.run_dbt(["run"])
+
+        results = util.run_sql_with_adapter(
+            project.adapter,
+            f"show tblproperties {project.test_schema}.uniform_iceberg",
+            fetch="all",
+        )
+        tblproperties = {result[0]: result[1] for result in results}
+
+        assert tblproperties["delta.universalFormat.enabledFormats"] == "iceberg"
+        assert tblproperties["delta.enableIcebergCompatV2"] == "true"


### PR DESCRIPTION
### Description

Adds functional coverage for two previously-untested `tblproperties` behaviors.

**UniForm Iceberg property injection.** With `use_managed_iceberg` off (the default), a `table_format='iceberg'` model is a Delta table in UniForm mode, so dbt auto-injects the Delta→Iceberg compatibility properties `delta.universalFormat.enabledFormats=iceberg` and `delta.enableIcebergCompatV2=true`. Nothing in the suite asserted these land. `TestUniformIcebergTblproperties` creates such a table and asserts both via `SHOW TBLPROPERTIES`.

**Property removal is a no-op.** dbt emits `ALTER … SET` for tblproperties but never `UNSET`, so a property dropped from config is left in place on the table. The existing incremental change fixtures already drop key `a` (`{a:b,c:d}` → `{c:e,d:f}`) but asserted only the changed keys. Strengthened both `TestIncrementalTblproperties` and `TestIncrementalPythonTblproperties` to assert the dropped key persists.

All assertions are server-observable (`SHOW TBLPROPERTIES`).

### Checklist

- [x] Tests pass locally against `databricks_uc_sql_endpoint` (uniform + both incremental classes green; full `tblproperties/` section green)
- [x] `pre-commit` (ruff / ruff-format / mypy) clean
- [ ] Changelog — not applicable; test-only change with no runtime impact
