### PR TITLE
test: cover seed column_types override and seed-onto-view error

### DIFF
--- a/tests/functional/adapter/simple_seed/fixtures.py
+++ b/tests/functional/adapter/simple_seed/fixtures.py
@@ -511,3 +511,25 @@ INSERT INTO {schema}.seed_expected
         (499,NULL,'ethomasdu@hhs.gov','6.241.88.250','2007-09-14 13:03:34'),
         (500,'Paula','pshawdv@networksolutions.com','123.27.47.249','2003-10-30 21:19:20')
 """
+
+seeds__column_types_csv = """id,rate,amount
+1,1,100
+2,2,200
+3,3,300
+"""
+
+# rate/amount would be inferred as integers; column_types must override them in the CREATE DDL.
+seeds__column_types_schema_yml = """
+version: 2
+seeds:
+  - name: seed_column_types
+    config:
+      column_types:
+        rate: double
+        amount: decimal(10,2)
+"""
+
+seeds__over_view_csv = """id
+1
+2
+"""

--- a/tests/functional/adapter/simple_seed/test_seeds.py
+++ b/tests/functional/adapter/simple_seed/test_seeds.py
@@ -155,3 +155,56 @@ class TestSeedSpecificFormats(DatabricksSetup, BaseSeedSpecificFormats):
 
 class TestSeedSpecificFormatsV2(TestSeedSpecificFormats, MaterializationV2Mixin):
     pass
+
+
+class TestSeedColumnTypes:
+    @pytest.fixture(scope="class")
+    def seeds(self):
+        return {
+            "seed_column_types.csv": fixtures.seeds__column_types_csv,
+            "schema.yml": fixtures.seeds__column_types_schema_yml,
+        }
+
+    def test_column_types_override(self, project):
+        util.run_dbt(["seed"])
+        relation = util.relation_from_name(project.adapter, "seed_column_types")
+        # describe trails a blank row then "# ..." metadata sections; keep only the real columns.
+        described = project.run_sql(f"describe {relation}", fetch="all")
+        column_types = {
+            col_name: data_type
+            for col_name, data_type, *_ in described
+            if col_name and not col_name.startswith("#")
+        }
+        assert column_types["rate"] == "double"
+        assert column_types["amount"] == "decimal(10,2)"
+        row_count = project.run_sql(f"select count(*) from {relation}", fetch="one")[0]
+        assert row_count == 3
+
+
+class TestSeedColumnTypesV2(TestSeedColumnTypes, MaterializationV2Mixin):
+    pass
+
+
+class TestSeedOntoView:
+    @pytest.fixture(scope="class")
+    def seeds(self):
+        return {"seed_over_view.csv": fixtures.seeds__over_view_csv}
+
+    def test_seed_onto_view_is_rejected(self, project):
+        relation = util.relation_from_name(project.adapter, "seed_over_view")
+        project.run_sql(f"create or replace view {relation} as select 1 as id")
+
+        util.run_dbt(["seed"], expect_pass=False)
+
+        # the pre-existing view must be left intact -- the seed must not replace it with a table
+        with project.adapter.connection_named("_check_seed_over_view"):
+            existing = project.adapter.get_relation(
+                database=project.database,
+                schema=project.test_schema,
+                identifier="seed_over_view",
+            )
+        assert existing is not None and existing.is_view
+
+
+class TestSeedOntoViewV2(TestSeedOntoView, MaterializationV2Mixin):
+    pass


### PR DESCRIPTION
## Description

Adds functional-test coverage for two previously-untested `seed` materialization behaviors, on both the V1 and V2 (`use_materialization_v2`) paths:

- **`column_types` override** (`TestSeedColumnTypes` / `TestSeedColumnTypesV2`) — a seed configured with `column_types` should produce a table whose columns carry the overridden types. Asserted server-side via `DESCRIBE` (`rate` → `double`, `amount` → `decimal(10,2)`), plus a row-count check.
- **Seeding onto an existing view is rejected** (`TestSeedOntoView` / `TestSeedOntoViewV2`) — the `create_seed_v1`/`create_seed_v2` guard raises a compiler error. The test asserts the run fails and the pre-existing view is left intact (`get_relation(...).is_view`), i.e. the seed did not silently replace it with a table.

Both new base classes intentionally define no `project_config_update`, so their V2 subclasses genuinely apply `use_materialization_v2` (the dbt-core seed base classes define `project_config_update`, which otherwise shadows the `MaterializationV2Mixin` flag).

## Testing

`hatch run pytest tests/functional/adapter/simple_seed/test_seeds.py -k "ColumnTypes or OntoView"` → **4 passed** against a UC SQL warehouse. The rest of the `simple_seed` suite is unaffected (33 tests collect; a sample pre-existing class re-run green). `ruff` / `ruff-format` / `mypy` pass.

This is a **test-only** change with no runtime impact, so no `CHANGELOG.md` entry is required.