### PR TITLE
test: cover view tag-add via ALTER and hive ALTER-VIEW error

### DIFF
--- a/tests/functional/adapter/views/fixtures.py
+++ b/tests/functional/adapter/views/fixtures.py
@@ -40,6 +40,23 @@ models:
       - name: msg
 """
 
+two_tag_schema_yml = """
+version: 2
+models:
+  - name: initial_view
+    description: "This is a view"
+    config:
+      tblproperties:
+        key: value
+      databricks_tags:
+        tag1: value1
+        tag2: value2
+    columns:
+      - name: id
+        description: "This is the id column"
+      - name: msg
+"""
+
 hive_schema_yml = """
 version: 2
 models:

--- a/tests/functional/adapter/views/test_views.py
+++ b/tests/functional/adapter/views/test_views.py
@@ -1,5 +1,6 @@
 import pytest
 from agate import Row
+from dbt.artifacts.schemas.results import RunStatus
 from dbt.tests import util
 
 from tests.functional.adapter.fixtures import RequiresDescribeAsJsonCapabilityMixin
@@ -28,9 +29,8 @@ class BaseUpdateDescription(BaseUpdateView):
             "describe extended {database}.{schema}.initial_view",
             fetch="all",
         )
-        for row in results:
-            if row[0] == "comment":
-                assert row[1] == "This is an updated view"
+        comments = [row[1] for row in results if row[0] == "Comment"]
+        assert "This is an updated view" in comments
 
 
 class BaseUpdateQuery(BaseUpdateView):
@@ -125,6 +125,44 @@ class BaseRemoveTags(BaseUpdateView):
         assert len(results) == 1
         assert results[0][0] == "tag1"
         assert results[0][1] == "value1"
+
+
+class BaseAddTags(BaseUpdateView):
+    def test_view_update_add_tags(self, project):
+        util.run_dbt(["build"])
+        util.write_file(fixtures.two_tag_schema_yml, "models", "schema.yml")
+        util.run_dbt(["run"])
+
+        results = project.run_sql(
+            f"""
+            SELECT TAG_NAME, TAG_VALUE FROM {project.database}.information_schema.table_tags
+            WHERE schema_name = '{project.test_schema}' AND table_name = 'initial_view'
+            ORDER BY TAG_NAME
+            """,
+            fetch="all",
+        )
+
+        assert len(results) == 2
+        assert results[0][0] == "tag1"
+        assert results[0][1] == "value1"
+        assert results[1][0] == "tag2"
+        assert results[1][1] == "value2"
+
+
+@pytest.mark.skip_profile("databricks_cluster")
+class TestUpdateViewViaAlterAddTags(BaseAddTags):
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {
+            "flags": {"use_materialization_v2": True},
+            "models": {
+                "+view_update_via_alter": True,
+                "+persist_docs": {
+                    "relation": True,
+                    "columns": True,
+                },
+            },
+        }
 
 
 @pytest.mark.skip_profile("databricks_cluster")
@@ -466,5 +504,30 @@ class TestHiveUpdateUnsafeReplaceTblproperties(HiveBaseUpdateTblproperties):
                     "relation": True,
                     "columns": True,
                 },
+            },
+        }
+
+
+class HiveViewUpdateViaAlterError(BaseUpdateView):
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"initial_view.sql": fixtures.view_sql, "schema.yml": fixtures.hive_schema_yml}
+
+    def test_view_update_via_alter_errors_on_hive(self, project):
+        util.run_dbt(["build"])
+        # ALTER VIEW is unavailable in the Hive metastore, so the second run must
+        # fail instead of attempting an in-place update.
+        failed = util.run_dbt(["run"], expect_pass=False)
+        assert failed.results[0].status == RunStatus.Error
+
+
+@pytest.mark.skip_profile("databricks_uc_cluster", "databricks_uc_sql_endpoint")
+class TestHiveViewUpdateViaAlterError(HiveViewUpdateViaAlterError):
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {
+            "flags": {"use_materialization_v2": True},
+            "models": {
+                "+view_update_via_alter": True,
             },
         }


### PR DESCRIPTION
## Description

Closes coverage gaps on the view materialization's ALTER path and fixes a vacuous existing assertion.

- **`TestUpdateViewViaAlterAddTags`** — asserts that two `databricks_tags` added on a `view_update_via_alter` run land on the view, read back from `information_schema.table_tags` (mirrors the existing `BaseRemoveTags` pattern).
- **`TestHiveViewUpdateViaAlterError`** — asserts a `view_update_via_alter` model on the Hive metastore **fails (run status `Error`)** rather than silently attempting an in-place update. Asserts only the server-observable failed-run status (no error-message-string check). Runs on the `databricks_cluster` (hive) profile.
- **`BaseUpdateDescription` fix** — the assertion looped for a lowercase `"comment"` key, but `describe extended` emits the view comment under `"Comment"`, so the check never fired. Rewritten to match `"Comment"`, making the description-update assertion load-bearing.

Verified green: 2 passed on `databricks_uc_sql_endpoint`, 1 passed on `databricks_cluster` (hive).

Test-only; no changelog entry required.