### PR TITLE
fix: don't reconcile constraints on incremental runs when contract is unenforced

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Add `skip_optimize` model config to opt out of the post-materialization `OPTIMIZE` call without dropping `zorder` / `liquid_clustered_by` / `auto_liquid_cluster` from the table definition. Useful when `OPTIMIZE` is delegated to Predictive Optimization or scheduled out of band. Complements the existing run-wide `DATABRICKS_SKIP_OPTIMIZE` var by allowing project-, folder-, or model-level opt-out via standard dbt config inheritance ([#703](https://github.com/databricks/dbt-databricks/issues/703)).
 
 ### Fixes
+- Stop dropping existing constraints on incremental runs when `contract.enforced` is `false` ([#1557](https://github.com/databricks/dbt-databricks/pull/1557))
 - Honor the `expression` field on `primary_key` constraints on the V1 materialization path. A primary key declared with `expression: RELY` (or any trailing clause) previously had its expression silently dropped. ([#1551](https://github.com/databricks/dbt-databricks/pull/1551))
 - Apply column-level `databricks_tags` for incremental models on the V1 materialization path ([#1520](https://github.com/databricks/dbt-databricks/pull/1520) closes [#1307](https://github.com/databricks/dbt-databricks/issues/1307))
 - Raise a `DbtRuntimeError` when a Python model job run terminates with a non-success `result_state` (e.g. `FAILED`/`TIMEDOUT`) instead of returning silently ([#1477](https://github.com/databricks/dbt-databricks/pull/1477))

--- a/dbt/include/databricks/macros/relations/table/alter.sql
+++ b/dbt/include/databricks/macros/relations/table/alter.sql
@@ -28,7 +28,9 @@
       {% if column_tags %}
         {{ apply_column_tags(target_relation, column_tags) }}
       {% endif %}
-      {% if constraints %}
+      {#-- Reconcile constraints only when the contract is enforced. --#}
+      {% set contract_config = config.get('contract') %}
+      {% if constraints and contract_config and contract_config.enforced %}
         {{ apply_constraints(target_relation, constraints) }}
       {% endif %}
       {% if column_masks %}

--- a/tests/functional/adapter/constraints/fixtures.py
+++ b/tests/functional/adapter/constraints/fixtures.py
@@ -410,3 +410,32 @@ incremental_rely_pk_child_sql = """
 
 select 1 as parent_n, 10 as child_id
 """
+
+
+def _incremental_contract_off_pk_schema_yml(enforced):
+    return f"""
+version: 2
+models:
+  - name: contract_off_pk
+    config:
+      materialized: incremental
+      unique_key: id
+      on_schema_change: append_new_columns
+      contract:
+        enforced: {enforced}
+    columns:
+      - name: id
+        data_type: int
+        constraints:
+          - type: not_null
+          - type: primary_key
+            name: pk_contract_off
+"""
+
+
+incremental_contract_off_pk_enforced_schema_yml = _incremental_contract_off_pk_schema_yml("true")
+incremental_contract_off_pk_unenforced_schema_yml = _incremental_contract_off_pk_schema_yml("false")
+
+incremental_contract_off_pk_sql = """
+select 1 as id
+"""

--- a/tests/functional/adapter/constraints/test_constraints.py
+++ b/tests/functional/adapter/constraints/test_constraints.py
@@ -10,6 +10,7 @@ from dbt.tests.adapter.constraints.test_constraints import (
 )
 
 from tests.functional.adapter.constraints import fixtures as override_fixtures
+from tests.functional.adapter.fixtures import RerunSafeMixin
 
 
 class DatabricksConstraintsBase:
@@ -258,3 +259,50 @@ class TestIncrementalRelyConstraintReconciliation:
         util.run_dbt(["run", "--select", "rely_parent"])
 
         assert "fk_rely_child" in self._foreign_key_names(project)
+
+
+@pytest.mark.skip_profile("databricks_cluster")
+class TestIncrementalContractOffPreservesConstraints(RerunSafeMixin):
+    """Constraints are reconciled only when the contract is enforced; when unenforced, a no-op."""
+
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {"flags": {"use_materialization_v2": True}}
+
+    @pytest.fixture(scope="class")
+    def relations_to_reset(self):
+        return ("contract_off_pk",)
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "schema.yml": override_fixtures.incremental_contract_off_pk_enforced_schema_yml,
+            "contract_off_pk.sql": override_fixtures.incremental_contract_off_pk_sql,
+        }
+
+    def _primary_key_names(self, project):
+        rows = project.run_sql(
+            """
+            SELECT constraint_name
+            FROM {database}.information_schema.table_constraints
+            WHERE table_schema = '{schema}' AND constraint_type = 'PRIMARY KEY'
+            """,
+            fetch="all",
+        )
+        return {row[0] for row in rows}
+
+    def test_contract_off_incremental_preserves_existing_pk(self, project):
+        # Run 1 (contract enforced): the primary key is created server-side.
+        util.run_dbt(["run"])
+        assert "pk_contract_off" in self._primary_key_names(project)
+
+        # Flip contract.enforced to false, then run the incremental merge again.
+        util.write_file(
+            override_fixtures.incremental_contract_off_pk_unenforced_schema_yml,
+            "models",
+            "schema.yml",
+        )
+        util.run_dbt(["run"])
+
+        # The existing PK must be left untouched, not silently dropped.
+        assert "pk_contract_off" in self._primary_key_names(project)


### PR DESCRIPTION
## What
Gate constraint reconciliation in `apply_config_changeset` on `contract.enforced`. With the contract off, constraints are now a no-op (matching V1).

## Why
On `contract.enforced: false` the model contributes no constraints (the [#1342](https://github.com/databricks/dbt-databricks/issues/1342) guard), so the diff is all-unset and existing constraints were dropped via `ALTER TABLE … DROP CONSTRAINT … CASCADE` (taking dependent FKs) on the next incremental run.

## Tests
`TestIncrementalContractOffPreservesConstraints`: enforce → flip off → re-run incrementally → PK survives (checked via `information_schema`). Fails on `main`, passes here. Contract-on reconciliation (`TestIncrementalConstraintsColumnsEqual`) unaffected.

## Checklist
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md`
