### PR TITLE
test: run parse-offline auth guards on all SDK versions

### DIFF
--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -5,20 +5,11 @@ from unittest import mock
 
 import keyring.backend
 import pytest
-from databricks.sdk import config as _sdk_config
 
 from dbt.adapters.databricks.credentials import (
     DatabricksCredentialManager,
     DatabricksCredentials,
 )
-
-# databricks-sdk >=0.103 added a network probe to Config(); on older SDKs
-# this symbol doesn't exist and the lazy `_ensure_config` path is unnecessary.
-_REQUIRES_LAZY_CONFIG = pytest.mark.skipif(
-    not hasattr(_sdk_config, "get_host_metadata"),
-    reason="lazy _ensure_config is only required when Config() does a network probe",
-)
-
 
 _COMMON_KWARGS = {
     "host": "yourorg.databricks.com",
@@ -28,7 +19,6 @@ _COMMON_KWARGS = {
 }
 
 
-@_REQUIRES_LAZY_CONFIG
 class TestParseTimeIsOffline:
     """`dbt parse/list/compile` must stay fully offline. Building
     `DatabricksCredentials` is on that path, so for every supported auth
@@ -65,7 +55,6 @@ class TestParseTimeIsOffline:
             mock_config.assert_not_called()
 
 
-@_REQUIRES_LAZY_CONFIG
 class TestEnsureConfigTriggersTheRightAuth:
     """Connect-time counterpart to TestParseTimeIsOffline: when something
     actually does need the config (e.g. opening a connection), `_ensure_config`


### PR DESCRIPTION
### Description

`TestParseTimeIsOffline` and `TestEnsureConfigTriggersTheRightAuth` were gated on the `databricks-sdk>=0.103` host-metadata probe, so they were **skipped on the min-deps floor** (sdk 0.68.0). That gate is wrong for non-PAT auth: building a non-PAT `Config` does OIDC discovery — a network call on *every* SDK version (the path #940 hit on 1.10.x), not just probe-carrying ones. Drop the gate and its now-dead marker/import so both guards run on all SDK versions.

Test-only, pure deletion (−11 lines). Verified passing on sdk 0.117 and on the floor sdk 0.68.0 (skipped there before).

Context: #940 — the bug itself shipped fixed in 1.12.1 (#1474); this just hardens the regression guard.

### Checklist
- [x] Ran in development; guards pass on current and min-deps SDK
- [x] Test-only change
- [ ] `CHANGELOG.md` — n/a (test-only, not user-facing)
