### PR TITLE
test: assert table_format selects the correct storage provider

### DIFF
--- a/tests/functional/adapter/iceberg/test_iceberg_support.py
+++ b/tests/functional/adapter/iceberg/test_iceberg_support.py
@@ -6,6 +6,26 @@ from tests.functional.adapter.fixtures import ManagedIcebergMixin
 from tests.functional.adapter.iceberg import fixtures
 
 
+def get_provider(project, identifier):
+    rows = project.run_sql(
+        f"describe extended {{database}}.{{schema}}.{identifier}",
+        fetch="all",
+    )
+    for col_name, value, *_ in rows:
+        if str(col_name).strip() == "Provider":
+            return str(value).strip().lower()
+    return None
+
+
+def get_tblproperty(project, identifier, key):
+    rows = project.run_sql(
+        f"show tblproperties {{database}}.{{schema}}.{identifier}",
+        fetch="all",
+    )
+    values = [row[1] for row in rows if row[0] == key]
+    return values[0] if values else None
+
+
 @pytest.mark.skip_profile("databricks_cluster")
 class TestIcebergTables:
     @pytest.fixture(scope="class")
@@ -21,6 +41,15 @@ class TestIcebergTables:
         util.run_dbt()
         run_results = util.run_dbt()
         assert len(run_results) == 3
+
+    def test_table_format_providers(self, project):
+        # With use_managed_iceberg off, table_format="iceberg" produces a Delta
+        # table with UniForm Iceberg metadata rather than a native Iceberg table.
+        util.run_dbt()
+        assert get_provider(project, "first_table") == "delta"
+        assert get_provider(project, "iceberg_table") == "delta"
+        uniform = get_tblproperty(project, "iceberg_table", "delta.universalFormat.enabledFormats")
+        assert uniform is not None and "iceberg" in uniform
 
 
 @pytest.mark.skip_profile("databricks_cluster")
@@ -99,7 +128,16 @@ class TestIcebergIncrementalPartitionClustering(ManagedIcebergMixin):
 
 
 class TestManagedIcebergTables(TestIcebergTables, ManagedIcebergMixin):
-    pass
+    def test_table_format_providers(self, project):
+        # With use_managed_iceberg on, table_format="iceberg" produces a native
+        # Iceberg table, not a UniForm-enabled Delta table.
+        util.run_dbt()
+        assert get_provider(project, "first_table") == "delta"
+        assert get_provider(project, "iceberg_table") == "iceberg"
+        assert (
+            get_tblproperty(project, "iceberg_table", "delta.universalFormat.enabledFormats")
+            is None
+        )
 
 
 class TestManagedIcebergSwap(TestIcebergSwap, ManagedIcebergMixin):


### PR DESCRIPTION
Adds server-observable assertions for the storage format `table_format` selects on table create — the one effect the existing iceberg tests never checked (they asserted only run-success / row data, so a regression silently producing Delta where managed Iceberg was requested, or vice-versa, would pass).

Strengthened the two classes that already build the right models (`first_table` = default Delta, `iceberg_table` = `table_format="iceberg"`):

- `TestIcebergTables` (`use_managed_iceberg` off): `iceberg_table` is a Delta table with UniForm Iceberg metadata — `Provider == delta` and `delta.universalFormat.enabledFormats` contains `iceberg`.
- `TestManagedIcebergTables` (`use_managed_iceberg` on): `iceberg_table` is a native Iceberg table — `Provider == iceberg`, and no `delta.universalFormat` property.
- Both confirm a plain model (`first_table`) stays `Provider == delta` as a control.

Assertions read server state only (`DESCRIBE EXTENDED` Provider row, read by name; `SHOW TBLPROPERTIES`). No new models or fixtures — reuses what both classes already build. 4/4 pass on `databricks_uc_sql_endpoint` (incl. the pre-existing `test_iceberg_refs`).