### PR TITLE
test: server-observable assertions for python model submission + schema change

### DIFF
--- a/tests/functional/adapter/python_model/test_python_model.py
+++ b/tests/functional/adapter/python_model/test_python_model.py
@@ -121,7 +121,7 @@ class TestChangingSchema(SchemaNameVarMixin):
     def project_config_update(self):
         return {"models": {"+create_notebook": "true"}}
 
-    def test_changing_schema_with_log_validation(self, project, logs_dir):
+    def test_changing_schema(self, project):
         schema_vars = self.schema_name_vars(project)
         util.run_dbt(["run", *schema_vars])
         util.write_file(
@@ -130,12 +130,13 @@ class TestChangingSchema(SchemaNameVarMixin):
             "simple_python_model.py",
         )
         util.run_dbt(["run", *schema_vars])
-        log_file = os.path.join(logs_dir, "dbt.log")
-        with open(log_file) as f:
-            log = f.read()
-            assert "On model.test.simple_python_model:" in log
-            assert "spark.createDataFrame(data, schema=['test1', 'test3'])" in log
-            assert "Execution status: OK in" in log
+        columns = project.run_sql(
+            "SELECT column_name FROM {database}.information_schema.columns "
+            "WHERE table_schema = '{schema}' AND table_name = 'simple_python_model' "
+            "ORDER BY ordinal_position",
+            fetch="all",
+        )
+        assert [c[0] for c in columns] == ["test1", "test3"]
 
 
 @pytest.mark.python
@@ -207,6 +208,15 @@ class TestServerlessCluster(BasePythonModelTests):
             "my_python_model.py": fixtures.basic_python,
             "second_sql_model.sql": fixtures.second_sql,
         }
+
+    def test_serverless_python_model_data(self, project):
+        run_vars = ["--vars", json.dumps({"test_run_schema": project.test_schema})]
+        util.run_dbt(["seed", *run_vars])
+        util.run_dbt(["run", *run_vars])
+        # basic_python refs my_sql_model (six id=1 rows) and returns df.limit(2),
+        # so the serverless-built table must hold exactly those two rows.
+        rows = project.run_sql("SELECT id FROM {database}.{schema}.my_python_model", fetch="all")
+        assert sorted(row[0] for row in rows) == [1, 1]
 
 
 @pytest.mark.python


### PR DESCRIPTION
## Description

Strengthens the `python_model` functional suite so the python-model submission paths assert **server-observable state** instead of build-success-only / log-substring checks.

- **`TestServerlessCluster::test_serverless_python_model_data`** (new) — the inherited `BasePythonModelTests.test_singular_tests` only asserts `len(results) == 4`; it never queries the built table. This adds an assertion that the serverless-built `my_python_model` holds exactly the two `id=1` rows that `basic_python`'s `df.limit(2)` over `basic_sql` produces, so the serverless submission path is verified end-to-end (submit → poll → table with correct data).
- **`TestChangingSchema::test_changing_schema`** (was `test_changing_schema_with_log_validation`) — replaces three `dbt.log` substring assertions with an `information_schema.columns` check confirming the table reflects the schema-changing re-run (columns become `["test1", "test3"]`). This removes a forbidden log-substring assertion from a functional test and proves the table actually changed, not just that a log line appeared.

## How tested

Both tests verified green on `databricks_uc_sql_endpoint` (serverless):

```
tests/functional/adapter/python_model/test_python_model.py::TestServerlessCluster::test_serverless_python_model_data PASSED
tests/functional/adapter/python_model/test_python_model.py::TestChangingSchema::test_changing_schema PASSED
```

`ruff` / `ruff format` / `mypy` clean; section collection clean (22 tests).

## Checklist

- [x] Tests added/strengthened
- [N/A] CHANGELOG entry — test-only change, no runtime impact