### PR TITLE
test: add unit tests for live events/logging classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Raise the `dbt-adapters` upper bound to `<1.25.0` ([#1507](https://github.com/databricks/dbt-databricks/pull/1507))
 - Raise the `databricks-sdk` upper bound to `<0.118.0` to pick up 0.117.0, which fixes `WorkspaceClient` construction failing with `CONTEXT_UNAVAILABLE_FOR_REMOTE_CLIENT` on Spark Connect clusters ([#1517](https://github.com/databricks/dbt-databricks/pull/1517) closes [#1252](https://github.com/databricks/dbt-databricks/issues/1252))
 - Make the remaining incremental functional tests (tags, column tags, tblproperties, liquid clustering, column masks, persist_docs, replace table) rerun-safe so a `pytest --reruns` retry no longer inherits mutated state (rewritten `schema.yml`/model files, half-built relations) from the failed attempt (test-only, no runtime impact).
+- Add unit tests for the previously-uncovered live event/logging classes (`QueryError`, `ConnectionCreate`, `ConnectionCreateError`, and `DbtCoreHandler` log-level routing), bringing the live code in `events/` and `logging.py` to full coverage (test-only, no runtime impact). ([#1548](https://github.com/databricks/dbt-databricks/pull/1548))
 
 ## dbt-databricks 1.12.1 (June 10, 2026)
 

--- a/tests/unit/events/test_connection_events.py
+++ b/tests/unit/events/test_connection_events.py
@@ -1,6 +1,8 @@
 from unittest.mock import Mock
 
 from dbt.adapters.databricks.events.connection_events import (
+    ConnectionCreate,
+    ConnectionCreateError,
     ConnectionEvent,
 )
 
@@ -26,3 +28,15 @@ class TestConnectionEvents:
         mock.get_session_id_hex.return_value = "1234"
         event = ConnectionTestEvent(mock)
         assert str(event) == "Connection(session-id=1234) - This is a test"
+
+
+class TestConnectionCreateError:
+    def test_connection_create_error__formats_exception(self):
+        result = str(ConnectionCreateError(Exception("nope")))
+        assert "session-id=Unknown" in result
+        assert "nope" in result
+
+
+class TestConnectionCreate:
+    def test_connection_create(self):
+        assert str(ConnectionCreate("conn-1")) == "conn-1 - Creating connection"

--- a/tests/unit/events/test_logging.py
+++ b/tests/unit/events/test_logging.py
@@ -1,0 +1,36 @@
+import logging as stdlib_logging
+from unittest.mock import Mock
+
+import pytest
+
+from dbt.adapters.databricks.logging import DbtCoreHandler
+
+
+def _record(level, msg):
+    return stdlib_logging.LogRecord(
+        name="databricks.sql",
+        level=level,
+        pathname=__file__,
+        lineno=1,
+        msg=msg,
+        args=None,
+        exc_info=None,
+    )
+
+
+class TestDbtCoreHandler:
+    @pytest.mark.parametrize(
+        "level, method, msg",
+        [
+            (stdlib_logging.WARNING, "warning", "heads up"),
+            (stdlib_logging.ERROR, "error", "bad"),
+            (stdlib_logging.DEBUG, "debug", "trace"),
+        ],
+    )
+    def test_emit__routes_record_to_matching_logger_method(self, level, method, msg):
+        dbt_logger = Mock()
+        handler = DbtCoreHandler(level=stdlib_logging.DEBUG, dbt_logger=dbt_logger)
+
+        handler.emit(_record(level, msg))
+
+        getattr(dbt_logger, method).assert_called_once_with(msg)

--- a/tests/unit/events/test_other_events.py
+++ b/tests/unit/events/test_other_events.py
@@ -1,0 +1,18 @@
+from databricks.sql.exc import Error
+
+from dbt.adapters.databricks.events.other_events import QueryError
+
+
+class TestQueryError:
+    def test_query_error__formats_sql_and_exception(self):
+        result = str(QueryError("select 1", Exception("boom")))
+        assert "select 1" in result
+        assert result.endswith("boom")
+
+    def test_query_error__with_pysql_error_appends_properties(self):
+        e = Error("bad query", {"sqlstate": "42000", "operation": "select"})
+        event = QueryError("select 1", e)
+        assert (
+            str(event) == "Exception while trying to execute query\nselect 1\n: bad query\n"
+            "Error properties: operation=select, sqlstate=42000"
+        )


### PR DESCRIPTION
## Description

Several **live** classes in `dbt/adapters/databricks/events/` and `dbt/adapters/databricks/logging.py` had no unit-test coverage. This adds tests for them, bringing the live code in both modules to 100% line + branch coverage.

Newly covered (all currently used in `connections.py`):
- `QueryError` — query-execution error formatting (plain, plus the pysql `Error` property append path)
- `ConnectionCreate`, `ConnectionCreateError`
- `DbtCoreHandler.emit` — level → `AdapterLogger`-method routing (parametrized over WARNING/ERROR/DEBUG)

Tests follow the existing `tests/unit/events/` style; they assert the behavior/contract (dynamic values interpolated, exception surfaced, correct logger method called) and only pin exact strings where the format itself is the logic (the sorted `Error properties: …` join).

### Intentionally out of scope
Several event classes are currently **unused** — orphaned, with call sites removed by later refactors: the whole `credential_events` and `pipeline_events` modules, and the `ConnectionReset` / `ConnectionReuse` / `ConnectionIdleClose` / `ConnectionCreated` wrappers. They are deliberately left untested pending a separate keep-or-delete decision, so the remaining uncovered lines in `connection_events.py` map exactly to that dead code.

## Test plan
- `hatch run pytest tests/unit/events/` → **14 passed**
- `pre-commit` (ruff, ruff-format, mypy) clean

## Checklist
- [x] Added unit tests covering the change
- [x] Updated `CHANGELOG.md` ("dbt-databricks next" → Under the Hood; test-only, no runtime impact)
