### PR TITLE
test: cover list_relations_without_caching relation-type classification

### DIFF
--- a/tests/functional/adapter/basic/fixtures.py
+++ b/tests/functional/adapter/basic/fixtures.py
@@ -101,6 +101,16 @@ SELECT named_struct(
 ) AS big_struct;
 """
 
+list_relations_table_sql = """
+{{ config(materialized='table') }}
+select cast(1 as bigint) as id, 'a' as msg
+"""
+
+list_relations_view_sql = """
+{{ config(materialized='view') }}
+select cast(1 as bigint) as id, 'a' as msg
+"""
+
 # Fixtures for testing column capitalization preservation in materialization v2
 mixed_case_columns_sql = """
 {{ config(materialized='table') }}

--- a/tests/functional/adapter/basic/test_list_relations.py
+++ b/tests/functional/adapter/basic/test_list_relations.py
@@ -1,0 +1,51 @@
+import pytest
+from dbt.tests.util import run_dbt
+
+from dbt.adapters.databricks.relation import DatabricksRelationType, DatabricksTableType
+from tests.functional.adapter.basic.fixtures import (
+    list_relations_table_sql,
+    list_relations_view_sql,
+)
+
+
+@pytest.mark.skip_profile("databricks_cluster")
+class TestListRelationsWithoutCaching:
+    """Exercise list_relations_without_caching on Unity Catalog (get_uc_tables)."""
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "list_rel_table.sql": list_relations_table_sql,
+            "list_rel_view.sql": list_relations_view_sql,
+        }
+
+    def test_classifies_table_and_view(self, project):
+        run_dbt(["run"])
+
+        with project.adapter.connection_named("__test"):
+            schema_relation = project.adapter.Relation.create(
+                database=project.database,
+                schema=project.test_schema,
+            )
+            relations = {
+                relation.identifier: relation
+                for relation in project.adapter.list_relations_without_caching(schema_relation)
+            }
+
+        table = relations["list_rel_table"]
+        assert table.type == DatabricksRelationType.Table
+        assert table.databricks_table_type == DatabricksTableType.Managed
+        assert table.is_external_table is False
+        assert table.is_delta is True
+
+        view = relations["list_rel_view"]
+        assert view.type == DatabricksRelationType.View
+        assert view.is_delta is False
+
+    def test_missing_schema_returns_empty(self, project):
+        with project.adapter.connection_named("__test"):
+            absent = project.adapter.Relation.create(
+                database=project.database,
+                schema=f"{project.test_schema}_does_not_exist",
+            )
+            assert project.adapter.list_relations_without_caching(absent) == []


### PR DESCRIPTION
## Description

Adds functional coverage for `list_relations_without_caching` (the UC `get_uc_tables` path), which had no direct test asserting how it classifies relations.

`TestListRelationsWithoutCaching`:
- `test_classifies_table_and_view` — asserts a managed table comes back as `Table` / `Managed` / non-external / Delta, and a view as `View` / non-Delta, from the server-returned relation metadata.
- `test_missing_schema_returns_empty` — asserts an absent schema yields an empty list.

All assertions are server-observable (relation classification returned by the adapter). Verified green on `databricks_uc_sql_endpoint` (2 passed).

Test-only; no changelog entry required.