### PR TITLE
fix: PK/FK constraints with an expression (e.g. RELY) dropped and re-added on every incremental run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Fixes
 - Apply column-level `databricks_tags` for incremental models on the V1 materialization path (`use_materialization_v2: false`, the default). They were silently dropped at create and on subsequent tag changes; the V1 incremental materialization now applies them, matching the `table` materialization and the V2 path. ([#1520](https://github.com/databricks/dbt-databricks/pull/1520) closes [#1307](https://github.com/databricks/dbt-databricks/issues/1307))
 - Raise a `DbtRuntimeError` when a Python model job run terminates with a non-success `result_state` (e.g. `FAILED`/`TIMEDOUT`) instead of returning silently ([#1477](https://github.com/databricks/dbt-databricks/pull/1477))
+- Fix PK/FK constraints declaring an `expression` (e.g. `RELY`) being dropped and re-added on every incremental run. The `expression` isn't readable from `information_schema`, so reconciliation never converged and issued `DROP CONSTRAINT ... CASCADE` each run — silently dropping dependent FKs, and erroring with `INTERNAL_ERROR` on newer Unity Catalog. PK/FK are now compared on `(name, columns)`. **Regression:** changing the `expression` on an existing PK/FK (`RELY`↔`NORELY`, or an expression-form FK's target) is no longer applied on incremental runs — use `--full-refresh`. ([#1552](https://github.com/databricks/dbt-databricks/pull/1552) closes [#1513](https://github.com/databricks/dbt-databricks/issues/1513))
 
 ### Under the Hood
 

--- a/dbt/adapters/databricks/relation_configs/constraints.py
+++ b/dbt/adapters/databricks/relation_configs/constraints.py
@@ -39,10 +39,12 @@ class ConstraintsConfig(DatabricksComponentConfig):
     def normalize_constraint(self, constraint: TypedConstraint) -> TypedConstraint:
         """
         Normalize a constraint for comparison by standardizing format
-        and removing irrelevant fields when necessary.
+        and removing fields that Databricks does not round-trip via information_schema.
         This is necessary because Databricks :
         - Reformats expressions for check constraints
         - Does not persist the `columns` in check constraints
+        - Does not expose PK/FK RELY/NORELY in information_schema (#1513)
+        - Does not persist FK `to`/`to_columns` on expression-form FKs
         """
         if isinstance(constraint, CheckConstraint):
             return CheckConstraint(
@@ -55,25 +57,53 @@ class ConstraintsConfig(DatabricksComponentConfig):
                 to_columns=constraint.to_columns,
                 columns=[],
             )
+        elif isinstance(constraint, PrimaryKeyConstraint):
+            return PrimaryKeyConstraint(
+                type=constraint.type,
+                name=constraint.name,
+                columns=constraint.columns,
+            )
+        elif isinstance(constraint, ForeignKeyConstraint):
+            return ForeignKeyConstraint(
+                type=constraint.type,
+                name=constraint.name,
+                columns=constraint.columns,
+            )
         else:
             return constraint
 
     def get_diff(self, other: "ConstraintsConfig") -> Optional["ConstraintsConfig"]:
-        self_set_constraints_normalized = {
-            self.normalize_constraint(c) for c in self.set_constraints
-        }
-        other_set_constraints_normalized = {
-            self.normalize_constraint(c) for c in other.set_constraints
-        }
+        # Diff on normalized keys; emit original constraints for ADD/DROP SQL.
+        self_by_key = {self.normalize_constraint(c): c for c in self.set_constraints}
+        other_by_key = {self.normalize_constraint(c): c for c in other.set_constraints}
 
         # Find constraints that need to be unset
-        constraints_to_unset = other_set_constraints_normalized - self_set_constraints_normalized
+        constraints_to_unset = {
+            original for key, original in other_by_key.items() if key not in self_by_key
+        }
         # Find non-nulls that need to be unset
         non_nulls_to_unset = other.set_non_nulls - self.set_non_nulls
 
         # Set constraints that exist in self but not in other
-        set_constraints = self_set_constraints_normalized - other_set_constraints_normalized
+        set_constraints = {
+            original for key, original in self_by_key.items() if key not in other_by_key
+        }
         set_non_nulls = self.set_non_nulls - other.set_non_nulls
+
+        # Reconcile same-name FKs whose target changed (`to`/`to_columns`).
+        # Skip expression-form FKs: the target lives in `expression`, which the catalog
+        # does not round-trip, so comparing `to`/`to_columns` would churn every run.
+        for key in self_by_key.keys() & other_by_key.keys():
+            model_constraint = self_by_key[key]
+            catalog_constraint = other_by_key[key]
+            if (
+                isinstance(model_constraint, ForeignKeyConstraint)
+                and model_constraint.to is not None
+                and (model_constraint.to, tuple(model_constraint.to_columns or ()))
+                != (catalog_constraint.to, tuple(catalog_constraint.to_columns or ()))
+            ):
+                set_constraints.add(model_constraint)
+                constraints_to_unset.add(catalog_constraint)
 
         if set_constraints or set_non_nulls or constraints_to_unset or non_nulls_to_unset:
             return ConstraintsConfig(

--- a/tests/functional/adapter/constraints/fixtures.py
+++ b/tests/functional/adapter/constraints/fixtures.py
@@ -362,3 +362,51 @@ models:
       - name: color
         data_type: string
 """
+
+incremental_rely_pk_cascade_schema_yml = """
+version: 2
+models:
+  - name: rely_parent
+    config:
+      materialized: incremental
+      unique_key: n
+      on_schema_change: append_new_columns
+      contract:
+        enforced: true
+    columns:
+      - name: n
+        data_type: int
+        constraints:
+          - type: not_null
+          - type: primary_key
+            name: pk_rely_parent
+            expression: RELY
+  - name: rely_child
+    config:
+      materialized: table
+      contract:
+        enforced: true
+    constraints:
+      - type: foreign_key
+        name: fk_rely_child
+        columns: ["parent_n"]
+        to: ref('rely_parent')
+        to_columns: ["n"]
+    columns:
+      - name: parent_n
+        data_type: int
+        constraints:
+          - type: not_null
+      - name: child_id
+        data_type: int
+"""
+
+incremental_rely_pk_parent_sql = """
+select 1 as n
+"""
+
+incremental_rely_pk_child_sql = """
+-- depends_on: {{ ref('rely_parent') }}
+
+select 1 as parent_n, 10 as child_id
+"""

--- a/tests/functional/adapter/constraints/test_constraints.py
+++ b/tests/functional/adapter/constraints/test_constraints.py
@@ -218,3 +218,43 @@ class TestForeignKeyParentConstraint:
 
     def test_foreign_key_constraint(self, project):
         util.run_dbt(["build"])
+
+
+@pytest.mark.skip_profile("databricks_cluster")
+class TestIncrementalRelyConstraintReconciliation:
+    """A RELY expression on a primary key cannot be read back from information_schema, so it
+    must not trigger constraint reconciliation on an incremental run. Otherwise the parent PK
+    is dropped with CASCADE every run, silently dropping the child's foreign key (#1513).
+    """
+
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {"flags": {"use_materialization_v2": False}}
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "schema.yml": override_fixtures.incremental_rely_pk_cascade_schema_yml,
+            "rely_parent.sql": override_fixtures.incremental_rely_pk_parent_sql,
+            "rely_child.sql": override_fixtures.incremental_rely_pk_child_sql,
+        }
+
+    def _foreign_key_names(self, project):
+        rows = project.run_sql(
+            """
+            SELECT constraint_name
+            FROM {database}.information_schema.referential_constraints
+            WHERE constraint_schema = '{schema}'
+            """,
+            fetch="all",
+        )
+        return {row[0] for row in rows}
+
+    def test_rely_pk_reconcile_keeps_dependent_foreign_key(self, project):
+        util.run_dbt(["build"])
+        assert "fk_rely_child" in self._foreign_key_names(project)
+
+        # A plain incremental re-run of the parent must not reconcile its RELY PK.
+        util.run_dbt(["run", "--select", "rely_parent"])
+
+        assert "fk_rely_child" in self._foreign_key_names(project)

--- a/tests/unit/relation_configs/test_constraint.py
+++ b/tests/unit/relation_configs/test_constraint.py
@@ -378,3 +378,101 @@ class TestConstraintsConfig:
         )
         diff = config.get_diff(other)
         assert diff is None
+
+    def test_get_diff__primary_key_rely_is_noop(self):
+        # information_schema does not expose RELY/NORELY, so a catalog-read PK always has
+        # expression=None. The model's RELY must not be treated as a change (issue #1513).
+        config = ConstraintsConfig(
+            set_non_nulls={"n"},
+            set_constraints={
+                PrimaryKeyConstraint(
+                    type=ConstraintType.primary_key,
+                    name="pk_n",
+                    columns=["n"],
+                    expression="RELY",
+                )
+            },
+        )
+        other = ConstraintsConfig(
+            set_non_nulls={"n"},
+            set_constraints={
+                PrimaryKeyConstraint(type=ConstraintType.primary_key, name="pk_n", columns=["n"])
+            },
+        )
+        assert config.get_diff(other) is None
+
+    def test_get_diff__foreign_key_expression_form_is_noop(self):
+        # An expression-form FK carries its target inside `expression` (to/to_columns None);
+        # the catalog reconstructs to/to_columns and drops the expression. Must not churn.
+        config = ConstraintsConfig(
+            set_non_nulls=set(),
+            set_constraints={
+                ForeignKeyConstraint(
+                    type=ConstraintType.foreign_key,
+                    name="fk_n",
+                    columns=["n"],
+                    expression="(n) REFERENCES `cat`.`sch`.`parent` RELY",
+                )
+            },
+        )
+        other = ConstraintsConfig(
+            set_non_nulls=set(),
+            set_constraints={
+                ForeignKeyConstraint(
+                    type=ConstraintType.foreign_key,
+                    name="fk_n",
+                    columns=["n"],
+                    to="`cat`.`sch`.`parent`",
+                    to_columns=["id"],
+                )
+            },
+        )
+        assert config.get_diff(other) is None
+
+    def test_get_diff__foreign_key_repointed_to_new_target(self):
+        # A repointed explicit FK (same name + columns, different target) is still reconciled.
+        config = ConstraintsConfig(
+            set_non_nulls=set(),
+            set_constraints={
+                ForeignKeyConstraint(
+                    type=ConstraintType.foreign_key,
+                    name="fk_p",
+                    columns=["parent_id"],
+                    to="`cat`.`sch`.`parent_v2`",
+                    to_columns=["id"],
+                )
+            },
+        )
+        other = ConstraintsConfig(
+            set_non_nulls=set(),
+            set_constraints={
+                ForeignKeyConstraint(
+                    type=ConstraintType.foreign_key,
+                    name="fk_p",
+                    columns=["parent_id"],
+                    to="`cat`.`sch`.`parent`",
+                    to_columns=["id"],
+                )
+            },
+        )
+        diff = config.get_diff(other)
+        assert diff is not None
+        assert {c.to for c in diff.set_constraints} == {"`cat`.`sch`.`parent_v2`"}
+        assert {c.to for c in diff.unset_constraints} == {"`cat`.`sch`.`parent`"}
+
+    def test_get_diff__new_primary_key_retains_expression(self):
+        # A genuinely new PK is added with its RELY intact, so the ADD renders `... RELY`.
+        config = ConstraintsConfig(
+            set_non_nulls={"n"},
+            set_constraints={
+                PrimaryKeyConstraint(
+                    type=ConstraintType.primary_key,
+                    name="pk_n",
+                    columns=["n"],
+                    expression="RELY",
+                )
+            },
+        )
+        other = ConstraintsConfig(set_non_nulls=set(), set_constraints=set())
+        diff = config.get_diff(other)
+        assert {(c.name, c.expression) for c in diff.set_constraints} == {("pk_n", "RELY")}


### PR DESCRIPTION
### Description

Resolves #1513.

A contract-enforced incremental PK/FK declaring an `expression` was dropped and re-added on **every** run. The catalog read-back (`information_schema`) never carries the `expression` — no `RELY`/`NORELY`, and expression-form FKs come back as `to`/`to_columns` — so it never matched the model, and `get_diff` flagged the constraint as both add and drop every run (for any `expression`, not just `RELY`). The PK drop is `DROP CONSTRAINT ... CASCADE`, which silently drops dependent FKs and can `INTERNAL_ERROR` on newer UC.

### Fix

Compare PK/FK on `(type, name, columns)` (dropping the un-round-trippable `expression`, and `to`/`to_columns` for FKs), but emit the original constraints so an ADD keeps its `RELY`. Explicit FK target changes (`to`/`to_columns`) are still reconciled.

### Behavior change (accepted regression)

Changing the `expression` on an *existing* PK/FK — `RELY`↔`NORELY`, or an expression-form FK's target — is no longer applied on incremental runs; use `--full-refresh`. It only worked before as a side effect of the every-run recreate, and the catalog can't report the current state without fragile `SHOW CREATE TABLE` parsing. PK/FK are informational (`NOT_ENFORCED`), so this is metadata-only.

### Tests

- Unit (`TestConstraintsConfig`): RELY PK no-op, expression-form FK no-op, explicit FK repoint reconciled, new RELY PK keeps its expression.
- Functional (`TestIncrementalRelyConstraintReconciliation`): a dependent FK survives an incremental re-run of a RELY-PK parent (asserted via `information_schema`); fails on `main`, passes here.

### Checklist

- [x] Run in development; resolves the issue.
- [x] Includes tests.
- [x] `CHANGELOG.md` updated.
