### PR TITLE
fix: honor `expression` on `primary_key` constraints in V1 materialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Add catalogs.yml v2 support (requires `use_catalogs_v2: true` in dbt-core) ([1440](https://github.com/databricks/dbt-databricks/pull/1440))
 
 ### Fixes
+- Honor the `expression` field on `primary_key` constraints on the V1 materialization path. A primary key declared with `expression: RELY` (or any trailing clause) previously had its expression silently dropped — the key was created without it. ([#XXXX](https://github.com/databricks/dbt-databricks/pull/XXXX))
 - Apply column-level `databricks_tags` for incremental models on the V1 materialization path (`use_materialization_v2: false`, the default). They were silently dropped at create and on subsequent tag changes; the V1 incremental materialization now applies them, matching the `table` materialization and the V2 path. ([#1520](https://github.com/databricks/dbt-databricks/pull/1520) closes [#1307](https://github.com/databricks/dbt-databricks/issues/1307))
 - Raise a `DbtRuntimeError` when a Python model job run terminates with a non-success `result_state` (e.g. `FAILED`/`TIMEDOUT`) instead of returning silently ([#1477](https://github.com/databricks/dbt-databricks/pull/1477))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Add catalogs.yml v2 support (requires `use_catalogs_v2: true` in dbt-core) ([1440](https://github.com/databricks/dbt-databricks/pull/1440))
 
 ### Fixes
-- Honor the `expression` field on `primary_key` constraints on the V1 materialization path. A primary key declared with `expression: RELY` (or any trailing clause) previously had its expression silently dropped — the key was created without it. ([#XXXX](https://github.com/databricks/dbt-databricks/pull/XXXX))
+- Honor the `expression` field on `primary_key` constraints on the V1 materialization path. A primary key declared with `expression: RELY` (or any trailing clause) previously had its expression silently dropped — the key was created without it. ([#1551](https://github.com/databricks/dbt-databricks/pull/1551))
 - Apply column-level `databricks_tags` for incremental models on the V1 materialization path (`use_materialization_v2: false`, the default). They were silently dropped at create and on subsequent tag changes; the V1 incremental materialization now applies them, matching the `table` materialization and the V2 path. ([#1520](https://github.com/databricks/dbt-databricks/pull/1520) closes [#1307](https://github.com/databricks/dbt-databricks/issues/1307))
 - Raise a `DbtRuntimeError` when a Python model job run terminates with a non-success `result_state` (e.g. `FAILED`/`TIMEDOUT`) instead of returning silently ([#1477](https://github.com/databricks/dbt-databricks/pull/1477))
 

--- a/dbt/include/databricks/macros/relations/constraints.sql
+++ b/dbt/include/databricks/macros/relations/constraints.sql
@@ -178,7 +178,9 @@
         {{ exceptions.raise_compiler_error("Constraint of type " ~ type ~ " with no `name` provided, and no md5 utility.") }}
       {% endif %}
     {% endif %}
-    {% set stmt = "alter table " ~ relation.render() ~ " add constraint " ~ name ~ " primary key(" ~ joined_names ~ ");" %}
+    {% set pk_expression = constraint.get('expression') %}
+    {% set pk_suffix = (" " ~ pk_expression) if pk_expression else "" %}
+    {% set stmt = "alter table " ~ relation.render() ~ " add constraint " ~ name ~ " primary key(" ~ joined_names ~ ")" ~ pk_suffix ~ ";" %}
     {% do statements.append(stmt) %}
   {% elif type == 'foreign_key' %}
 

--- a/dbt/include/databricks/macros/relations/constraints.sql
+++ b/dbt/include/databricks/macros/relations/constraints.sql
@@ -168,17 +168,21 @@
     {% endfor %}
 
     {% set joined_names = quoted_names|join(", ") %}
+    {% set pk_expression = constraint.get('expression') %}
 
     {% set name = constraint.get('name') %}
     {% if not name %}
       {% if local_md5 %}
         {{ exceptions.warn("Constraint of type " ~ type ~ " with no `name` provided. Generating hash instead for relation " ~ relation.identifier) }}
-        {%- set name = local_md5("primary_key;" ~ relation.identifier ~ ";" ~ column_names ~ ";") -%}
+        {%- set hash_input = "primary_key;" ~ relation.identifier ~ ";" ~ column_names ~ ";" -%}
+        {%- if pk_expression -%}
+          {%- set hash_input = hash_input ~ pk_expression ~ ";" -%}
+        {%- endif -%}
+        {%- set name = local_md5(hash_input) -%}
       {% else %}
         {{ exceptions.raise_compiler_error("Constraint of type " ~ type ~ " with no `name` provided, and no md5 utility.") }}
       {% endif %}
     {% endif %}
-    {% set pk_expression = constraint.get('expression') %}
     {% set pk_suffix = (" " ~ pk_expression) if pk_expression else "" %}
     {% set stmt = "alter table " ~ relation.render() ~ " add constraint " ~ name ~ " primary key(" ~ joined_names ~ ")" ~ pk_suffix ~ ";" %}
     {% do statements.append(stmt) %}

--- a/tests/unit/macros/relations/test_constraint_macros.py
+++ b/tests/unit/macros/relations/test_constraint_macros.py
@@ -277,6 +277,23 @@ class TestConstraintMacros(MacroTestBase):
         )
         assert expected in r
 
+    def test_macros_get_constraint_sql_primary_key_with_expression(self, template_bundle, model):
+        # `expression` trails the key list (e.g. RELY), matching the foreign_key branch.
+        constraint = {
+            "type": "primary_key",
+            "name": "myconstraint",
+            "columns": ["name"],
+            "expression": "RELY",
+        }
+        r = self.render_constraint_sql(template_bundle, constraint, model)
+
+        # clean_sql() lowercases the rendered SQL, so the expression is matched as `rely`.
+        expected = (
+            "['alter table `some_database`.`some_schema`.`some_table` add constraint "
+            "myconstraint primary key(`name`) rely;']"
+        )
+        assert expected in r
+
     def test_macros_get_constraint_sql_primary_key_with_specified_column(
         self, template_bundle, model
     ):

--- a/tests/unit/macros/relations/test_constraint_macros.py
+++ b/tests/unit/macros/relations/test_constraint_macros.py
@@ -338,6 +338,22 @@ class TestConstraintMacros(MacroTestBase):
         )
         assert expected in r
 
+    def test_macros_get_constraint_sql_primary_key_noname_with_expression(
+        self, template_bundle, model
+    ):
+        constraint = {"type": "primary_key", "expression": "RELY"}
+        column = {"name": "id"}
+
+        r = self.render_constraint_sql(template_bundle, constraint, model, column)
+
+        # clean_sql() lowercases the rendered SQL, including the hash input echoed by the mock.
+        expected = (
+            '["alter table `some_database`.`some_schema`.`some_table` add constraint '
+            "hash(primary_key;some_table;['id'];rely;) "
+            'primary key(`id`) rely;"]'
+        )
+        assert expected in r
+
     def test_macros_get_constraint_sql_foreign_key(self, template_bundle, model):
         constraint = {
             "type": "foreign_key",


### PR DESCRIPTION
## What

On the V1 materialization path (`use_materialization_v2: false`, the default), the `persist_constraints` flow rendered `primary key(<cols>)` and silently dropped the constraint's `expression`. A primary key declared with `expression: RELY` (or any trailing clause) was created **without** it — no error, no warning.

The V2 path (`PrimaryKeyConstraint._render_suffix`) and V1's own `foreign_key` branch already honor `expression`. This change makes the V1 `primary_key` branch in `relations/constraints.sql` append `expression` as a trailing suffix, gated on its presence so a PK without an expression renders identically to before.

## Why

`PRIMARY KEY (id) RELY` is valid Databricks syntax for an informational primary key the optimizer can rely on. Before this fix, the only way to attach `RELY` at model-build time on the default path was a post-hook.

Given (default path, `contract.enforced: true`):

```yaml
constraints:
  - type: primary_key
    columns: [id]
    expression: RELY
```

- Before: `ALTER TABLE … ADD CONSTRAINT pk PRIMARY KEY (id);`  ← RELY dropped
- After:  `ALTER TABLE … ADD CONSTRAINT pk PRIMARY KEY (id) RELY;`

## Tests

- Added `test_macros_get_constraint_sql_primary_key_with_expression` (`tests/unit/macros/relations/test_constraint_macros.py`) asserting the rendered SQL carries the expression suffix. Fails without the fix, passes with it.
- PKs without an `expression` render byte-identically, so the pre-existing constraint macro unit tests are unchanged — full unit suite green.
- Existing `constraints/` + `persist_constraints/` functional suites pass on a UC SQL warehouse (39 passed).
