### PR TITLE
test: revive and extend dbt clone functional coverage

### DIFF
--- a/tests/functional/adapter/dbt_clone/test_dbt_clone.py
+++ b/tests/functional/adapter/dbt_clone/test_dbt_clone.py
@@ -22,7 +22,6 @@ class CleanupMixin:
             project.adapter.drop_schema(relation)
 
 
-@pytest.mark.skip("Skip until tests fixed upstream in 1.8.0 final")
 class TestClonePossible(BaseClonePossible, CleanupMixin):
     pass
 
@@ -93,14 +92,59 @@ class TestClonePersistDocs(BaseClone):
             f"describe extended {project.database}.{other_schema}.table_model",
             fetch="all",
         )
-        for row in results:
-            if row[0] == "comment":
-                assert row[1] == "This is a table model"
+        table_comment = next(row[1] for row in results if row[0].strip() == "Comment")
+        assert table_comment == "This is a table model"
 
         results = project.run_sql(
             f"describe extended {project.database}.{other_schema}.view_model",
             fetch="all",
         )
-        for row in results:
-            if row[0] == "comment":
-                assert row[1] == "This is a view model"
+        view_comment = next(row[1] for row in results if row[0].strip() == "Comment")
+        assert view_comment == "This is a view model"
+
+
+class TestCloneShallowClone(BaseClone, CleanupMixin):
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"table_model.sql": fixtures.table_model_sql}
+
+    @pytest.fixture(scope="class")
+    def snapshots(self):
+        return {}
+
+    @pytest.fixture(scope="class")
+    def seeds(self):
+        return {}
+
+    def _latest_version(self, project, relation):
+        history = project.run_sql(f"describe history {relation}", fetch="all")
+        operations = {row[4] for row in history}
+        return max(row[0] for row in history), operations
+
+    def test_shallow_clone(self, project, unique_schema, other_schema):
+        project.create_test_schema(other_schema)
+        run_dbt(["run"])
+        self.copy_state(project.project_root)
+
+        clone_args = ["clone", "--state", "state", "--target", "otherschema"]
+        run_dbt(clone_args)
+
+        cloned = f"{project.database}.{other_schema}.table_model"
+
+        # the table branch materializes via CREATE OR REPLACE ... SHALLOW CLONE,
+        # which Delta records as a CLONE operation rather than a full rewrite
+        version, operations = self._latest_version(project, cloned)
+        assert "CLONE" in operations, f"clone history operations: {operations}"
+
+        # an existing target is left untouched without --full-refresh
+        run_dbt(clone_args)
+        noop_version, _ = self._latest_version(project, cloned)
+        assert noop_version == version
+
+        # --full-refresh re-clones in place, adding a fresh CLONE version
+        run_dbt([*clone_args, "--full-refresh"])
+        refreshed_version, refreshed_operations = self._latest_version(project, cloned)
+        assert refreshed_version > version
+        assert "CLONE" in refreshed_operations, (
+            f"full-refresh history operations: {refreshed_operations}"
+        )


### PR DESCRIPTION
## Summary

Improves functional-test coverage of the `clone` materialization, which was thin and partly inert:

- **Un-skip `TestClonePossible`.** It carried `"Skip until tests fixed upstream in 1.8.0 final"` — long stale. The upstream `BaseClonePossible` tests now pass against Databricks, restoring server-observable coverage of table→table / view→view cloning (`count_types == {table: 3, view: 1}` via `list_relations`) and the no-`--state` error path.
- **Fix the vacuous assertion in `TestClonePersistDocs`.** `DESCRIBE EXTENDED` returns the relation comment in a row whose first column is `Comment` (capitalized), but the test guarded on lowercase `"comment"`, so the `assert` never executed — the test passed regardless of whether `persist_docs` worked. It now reads the `Comment` row directly and raises if it is absent.
- **Add `TestCloneShallowClone`.** Asserts via `DESCRIBE HISTORY` that the table branch materializes as a shallow clone (operation `CLONE`), that an existing target is a no-op without `--full-refresh`, and that `--full-refresh` re-clones in place (a fresh `CLONE` version). Shallow-clone provenance — the behavior that distinguishes Databricks' clone from a plain rebuild — was previously only unit-tested.

`TestCloneSameTargetAndState` is intentionally left skipped: its sole assertion is a CLI-warning log substring (a dbt-core guard with no server-observable equivalent), which we don't want to revive into a functional test.

## Testing

Run against `databricks_uc_sql_endpoint`:
- `tests/functional/adapter/dbt_clone/test_dbt_clone.py` → **4 passed, 1 skipped** (intentional).
- `pre-commit` (ruff, ruff-format, mypy) clean.

No changelog entry — test-only, no runtime change.
