### PR TITLE
docs: sync DBR capability docs with current capabilities

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -201,12 +201,7 @@ DatabricksAdapter (impl.py)
   - Per-compute caching (different clusters can have different capabilities)
   - Named capabilities instead of magic version numbers
   - Automatic detection of DBR version and SQL warehouse environments
-- **Supported Capabilities**:
-  - `TIMESTAMPDIFF` (DBR 10.4+): Advanced date/time functions
-  - `INSERT_BY_NAME` (DBR 12.2+): Name-based column matching in INSERT
-  - `ICEBERG` (DBR 14.3+): Apache Iceberg table format
-  - `COMMENT_ON_COLUMN` (DBR 16.1+): Modern column comment syntax
-  - `JSON_COLUMN_METADATA` (DBR 16.2+): Efficient metadata retrieval
+- **Supported Capabilities**: see [`docs/dbr-capability-system.md`](docs/dbr-capability-system.md) for the canonical list (each capability's minimum DBR version and SQL-warehouse support). The authoritative source is the `DBRCapability` enum and `CAPABILITY_SPECS` in `dbr_capabilities.py`; the doc mirrors them in human-readable form.
 - **Usage in Code**:
 
   ```python
@@ -232,6 +227,7 @@ DatabricksAdapter (impl.py)
   1. Add to `DBRCapability` enum
   2. Add `CapabilitySpec` with version requirements
   3. Use `has_capability()` or `require_capability()` in code
+  4. Update `docs/dbr-capability-system.md` (the human-readable mirror of the enum/specs) whenever you add, remove, or change a capability or its version/SQL-warehouse support
 - **Important**: Each compute resource (identified by `http_path`) maintains its own capability cache
 
 #### Connection Management (`connections.py`)

--- a/docs/dbr-capability-system.md
+++ b/docs/dbr-capability-system.md
@@ -20,6 +20,7 @@ Instead of magic version numbers, features are identified by clear names:
 - `JSON_COLUMN_METADATA` - Efficient column metadata retrieval (DBR 16.2+)
 - `REPLACE_ON` - Modern REPLACE ON syntax for incremental loads (DBR 17.1+)
 - `STREAMING_TABLE_JSON_METADATA` - Streaming table metadata support (DBR 17.1+)
+- `DESCRIBE_TABLE_EXTENDED_AS_JSON` - `DESCRIBE TABLE EXTENDED ... AS JSON` for relation metadata (DBR 17.3+)
 
 ### 🔧 Automatic Detection
 The system automatically detects:
@@ -71,6 +72,7 @@ The system automatically handles feature availability based on your compute:
 | `JSON_COLUMN_METADATA` | DBR 16.2 | ✅ | Efficient metadata retrieval |
 | `REPLACE_ON` | DBR 17.1 | ✅ | REPLACE ON syntax for incremental loads |
 | `STREAMING_TABLE_JSON_METADATA` | DBR 17.1 | ❌ | Streaming table metadata (coming soon) |
+| `DESCRIBE_TABLE_EXTENDED_AS_JSON` | DBR 17.3 | ✅ | `DESCRIBE TABLE EXTENDED ... AS JSON` for relation metadata |
 
 ## Multi-Compute Scenarios
 
@@ -97,8 +99,7 @@ Each compute resource maintains its own capability cache, ensuring features are 
 
 If you encounter an error like:
 ```
-DbtConfigError: Iceberg table format requires DBR 14.3+.
-Current connection does not meet this requirement.
+DbtConfigError: iceberg requires DBR 14.3+. Current connection does not meet this requirement.
 ```
 
 **Solutions:**


### PR DESCRIPTION
## Summary

`docs/dbr-capability-system.md` had drifted from the implementation in `dbt/adapters/databricks/dbr_capabilities.py` (last substantive doc edit was the 1.11.0 prep). This brings it back in line and removes a duplicate copy of the capability list from `AGENTS.md`.

### `docs/dbr-capability-system.md`
- Add the missing **`DESCRIBE_TABLE_EXTENDED_AS_JSON`** capability (DBR 17.3+, SQL-warehouse supported) to both the named-capabilities list and the Supported Capabilities table — it exists in the `DBRCapability` enum / `CAPABILITY_SPECS` but was absent from the doc.
- Fix the troubleshooting error example to match the actual string raised by `require_capability` (`<capability> requires DBR X.Y+. Current connection does not meet this requirement.`).

### `AGENTS.md`
- Stop duplicating the capability inventory. `AGENTS.md` now points to `docs/dbr-capability-system.md` as the human-readable mirror, and notes the authoritative source is the `DBRCapability` enum + `CAPABILITY_SPECS`.
- Add a step to **'Adding New Capabilities'** to update the doc whenever a capability or its version / SQL-warehouse support changes.

Net layering: **code (enum/specs) = authoritative → `docs/dbr-capability-system.md` = human-readable mirror → `AGENTS.md` = pointer.** One place to maintain instead of three.

Docs-only; no code paths touched.