### PR TITLE
test: cover sync_all_columns column-type widening (databricks__alter_column_type)

### DIFF
--- a/tests/functional/adapter/columns/fixtures.py
+++ b/tests/functional/adapter/columns/fixtures.py
@@ -66,3 +66,17 @@ models:
       - name: id
       - name: name
 """
+
+type_widening_model = """
+{{ config(
+    materialized='incremental',
+    unique_key='id',
+    on_schema_change='sync_all_columns',
+    tblproperties={'delta.enableTypeWidening': 'true'}
+) }}
+{% if not is_incremental() %}
+select cast(1 as bigint) as id, cast(10 as int) as measure
+{% else %}
+select cast(2 as bigint) as id, cast(3000000000 as bigint) as measure
+{% endif %}
+"""

--- a/tests/functional/adapter/columns/test_alter_columns.py
+++ b/tests/functional/adapter/columns/test_alter_columns.py
@@ -1,0 +1,44 @@
+import pytest
+from dbt.tests import util
+
+from dbt.adapters.databricks.relation import DatabricksRelation
+from tests.functional.adapter.columns import fixtures
+from tests.functional.adapter.fixtures import MaterializationV2Mixin
+
+
+class SyncAllColumnsWidensType:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"type_widen_model.sql": fixtures.type_widening_model}
+
+    def test_sync_all_columns_widens_column_type(self, project):
+        relation = DatabricksRelation.create(
+            database=project.database,
+            schema=project.test_schema,
+            identifier="type_widen_model",
+            type=DatabricksRelation.Table,
+        )
+
+        def measure_dtype():
+            with project.adapter.connection_named("_test"):
+                columns = project.adapter.get_columns_in_relation(relation)
+            return {c.column: c.dtype for c in columns}["measure"]
+
+        util.run_dbt(["run", "--full-refresh"])
+        before = measure_dtype()
+
+        util.run_dbt(["run"])
+        after = measure_dtype()
+
+        assert before != after
+
+        widened = project.run_sql("select measure from type_widen_model where id = 2", fetch="all")
+        assert widened[0][0] == 3000000000
+
+
+class TestSyncAllColumnsWidensType(SyncAllColumnsWidensType):
+    pass
+
+
+class TestSyncAllColumnsWidensTypeV2(MaterializationV2Mixin, SyncAllColumnsWidensType):
+    pass


### PR DESCRIPTION
### Description

The `on_schema_change='sync_all_columns'` change-handling path has three effects: ADD COLUMNS, DROP COLUMNS, and **column type change** (`new_target_types` → `databricks__alter_column_type`). The first two are covered by the existing incremental tests, but the type-change branch had **no functional coverage** — the adapter's `sync_all_columns` test fixture casts every field to `string` in both runs, so dbt's type diff is always empty and the alter-type loop never fires.

This adds a focused test that exercises and asserts the type-change branch end to end.

### What the test does

`tests/functional/adapter/columns/test_alter_columns.py` widens a column from `int` to `bigint` on the incremental run (with `delta.enableTypeWidening='true'`, which Delta requires for `ALTER COLUMN ... TYPE`), and proves the widen server-side two ways:

1. `get_columns_in_relation` reports a different dtype for the column before vs after the incremental run, and
2. a value beyond the 32-bit int range (3,000,000,000) round-trips — impossible if the column hadn't actually widened.

Covers both V1 and V2 materialization. Rerun-safe via `--full-refresh` (clean `int` table each attempt).

### Testing

`hatch run pytest tests/functional/adapter/columns/ -v` — 5 passed (2 new + 3 pre-existing).

Verified on both profiles (the test carries no `skip_profile`, so CI runs it on every profile):

- `databricks_uc_sql_endpoint` (UC SQL warehouse)
- `databricks_cluster` (non-UC, hive_metastore) — also exercises the legacy `DESCRIBE TABLE` get-columns path

### Checklist

- This is **test-only** with no runtime impact, so no `CHANGELOG.md` entry is needed.
