### PR TITLE
test: cover table materialization replace-in-place and view→table conversion

### DIFF
--- a/tests/functional/adapter/basic/fixtures.py
+++ b/tests/functional/adapter/basic/fixtures.py
@@ -101,6 +101,34 @@ SELECT named_struct(
 ) AS big_struct;
 """
 
+# A delta table model whose SELECT changes between runs, so a rerun that merely
+# no-ops (or one that drops and recreates) is distinguishable from an in-place replace.
+rerun_target_initial_sql = """
+{{ config(materialized='table') }}
+select 1 as id, 'first' as msg
+"""
+
+rerun_target_updated_sql = """
+{{ config(materialized='table') }}
+select 2 as id, 'second' as msg
+"""
+
+# A model materialized as a view first, then switched to a table, to exercise the
+# table materialization dropping a non-table relation before creating the table.
+convertible_view_sql = """
+{{ config(materialized='view') }}
+select 1 as id, 'x' as val
+union all
+select 2 as id, 'y' as val
+"""
+
+convertible_table_sql = """
+{{ config(materialized='table') }}
+select 1 as id, 'x' as val
+union all
+select 2 as id, 'y' as val
+"""
+
 # Fixtures for testing column capitalization preservation in materialization v2
 mixed_case_columns_sql = """
 {{ config(materialized='table') }}

--- a/tests/functional/adapter/basic/test_table_materialization.py
+++ b/tests/functional/adapter/basic/test_table_materialization.py
@@ -3,11 +3,77 @@ from dbt.tests import util
 from dbt.tests.adapter.basic.test_table_materialization import BaseTableMaterialization
 
 from tests.functional.adapter.basic import fixtures
-from tests.functional.adapter.fixtures import MaterializationV2Mixin
+from tests.functional.adapter.fixtures import (
+    MaterializationV1Mixin,
+    MaterializationV2Mixin,
+    RerunSafeMixin,
+)
 
 
 class TestTableMat(BaseTableMaterialization):
     pass
+
+
+class BaseTableRerunReplacesInPlace(RerunSafeMixin):
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"rerun_target.sql": fixtures.rerun_target_initial_sql}
+
+    @pytest.fixture(scope="class")
+    def relations_to_reset(self):
+        return ("rerun_target",)
+
+    def test_rerun_replaces_in_place(self, project):
+        util.run_dbt(["run"])
+        history_before = project.run_sql(
+            "describe history {database}.{schema}.rerun_target", fetch="all"
+        )
+
+        util.write_file(fixtures.rerun_target_updated_sql, "models", "rerun_target.sql")
+        util.run_dbt(["run"])
+        history_after = project.run_sql(
+            "describe history {database}.{schema}.rerun_target", fetch="all"
+        )
+
+        # Replacing in place appends to the existing table history; dropping and
+        # recreating would reset it, so the history must have grown across the rerun.
+        assert len(history_after) > len(history_before)
+
+        rows = project.run_sql("select id, msg from {database}.{schema}.rerun_target", fetch="all")
+        assert len(rows) == 1
+        assert rows[0][0] == 2
+        assert rows[0][1] == "second"
+
+
+@pytest.mark.skip_profile("databricks_uc_cluster", "databricks_cluster")
+class TestTableRerunReplacesInPlace(BaseTableRerunReplacesInPlace, MaterializationV1Mixin):
+    pass
+
+
+@pytest.mark.skip_profile("databricks_uc_cluster", "databricks_cluster")
+class TestTableRerunReplacesInPlaceV2(BaseTableRerunReplacesInPlace, MaterializationV2Mixin):
+    pass
+
+
+class TestTableReplacesExistingView(RerunSafeMixin, MaterializationV1Mixin):
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"convertible.sql": fixtures.convertible_view_sql}
+
+    @pytest.fixture(scope="class")
+    def relations_to_reset(self):
+        return ("convertible",)
+
+    def test_view_is_replaced_by_table(self, project):
+        util.run_dbt(["run"])
+        util.check_relation_types(project.adapter, {"convertible": "view"})
+
+        util.write_file(fixtures.convertible_table_sql, "models", "convertible.sql")
+        util.run_dbt(["run"])
+        util.check_relation_types(project.adapter, {"convertible": "table"})
+
+        rows = project.run_sql("select count(*) from {database}.{schema}.convertible", fetch="one")
+        assert rows[0] == 2
 
 
 class TestAllColumnTypesV2(MaterializationV2Mixin):


### PR DESCRIPTION
## Description

Adds functional-test coverage for `table` materialization orchestration paths that were previously untested (verified against a live UC SQL warehouse).

- **Delta rerun replaces in place, not drop+recreate.** For a delta table, the materialization intentionally relies on `CREATE OR REPLACE` and skips the drop branch, so the table stays available during a rebuild. `TestTableRerunReplacesInPlace` (V1) and `TestTableRerunReplacesInPlaceV2` (V2) assert this by checking that the table's `DESCRIBE HISTORY` **grows** across a data-changing rerun — a drop-and-recreate would reset the history — and that the new row values are present. The single growth assertion is robust across V1 (one op per run) and V2 (create-or-replace + insert per run).
- **View → table conversion.** `TestTableReplacesExistingView` materializes a model as a view, switches it to a table, and asserts via `check_relation_types` that the relation type changes `view → table` with the expected rows — exercising the branch that drops a non-table relation before creating the table.

The three classes share a small base and reuse the existing `RerunSafeMixin` / `MaterializationV1Mixin` / `MaterializationV2Mixin`; fixtures live in the section's `fixtures.py`. All assertions are server-observable (`DESCRIBE HISTORY`, `check_relation_types`, query results).

## Checklist

- Tests: 3 new classes, green on `databricks_uc_sql_endpoint`; pre-existing classes in the file unaffected. Delta-history tests are gated with `skip_profile("databricks_uc_cluster", "databricks_cluster")`.
- Changelog: not applicable — test-only change with no runtime impact.