### PR TITLE
test: cover copy_into validate and files/pattern conflict

### DIFF
--- a/tests/functional/adapter/copy_into/fixtures.py
+++ b/tests/functional/adapter/copy_into/fixtures.py
@@ -10,6 +10,10 @@ expected_target = """id,name,date
 2,Bob,2022-01-02
 """
 
+expected_target_validate = """id,name,date
+0,Zero,2022-01-01
+"""
+
 source = """id,name,date
 1,Alice,2022-01-01
 2,Bob,2022-01-02
@@ -40,6 +44,12 @@ seeds:
         name: string
         date: string
   - name: expected_target_expression_list
+    config:
+      column_types:
+        id: int
+        name: string
+        date: string
+  - name: expected_target_validate
     config:
       column_types:
         id: int

--- a/tests/functional/adapter/copy_into/test_copy_into.py
+++ b/tests/functional/adapter/copy_into/test_copy_into.py
@@ -13,6 +13,7 @@ class BaseCopyInto:
             "source.csv": fixtures.source,
             "expected_target.csv": fixtures.expected_target,
             "expected_target_expression_list.csv": fixtures.expected_target_expression_list,
+            "expected_target_validate.csv": fixtures.expected_target_validate,
             "seed_schema.yml": fixtures.seed_schema,
         }
 
@@ -83,3 +84,46 @@ copy_options:
         path = self.path(project)
         self.copy_into(path, self.args_formatter)
         util.check_relations_equal(project.adapter, ["target", "expected_target_expression_list"])
+
+
+@pytest.mark.skip_profile("databricks_uc_cluster", "databricks_uc_sql_endpoint")
+class TestCopyIntoValidate(BaseCopyInto):
+    args_formatter = """
+target_table: target
+source: {source_path}
+file_format: parquet
+validate: all
+format_options:
+  mergeSchema: 'true'
+copy_options:
+  mergeSchema: 'true'
+"""
+
+    def test_copy_into_validate_does_not_load(self, project):
+        path = self.path(project)
+        self.copy_into(path, self.args_formatter)
+        util.check_relations_equal(project.adapter, ["target", "expected_target_validate"])
+
+
+@pytest.mark.skip_profile("databricks_uc_cluster", "databricks_uc_sql_endpoint")
+class TestCopyIntoFilesAndPatternConflict(BaseCopyInto):
+    args_formatter = """
+target_table: target
+source: {source_path}
+file_format: parquet
+files:
+  - part-00000.parquet
+pattern: '*.parquet'
+"""
+
+    def test_files_and_pattern_are_mutually_exclusive(self, project):
+        path = self.path(project)
+        util.run_dbt(
+            [
+                "run-operation",
+                "databricks_copy_into",
+                "--args",
+                self.args_formatter.format(source_path=path),
+            ],
+            expect_pass=False,
+        )


### PR DESCRIPTION
### Description

Adds two functional tests for the `databricks_copy_into` macro, covering behaviors the existing suite didn't exercise:

- **`TestCopyIntoValidate`** — a `validate`-only `COPY INTO` validates the source without loading it; the target keeps only its pre-existing row.
- **`TestCopyIntoFilesAndPatternConflict`** — passing both `files` and `pattern` raises a compiler error (the macro treats them as mutually exclusive).

Both subclass the existing `BaseCopyInto` and reuse its `skip_profile("databricks_uc_cluster", "databricks_uc_sql_endpoint")` markers, so — like the current `copy_into` tests — they run on the `databricks_cluster` profile. Verified green there.

No changelog entry: this is test-only with no runtime change.