### PR TITLE
test: assert concurrency outcome via result objects, not log output

### DIFF
--- a/tests/functional/adapter/concurrency/test_concurrency.py
+++ b/tests/functional/adapter/concurrency/test_concurrency.py
@@ -4,27 +4,28 @@ from dbt.tests.adapter.concurrency.test_concurrency import BaseConcurrency, seed
 
 # Copied from dbt-core
 class TestConcurrency(BaseConcurrency):
+    def assert_seed_relations(self, project):
+        util.check_relations_equal(project.adapter, ["seed", "view_model"])
+        util.check_relations_equal(project.adapter, ["seed", "dep"])
+        util.check_relations_equal(project.adapter, ["seed", "table_a"])
+        util.check_relations_equal(project.adapter, ["seed", "table_b"])
+        util.check_table_does_not_exist(project.adapter, "invalid")
+        util.check_table_does_not_exist(project.adapter, "skip")
+
     def test_concurrency(self, project):
         util.run_dbt(["seed", "--select", "seed"])
         results = util.run_dbt(["run"], expect_pass=False)
         assert len(results) == 7
-        util.check_relations_equal(project.adapter, ["seed", "view_model"])
-        util.check_relations_equal(project.adapter, ["seed", "dep"])
-        util.check_relations_equal(project.adapter, ["seed", "table_a"])
-        util.check_relations_equal(project.adapter, ["seed", "table_b"])
-        util.check_table_does_not_exist(project.adapter, "invalid")
-        util.check_table_does_not_exist(project.adapter, "skip")
+        self.assert_seed_relations(project)
 
         util.rm_file(project.project_root, "seeds", "seed.csv")
         util.write_file(seeds__update_csv, project.project_root, "seeds", "seed.csv")
 
-        results, output = util.run_dbt_and_capture(["run"], expect_pass=False)
+        results = util.run_dbt(["run"], expect_pass=False)
         assert len(results) == 7
-        util.check_relations_equal(project.adapter, ["seed", "view_model"])
-        util.check_relations_equal(project.adapter, ["seed", "dep"])
-        util.check_relations_equal(project.adapter, ["seed", "table_a"])
-        util.check_relations_equal(project.adapter, ["seed", "table_b"])
-        util.check_table_does_not_exist(project.adapter, "invalid")
-        util.check_table_does_not_exist(project.adapter, "skip")
+        self.assert_seed_relations(project)
 
-        assert "PASS=5 WARN=0 ERROR=1 SKIP=1" in output
+        statuses = [r.status for r in results]
+        assert statuses.count("success") == 5
+        assert statuses.count("error") == 1
+        assert statuses.count("skipped") == 1


### PR DESCRIPTION
## Summary

The concurrency functional test asserted the run summary by matching a substring of captured stdout:

```python
results, output = util.run_dbt_and_capture(["run"], expect_pass=False)
...
assert "PASS=5 WARN=0 ERROR=1 SKIP=1" in output
```

Functional tests should assert result/server-observable state rather than log text. This swaps the stdout-substring check for assertions over the run-result objects' statuses, which proves the same orchestration outcome (5 succeed, 1 fails, 1 dependent skips) more directly:

```python
results = util.run_dbt(["run"], expect_pass=False)
...
statuses = [r.status for r in results]
assert statuses.count("success") == 5
assert statuses.count("error") == 1
assert statuses.count("skipped") == 1
```

It also dedupes the two identical relation-check blocks into a small `assert_seed_relations` helper.

## Testing

Test-only change, no runtime impact. Ran the functional test against a live SQL warehouse:

```
tests/functional/adapter/concurrency/test_concurrency.py::TestConcurrency::test_concurrency PASSED
```

`ruff`, `ruff format`, and `mypy` all pass.