### PR TITLE
test: pin refresh-schedule interval equality for MV and ST

### DIFF
--- a/tests/functional/adapter/materialized_view_tests/test_schedule_modes.py
+++ b/tests/functional/adapter/materialized_view_tests/test_schedule_modes.py
@@ -121,6 +121,9 @@ class TestMaterializedViewScheduleLifecycle:
         assert refresh.mode.value == "on_update"
         assert refresh.at_most_every is not None
         assert "900" in refresh.at_most_every
+        # '15 MINUTES' comes back as '900 SECOND'; the two must compare equal so an
+        # unchanged re-run produces no spurious schedule diff.
+        assert refresh == RefreshConfig(on_update=True, at_most_every="15 MINUTES")
 
         util.write_file(
             fixtures.materialized_view_with_every("2 HOURS"), "models", "mv_lifecycle.sql"

--- a/tests/functional/adapter/streaming_tables/test_st_schedule_modes.py
+++ b/tests/functional/adapter/streaming_tables/test_st_schedule_modes.py
@@ -121,6 +121,9 @@ class TestStreamingTableScheduleLifecycle:
         assert refresh.mode.value == "on_update"
         assert refresh.at_most_every is not None
         assert "900" in refresh.at_most_every
+        # '15 MINUTES' comes back as '900 SECOND'; the two must compare equal so an
+        # unchanged re-run produces no spurious schedule diff.
+        assert refresh == RefreshConfig(on_update=True, at_most_every="15 MINUTES")
 
         util.write_file(
             fixtures.streaming_table_with_every("2 HOURS"), "models", "st_lifecycle.sql"


### PR DESCRIPTION
## Description

Databricks reads back a `15 MINUTES` refresh interval as `900 SECOND`. The existing schedule-lifecycle tests only asserted `"900" in refresh.at_most_every`, which doesn't guard against the unit normalizing the two forms differently and producing a spurious schedule diff on an unchanged re-run.

Adds an equality assertion — `refresh == RefreshConfig(on_update=True, at_most_every="15 MINUTES")` — to both `TestMaterializedViewScheduleLifecycle` and `TestStreamingTableScheduleLifecycle`, pinning that the parsed config round-trips to the configured interval.

Server-observable (parsed `RefreshConfig` from `describe extended`). Verified green on `databricks_uc_sql_endpoint` (8 passed).

Test-only; no changelog entry required.