### PR TITLE
test: Add functional tests pinning current v1/v2 materialization behavior

### DIFF
--- a/tests/functional/adapter/column_masks/fixtures.py
+++ b/tests/functional/adapter/column_masks/fixtures.py
@@ -54,3 +54,10 @@ models:
       - name: password
         data_type: string
 """
+
+# Python model returning the same id/password shape, for masking under each flag.
+base_model_py = """
+def model(dbt, session):
+    dbt.config(materialized="table")
+    return session.createDataFrame([("abc123", "password123")], ["id", "password"])
+"""

--- a/tests/functional/adapter/column_masks/test_column_mask.py
+++ b/tests/functional/adapter/column_masks/test_column_mask.py
@@ -2,13 +2,32 @@ import pytest
 from dbt.tests.util import run_dbt, write_file
 
 from tests.functional.adapter.column_masks.fixtures import (
+    base_model_py,
     base_model_sql,
     base_model_streaming_table,
     column_mask_seed,
     model,
     model_with_extra_args,
 )
-from tests.functional.adapter.fixtures import MaterializationV2Mixin
+from tests.functional.adapter.fixtures import MaterializationV1Mixin, MaterializationV2Mixin
+
+
+def _create_password_mask(project):
+    project.run_sql(
+        f"CREATE OR REPLACE FUNCTION {project.database}.{project.test_schema}."
+        "password_mask(password STRING) RETURNS STRING RETURN '*****';"
+    )
+
+
+def _column_masks(project, table_name):
+    return project.run_sql(
+        f"""
+        SELECT column_name
+        FROM {project.database}.information_schema.column_masks
+        WHERE table_schema = '{project.test_schema}' AND table_name = '{table_name}'
+        """,
+        fetch="all",
+    )
 
 
 class ColumnMaskMixin(MaterializationV2Mixin):
@@ -149,3 +168,67 @@ class TestMaterializedViewColumnMaskFailure(MaterializationV2Mixin):
     def test_view_column_mask_failure(self, project):
         result = run_dbt(["run"], expect_pass=False)
         assert "Column masks are not yet supported" in result.results[0].message
+
+
+@pytest.mark.skip_profile("databricks_cluster")
+class TestColumnMaskNotAppliedAtCreateV1(MaterializationV1Mixin):
+    """v1 applies no column mask at create (the headline v1/v2 fork): the value
+    round-trips unmasked and information_schema.column_masks is empty for the relation."""
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"base_model.sql": base_model_sql, "schema.yml": model}
+
+    def test_v1_applies_no_column_mask_at_create(self, project):
+        _create_password_mask(project)
+        run_dbt(["run"])
+        assert _column_masks(project, "base_model") == [], "v1 should apply no mask at create"
+        result = project.run_sql("SELECT id, password FROM base_model", fetch="one")
+        assert result[1] == "password123"
+
+
+@pytest.mark.python
+@pytest.mark.skip_profile("databricks_cluster")
+class TestPythonColumnMaskV1:
+    """Python model column mask under v1 (saveAsTable): no mask applied."""
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"base_model.py": base_model_py, "schema.yml": model}
+
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {
+            "flags": {"use_materialization_v2": False},
+            "models": {"+submission_method": "serverless_cluster"},
+        }
+
+    def test_v1_python_applies_no_mask(self, project):
+        _create_password_mask(project)
+        run_dbt(["run"])
+        assert _column_masks(project, "base_model") == [], "v1 Python should apply no mask"
+        assert project.run_sql("SELECT password FROM base_model", fetch="one")[0] == "password123"
+
+
+@pytest.mark.python
+@pytest.mark.skip_profile("databricks_cluster")
+class TestPythonColumnMaskV2:
+    """Python model column mask under v2 (create_table_at): mask applied."""
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"base_model.py": base_model_py, "schema.yml": model}
+
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {
+            "flags": {"use_materialization_v2": True},
+            "models": {"+submission_method": "serverless_cluster"},
+        }
+
+    def test_v2_python_applies_mask(self, project):
+        _create_password_mask(project)
+        run_dbt(["run"])
+        masks = _column_masks(project, "base_model")
+        assert len(masks) == 1 and masks[0][0] == "password", f"v2 Python should mask, got {masks}"
+        assert project.run_sql("SELECT password FROM base_model", fetch="one")[0] == "*****"

--- a/tests/functional/adapter/constraints/fixtures.py
+++ b/tests/functional/adapter/constraints/fixtures.py
@@ -410,3 +410,26 @@ incremental_rely_pk_child_sql = """
 
 select 1 as parent_n, 10 as child_id
 """
+
+check_constraint_model_sql = """
+{{ config(materialized='table') }}
+select 1 as id, 'blue' as color
+"""
+
+check_constraint_schema_yml = """
+version: 2
+models:
+  - name: check_constraint_model
+    config:
+      contract:
+        enforced: true
+    constraints:
+      - type: check
+        name: id_is_positive
+        expression: id > 0
+    columns:
+      - name: id
+        data_type: int
+      - name: color
+        data_type: string
+"""

--- a/tests/functional/adapter/constraints/test_constraints_v2.py
+++ b/tests/functional/adapter/constraints/test_constraints_v2.py
@@ -90,3 +90,27 @@ class TestTableConstraintsRollback(BaseDatabricksConstraintHandling):
             "my_model.sql": override_fixtures.my_model_sql,
             "constraints_schema.yml": override_fixtures.constraints_yml,
         }
+
+
+@pytest.mark.skip_profile("databricks_cluster")
+class TestCheckConstraintReadbackV2(DatabricksConstraintsBaseV2):
+    """Under v2 a contract CHECK constraint is observable as a delta.constraints.* property."""
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "check_constraint_model.sql": override_fixtures.check_constraint_model_sql,
+            "schema.yml": override_fixtures.check_constraint_schema_yml,
+        }
+
+    def test_check_constraint_present(self, project):
+        util.run_dbt(["run"])
+        rows = project.run_sql(
+            "show tblproperties {database}.{schema}.check_constraint_model", fetch="all"
+        )
+        constraints = {
+            row.key: row.value for row in rows if row.key.startswith("delta.constraints.")
+        }
+        assert constraints.get("delta.constraints.id_is_positive") == "id > 0", (
+            f"CHECK constraint not observable under v2; delta.constraints = {constraints}"
+        )

--- a/tests/functional/adapter/incremental/fixtures.py
+++ b/tests/functional/adapter/incremental/fixtures.py
@@ -1291,3 +1291,13 @@ models:
             name: fk
             warn_unenforced: false
 """
+
+partitioned_incremental_initial_sql = """
+{{ config(materialized='incremental', incremental_strategy='append', partition_by='part_a') }}
+select 1 as id, 'x' as part_a, 'y' as part_b
+"""
+
+partitioned_incremental_changed_sql = """
+{{ config(materialized='incremental', incremental_strategy='append', partition_by='part_b') }}
+select 2 as id, 'x' as part_a, 'y' as part_b
+"""

--- a/tests/functional/adapter/incremental/test_incremental_partition_reconcile.py
+++ b/tests/functional/adapter/incremental/test_incremental_partition_reconcile.py
@@ -1,0 +1,50 @@
+"""partition_by is fixed at create and not reconciled on an incremental merge/append run
+on either flag path (a layout change requires --full-refresh). Liquid clustering, by
+contrast, IS reconciled (see test_incremental_clustering)."""
+
+import pytest
+from dbt.tests import util
+
+from tests.functional.adapter.fixtures import (
+    MaterializationV1Mixin,
+    MaterializationV2Mixin,
+    RerunSafeMixin,
+)
+from tests.functional.adapter.incremental import fixtures
+
+
+def _partition_columns(project, identifier):
+    rows = project.run_sql(f"describe detail {{database}}.{{schema}}.{identifier}", fetch="all")
+    return rows[0]["partitionColumns"]
+
+
+class _PartitionNotReconciledBase(RerunSafeMixin):
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"part_model.sql": fixtures.partitioned_incremental_initial_sql}
+
+    @pytest.fixture(scope="class")
+    def relations_to_reset(self):
+        return ("part_model",)
+
+    def _assert_partition_unchanged(self, project):
+        util.run_dbt(["run"])
+        assert _partition_columns(project, "part_model") == ["part_a"]
+        util.write_file(fixtures.partitioned_incremental_changed_sql, "models", "part_model.sql")
+        util.run_dbt(["run"])  # incremental append run, no --full-refresh
+        after = _partition_columns(project, "part_model")
+        assert after == ["part_a"], (
+            f"partition_by must not be reconciled on an incremental append run, got {after}"
+        )
+
+
+@pytest.mark.skip_profile("databricks_cluster")
+class TestPartitionNotReconciledV1(_PartitionNotReconciledBase, MaterializationV1Mixin):
+    def test_partition_not_reconciled(self, project):
+        self._assert_partition_unchanged(project)
+
+
+@pytest.mark.skip_profile("databricks_cluster")
+class TestPartitionNotReconciledV2(_PartitionNotReconciledBase, MaterializationV2Mixin):
+    def test_partition_not_reconciled(self, project):
+        self._assert_partition_unchanged(project)

--- a/tests/functional/adapter/incremental/test_incremental_persist_docs.py
+++ b/tests/functional/adapter/incremental/test_incremental_persist_docs.py
@@ -62,3 +62,37 @@ class TestIncrementalPersistDocsV2(TestIncrementalPersistDocs):
                 }
             },
         }
+
+
+class TestIncrementalColumnCommentReconcileSubkeyV1(RerunSafeMixin):
+    """v1 reconciles column comments on the persist_docs.columns sub-key, independent of
+    persist_docs.relation (the typed path keys this reconcile on .relation instead)."""
+
+    @pytest.fixture(scope="class")
+    def relations_to_reset(self):
+        return ("merge_update_columns_sql",)
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "merge_update_columns_sql.sql": fixtures.merge_update_columns_sql,
+            "schema.yml": fixtures.no_comment_schema,
+        }
+
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {
+            "flags": {"use_materialization_v2": False},
+            "models": {"test": {"+persist_docs": {"relation": False, "columns": True}}},
+        }
+
+    def test_column_comment_reconciles_on_columns_subkey(self, project):
+        util.run_dbt(["run"])
+        util.write_file(fixtures.comment_schema, "models", "schema.yml")
+        util.run_dbt(["run"])  # incremental merge run
+        results = project.run_sql(
+            f"describe table {project.database}.{project.test_schema}.merge_update_columns_sql",
+            fetch="all",
+        )
+        assert results[0][2] == "This is the id column"
+        assert results[1][2] == "This is the msg column"

--- a/tests/functional/adapter/persist_docs/fixtures.py
+++ b/tests/functional/adapter/persist_docs/fixtures.py
@@ -33,3 +33,18 @@ seeds:
       - name: name
         description: 'A name column'
 """
+
+gate_model_sql = """
+{{ config(materialized='table') }}
+select 1 as id, 'alice' as name
+"""
+
+gate_model_schema = """
+version: 2
+models:
+  - name: gate_model
+    description: A described relation
+    columns:
+      - name: id
+        description: The id column description
+"""

--- a/tests/functional/adapter/persist_docs/test_persist_docs.py
+++ b/tests/functional/adapter/persist_docs/test_persist_docs.py
@@ -370,3 +370,52 @@ models:
                 assert column.comment and column.comment.startswith("Account ID column")
             elif column.column.lower() == "user_name":
                 assert column.comment and column.comment.startswith("User name column")
+
+
+class TestPersistDocsColumnsGateV1:
+    """v1 gates inline column COMMENT on persist_docs.columns.
+
+    With {relation: true, columns: false} a v1 model with a column description gets no
+    column comment, where the typed create path emits it unconditionally.
+    """
+
+    @pytest.fixture(scope="class", autouse=True)
+    def setUp(self, project):
+        util.run_dbt(["run"])
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "gate_model.sql": override_fixtures.gate_model_sql,
+            "schema.yml": override_fixtures.gate_model_schema,
+        }
+
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {
+            "flags": {"use_materialization_v2": False},
+            "models": {"test": {"+persist_docs": {"relation": True, "columns": False}}},
+        }
+
+    @pytest.fixture(scope="class")
+    def table_relation(self, project):
+        return DatabricksRelation.create(
+            database=project.database,
+            schema=project.test_schema,
+            identifier="gate_model",
+            type="table",
+        )
+
+    def test_column_comment_suppressed_when_columns_false(self, adapter, table_relation):
+        results = util.run_sql_with_adapter(
+            adapter, f"describe extended {table_relation}", fetch="all"
+        )
+        _, columns = adapter.parse_describe_extended(
+            table_relation, Table(results, ["col_name", "data_type", "comment"])
+        )
+        id_columns = [c for c in columns if c.column == "id"]
+        assert id_columns, "id column missing from describe output"
+        assert not id_columns[0].comment, (
+            f"v1 must suppress column comment when persist_docs.columns is false, "
+            f"got {id_columns[0].comment!r}"
+        )

--- a/tests/functional/adapter/relations/fixtures.py
+++ b/tests/functional/adapter/relations/fixtures.py
@@ -1,0 +1,19 @@
+flip_relation_as_table_sql = """
+{{ config(materialized='table') }}
+select 1 as id
+"""
+
+flip_relation_as_view_sql = """
+{{ config(materialized='view') }}
+select 1 as id
+"""
+
+safer_ops_table_sql = """
+{{ config(materialized='table') }}
+select 1 as id
+"""
+
+safer_ops_incremental_sql = """
+{{ config(materialized='incremental', incremental_strategy='append') }}
+select 1 as id
+"""

--- a/tests/functional/adapter/relations/test_changing_relation_type.py
+++ b/tests/functional/adapter/relations/test_changing_relation_type.py
@@ -1,11 +1,64 @@
 import pytest
+from dbt.tests import util
 from dbt.tests.adapter.relations.test_changing_relation_type import (
     BaseChangeRelationTypeValidator,
 )
 
+from tests.functional.adapter.fixtures import (
+    MaterializationV1Mixin,
+    MaterializationV2Mixin,
+    RerunSafeMixin,
+)
+from tests.functional.adapter.relations import fixtures
+
 
 class TestChangeRelationTypesDatabricks(BaseChangeRelationTypeValidator):
     pass
+
+
+class _TableToViewBase(RerunSafeMixin):
+    """Materialize a model as a table, then switch it to a view WITHOUT --full-refresh.
+
+    There is no handle_existing_table override in the adapter, so neither path raises; both
+    drop/convert the table to a view. This pins that server-observable outcome on each flag.
+    """
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"flip_relation.sql": fixtures.flip_relation_as_table_sql}
+
+    @pytest.fixture(scope="class")
+    def relations_to_reset(self):
+        return ("flip_relation",)
+
+    def _relation_type(self, project):
+        with project.adapter.connection_named("__test_check"):
+            relation = project.adapter.get_relation(
+                database=project.database,
+                schema=project.test_schema,
+                identifier="flip_relation",
+            )
+        return relation.type if relation is not None else None
+
+    def _materialize_table_then_view(self, project):
+        util.run_dbt(["run"])
+        assert self._relation_type(project) == "table"
+        util.write_file(fixtures.flip_relation_as_view_sql, "models", "flip_relation.sql")
+        util.run_dbt(["run"])  # no --full-refresh
+
+
+@pytest.mark.skip_profile("databricks_cluster")
+class TestTableToViewWithoutFullRefreshV1(_TableToViewBase, MaterializationV1Mixin):
+    def test_table_converted_to_view(self, project):
+        self._materialize_table_then_view(project)
+        assert self._relation_type(project) == "view"
+
+
+@pytest.mark.skip_profile("databricks_cluster")
+class TestTableToViewWithoutFullRefreshV2(_TableToViewBase, MaterializationV2Mixin):
+    def test_table_converted_to_view(self, project):
+        self._materialize_table_then_view(project)
+        assert self._relation_type(project) == "view"
 
 
 @pytest.mark.skip_profile("databricks_uc_cluster", "databricks_uc_sql_endpoint")

--- a/tests/functional/adapter/relations/test_safe_relation_operations.py
+++ b/tests/functional/adapter/relations/test_safe_relation_operations.py
@@ -1,0 +1,74 @@
+"""Server-observable behavior of use_safer_relation_operations.
+
+* The staging-swap mints a new UC object on each replace (the Delta id changes), which
+  breaks history/lineage.
+* incremental.sql reads the config with `| as_bool`, so a YAML string "false" is correctly
+  treated as False (in-place, stable Delta id).
+"""
+
+import pytest
+from dbt.tests import util
+
+from tests.functional.adapter.fixtures import MaterializationV2Mixin, RerunSafeMixin
+from tests.functional.adapter.relations import fixtures
+
+
+def _describe_detail(project, identifier):
+    rows = project.run_sql(f"describe detail {{database}}.{{schema}}.{identifier}", fetch="all")
+    return rows[0]
+
+
+@pytest.mark.skip_profile("databricks_cluster")
+class TestSaferOpsMintsNewObject(RerunSafeMixin, MaterializationV2Mixin):
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"safer_ops_model.sql": fixtures.safer_ops_table_sql}
+
+    @pytest.fixture(scope="class")
+    def relations_to_reset(self):
+        return ("safer_ops_model",)
+
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {
+            "flags": {"use_materialization_v2": True},
+            "models": {"+use_safer_relation_operations": True},
+        }
+
+    def test_replace_mints_new_object(self, project):
+        util.run_dbt(["run"])
+        first_id = _describe_detail(project, "safer_ops_model")["id"]
+        util.run_dbt(["run"])  # second run replaces via staging-swap
+        second_id = _describe_detail(project, "safer_ops_model")["id"]
+        assert first_id != second_id, (
+            "use_safer_relation_operations should mint a new UC object on replace "
+            f"(history broken); Delta id stayed {first_id}"
+        )
+
+
+@pytest.mark.skip_profile("databricks_cluster")
+class TestSaferOpsAsBoolIncremental(RerunSafeMixin, MaterializationV2Mixin):
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"asbool_incremental.sql": fixtures.safer_ops_incremental_sql}
+
+    @pytest.fixture(scope="class")
+    def relations_to_reset(self):
+        return ("asbool_incremental",)
+
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {
+            "flags": {"use_materialization_v2": True},
+            "models": {"+use_safer_relation_operations": "false"},
+        }
+
+    def test_string_false_does_not_swap_on_incremental(self, project):
+        util.run_dbt(["run"])
+        first_id = _describe_detail(project, "asbool_incremental")["id"]
+        util.run_dbt(["run"])
+        second_id = _describe_detail(project, "asbool_incremental")["id"]
+        assert first_id == second_id, (
+            "incremental reads use_safer_relation_operations | as_bool; string 'false' should "
+            f"be False and not swap; Delta id changed {first_id} -> {second_id}"
+        )

--- a/tests/functional/adapter/tblproperties/test_set_tblproperties.py
+++ b/tests/functional/adapter/tblproperties/test_set_tblproperties.py
@@ -1,6 +1,7 @@
 import pytest
 from dbt.tests import util
 
+from tests.functional.adapter.fixtures import MaterializationV2Mixin
 from tests.functional.adapter.tblproperties import fixtures
 
 
@@ -83,3 +84,9 @@ class TestUniformIcebergTblproperties:
 
         assert tblproperties["delta.universalFormat.enabledFormats"] == "iceberg"
         assert tblproperties["delta.enableIcebergCompatV2"] == "true"
+
+
+class TestTblpropertiesV2(TestTblproperties, MaterializationV2Mixin):
+    """tblproperties applied at create on the v2 path (the base class runs under v1)."""
+
+    pass


### PR DESCRIPTION
## What

Adds functional test coverage that pins the current server-observable behavior of both materialization code paths (selected by the `use_materialization_v2` behavior flag), focused on the points where the two paths diverge or where coverage previously existed for only one flag value.

| Area | Added |
| --- | --- |
| Column masks | v1 applies no column mask at create (the existing mask suite is v2-only); Python-model masks under both flags |
| persist_docs | inline column `COMMENT` gated on `persist_docs.columns` at create (v1); incremental column-comment reconcile keyed on the `persist_docs.columns` sub-key (v1) |
| Constraints | a contract `CHECK` constraint is observable via `SHOW TBLPROPERTIES` under v2 |
| Relations | `table` → `view` transition without `--full-refresh`, asserting the resulting relation type (both flags) |
| Incremental | `partition_by` is not reconciled on an incremental run (both flags) |
| Safer ops | `use_safer_relation_operations` mints a new table object on replace; the incremental path reads the flag as a boolean (`as_bool`) |
| tblproperties | applied at create under v2 |

## Notes

- Test-only — no runtime change, so no changelog entry (per the functional-test conventions).
- All assertions are server-observable (`information_schema`, `SHOW TBLPROPERTIES`, `DESCRIBE DETAIL` / `DESCRIBE EXTENDED`, query results); new fixtures live in each section's `fixtures.py`.
- New v1/v2 class variants are added into the existing topical test files; two small new files cover safer-ops (`relations/test_safe_relation_operations.py`) and partition reconcile (`incremental/test_incremental_partition_reconcile.py`).
