### PR TITLE
test: add SQL UDF lifecycle functional test

### DIFF
--- a/tests/functional/adapter/functions/fixtures.py
+++ b/tests/functional/adapter/functions/fixtures.py
@@ -63,3 +63,22 @@ functions:
     returns:
       data_type: float
 """
+
+
+SQL_UDF_V1 = """
+SELECT price * 2
+"""
+
+SQL_UDF_V2 = """
+SELECT price * 3
+"""
+
+SQL_UDF_YML = """
+functions:
+  - name: price_for_xlarge
+    arguments:
+      - name: price
+        data_type: float
+    returns:
+      data_type: float
+"""

--- a/tests/functional/adapter/functions/test_udfs.py
+++ b/tests/functional/adapter/functions/test_udfs.py
@@ -14,6 +14,9 @@ from tests.functional.adapter.functions.fixtures import (
     PYTHON_UDF_V1,
     PYTHON_UDF_V2,
     PYTHON_UDF_YML_V1,
+    SQL_UDF_V1,
+    SQL_UDF_V2,
+    SQL_UDF_YML,
 )
 
 
@@ -107,6 +110,65 @@ class TestDatabricksPythonUDFLifecycle:
         # ===========================================
         # Update the Python file
         write_file(PYTHON_UDF_V2, project.project_root, "functions", "price_for_xlarge.py")
+
+        result = run_dbt(["build"])
+
+        assert len(result.results) == 1
+        assert result.results[0].status == RunStatus.Success
+
+        # Verify new implementation works: price * 3
+        result = run_dbt(["show", "--inline", "SELECT {{ function('price_for_xlarge') }}(100)"])
+        assert int(result.results[0].agate_table.rows[0].values()[0]) == 300
+
+
+@pytest.mark.skip_profile("databricks_cluster")
+class TestDatabricksSqlUDFLifecycle:
+    """Test the full lifecycle of a SQL UDF.
+
+    Verifies:
+    1. Initial create - function is created successfully
+    2. Subsequent runs - function is replaced (idempotent)
+    3. Code change - function is updated with new implementation
+    """
+
+    @pytest.fixture(scope="class")
+    def functions(self):
+        return {
+            "price_for_xlarge.sql": SQL_UDF_V1,
+            "price_for_xlarge.yml": SQL_UDF_YML,
+        }
+
+    def test_sql_udf_lifecycle(self, project):
+        """Test the full lifecycle of a SQL UDF."""
+
+        # ===========================================
+        # Phase 1: Initial Create
+        # ===========================================
+        result = run_dbt(["build"])
+
+        assert len(result.results) == 1
+        assert result.results[0].status == RunStatus.Success
+
+        # Verify function works: price * 2
+        result = run_dbt(["show", "--inline", "SELECT {{ function('price_for_xlarge') }}(100)"])
+        assert int(result.results[0].agate_table.rows[0].values()[0]) == 200
+
+        # ===========================================
+        # Phase 2: Subsequent Run (Idempotent)
+        # ===========================================
+        result = run_dbt(["build"])
+
+        assert len(result.results) == 1
+        assert result.results[0].status == RunStatus.Success
+
+        # Function still works the same way
+        result = run_dbt(["show", "--inline", "SELECT {{ function('price_for_xlarge') }}(100)"])
+        assert int(result.results[0].agate_table.rows[0].values()[0]) == 200
+
+        # ===========================================
+        # Phase 3: Code Change (price * 2 -> price * 3)
+        # ===========================================
+        write_file(SQL_UDF_V2, project.project_root, "functions", "price_for_xlarge.sql")
 
         result = run_dbt(["build"])
 


### PR DESCRIPTION
### Description

Adds a functional test for the **SQL scalar UDF lifecycle**, mirroring the existing
`TestDatabricksPythonUDFLifecycle` for the SQL path:

1. **Create** — the UDF builds and `price_for_xlarge(100)` returns `200`.
2. **Idempotent re-run** — a second `dbt build` replaces it via `CREATE OR REPLACE`; result unchanged.
3. **Body change** — the body is rewritten (`price * 2` → `price * 3`), rebuilt, and `price_for_xlarge(100)` now returns `300`.

The SQL and Python UDF macro paths are separate: the SQL path renders `RETURN <expr>` /
`LANGUAGE SQL`, while the Python path is the self-contained `databricks__scalar_function_python`
(`LANGUAGE PYTHON ... AS $$...$$`). The existing Python lifecycle test therefore does not exercise
the SQL `RETURN`-body path on re-create — this fills that gap. All assertions are server-observable
(the UDF is executed and its returned value checked).

**Test results** (profile `databricks_uc_sql_endpoint`):
- New test alone: `1 passed`
- Full `functions/` section (4 pre-existing + new): `5 passed`, no regressions

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` — N/A: test-only change, no runtime impact.
