### PR TITLE
fix: rename dead `skip_non_matched_step` config to `skip_not_matched_step`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Add `skip_optimize` model config to opt out of the post-materialization `OPTIMIZE` call without dropping `zorder` / `liquid_clustered_by` / `auto_liquid_cluster` from the table definition. Useful when `OPTIMIZE` is delegated to Predictive Optimization or scheduled out of band. Complements the existing run-wide `DATABRICKS_SKIP_OPTIMIZE` var by allowing project-, folder-, or model-level opt-out via standard dbt config inheritance ([#703](https://github.com/databricks/dbt-databricks/issues/703)).
 
 ### Fixes
+- Recognize the `skip_not_matched_step` merge config in the adapter config schema. It was previously declared with a typo (`skip_non_matched_step`); the merge macro already read the correct key, so merge behavior is unchanged ([#1562](https://github.com/databricks/dbt-databricks/pull/1562)).
 - Honor the `expression` field on `primary_key` constraints on the V1 materialization path. A primary key declared with `expression: RELY` (or any trailing clause) previously had its expression silently dropped. ([#1551](https://github.com/databricks/dbt-databricks/pull/1551))
 - Apply column-level `databricks_tags` for incremental models on the V1 materialization path ([#1520](https://github.com/databricks/dbt-databricks/pull/1520) closes [#1307](https://github.com/databricks/dbt-databricks/issues/1307))
 - Raise a `DbtRuntimeError` when a Python model job run terminates with a non-success `result_state` (e.g. `FAILED`/`TIMEDOUT`) instead of returning silently ([#1477](https://github.com/databricks/dbt-databricks/pull/1477))

--- a/dbt/adapters/databricks/impl.py
+++ b/dbt/adapters/databricks/impl.py
@@ -207,7 +207,7 @@ class DatabricksConfig(AdapterConfig):
     zorder: Optional[Union[list[str], str]] = None
     skip_optimize: Optional[bool] = None
     unique_tmp_table_suffix: bool = False
-    skip_non_matched_step: Optional[bool] = None
+    skip_not_matched_step: Optional[bool] = None
     skip_matched_step: Optional[bool] = None
     matched_condition: Optional[str] = None
     not_matched_condition: Optional[str] = None

--- a/tests/unit/test_adapter.py
+++ b/tests/unit/test_adapter.py
@@ -1,5 +1,6 @@
 import re
 import warnings
+from dataclasses import fields
 from multiprocessing import get_context
 from typing import Any, Optional
 from unittest.mock import Mock, patch
@@ -26,6 +27,7 @@ from dbt.adapters.databricks.credentials import (
 )
 from dbt.adapters.databricks.impl import (
     DESCRIBE_TABLE_EXTENDED_MACRO_NAME,
+    DatabricksConfig,
     DatabricksRelationInfo,
     IncrementalTableAPI,
     MaterializedViewAPI,
@@ -47,6 +49,13 @@ from dbt.adapters.databricks.relation_configs.tags import TagsConfig, TagsProces
 from dbt.adapters.databricks.relation_configs.view import ViewConfig
 from dbt.adapters.databricks.utils import check_not_found_error
 from tests.unit.utils import config_from_parts_or_dicts
+
+
+def test_databricks_config_declares_skip_not_matched_step():
+    # Must match the key the merge macro reads (`skip_not_matched_step`), not the typo.
+    names = {f.name for f in fields(DatabricksConfig)}
+    assert "skip_not_matched_step" in names
+    assert "skip_non_matched_step" not in names
 
 
 def _catalog_row(column_name: str) -> dict:


### PR DESCRIPTION
### Description

`DatabricksConfig` declared the merge config field as `skip_non_matched_step` ("non"), but the incremental `merge` strategy macro has always read `skip_not_matched_step` ("not") (`dbt/include/databricks/macros/materializations/incremental/strategies.sql`). The declared field was therefore dead, and the key the macro actually consumes was missing from the adapter's config schema.

This renames the field to `skip_not_matched_step` so the adapter advertises the exact key the macro reads. The macro already read the correct key, so **merge behavior is unchanged** — this only fixes which key the adapter recognizes as valid (e.g. for dbt-core's jsonschema config validation). No backward-compat shim is needed: the typo'd key never had any effect, so nothing depends on it.

Testing:
- New unit test `tests/unit/test_adapter.py::test_databricks_config_declares_skip_not_matched_step` (red before the rename, green after).
- Existing `TestSkipNotMatched` / `TestSkipMatched` functional tests pass against a SQL warehouse, confirming merge behavior is unchanged.

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the topmost `(TBD)` section.
