### PR TITLE
test: cover split_part out-of-range index; assert uppercase dateadd value

### DIFF
--- a/tests/functional/adapter/utils/fixture_split_part.py
+++ b/tests/functional/adapter/utils/fixture_split_part.py
@@ -1,0 +1,25 @@
+# split_part boundary cases
+
+# part_number 0 resolves to the first element; an index past the end of the array
+# (positive or negative) resolves to NULL rather than raising, because the macro
+# extracts with get(...) instead of an array subscript.
+models__test_split_part_boundaries_sql = """
+select {{ split_part("'a|b|c'", "'|'", 0) }} as actual, 'a' as expected
+union all
+select {{ split_part("'1|2|3'", "'|'", 0) }} as actual, '1' as expected
+union all
+select {{ split_part("'a|b|c'", "'|'", 5) }} as actual, cast(null as string) as expected
+union all
+select {{ split_part("'a|b|c'", "'|'", -5) }} as actual, cast(null as string) as expected
+"""
+
+
+models__test_split_part_boundaries_yml = """
+version: 2
+models:
+  - name: test_split_part_boundaries
+    data_tests:
+      - assert_equal:
+          actual: actual
+          expected: expected
+"""

--- a/tests/functional/adapter/utils/test_dateadd_uppercase.py
+++ b/tests/functional/adapter/utils/test_dateadd_uppercase.py
@@ -20,3 +20,12 @@ class TestDateAddUppercaseDatepartOnWarehouse:
     @pytest.mark.skip_profile("databricks_uc_cluster", "databricks_cluster")
     def test_uppercase_datepart_compiles_and_runs(self, project):
         util.run_dbt(["run"])
+        ts = project.run_sql("select ts from uppercase_dateadd", fetch="all")[0][0]
+        assert (ts.year, ts.month, ts.day, ts.hour, ts.minute, ts.second) == (
+            2024,
+            1,
+            2,
+            0,
+            0,
+            0,
+        )

--- a/tests/functional/adapter/utils/test_utils.py
+++ b/tests/functional/adapter/utils/test_utils.py
@@ -1,3 +1,5 @@
+import pytest
+from dbt.tests.adapter.utils import base_utils
 from dbt.tests.adapter.utils.test_any_value import BaseAnyValue
 from dbt.tests.adapter.utils.test_array_append import BaseArrayAppend
 from dbt.tests.adapter.utils.test_array_concat import BaseArrayConcat
@@ -28,6 +30,8 @@ from dbt.tests.adapter.utils.test_safe_cast import BaseSafeCast
 from dbt.tests.adapter.utils.test_split_part import BaseSplitPart
 from dbt.tests.adapter.utils.test_string_literal import BaseStringLiteral
 from dbt.tests.adapter.utils.test_validate_sql import BaseValidateSqlMethod
+
+import tests.functional.adapter.utils.fixture_split_part as fixture_split_part
 
 
 class TestAnyValue(BaseAnyValue):
@@ -136,6 +140,19 @@ class TestSafeCast(BaseSafeCast):
 
 class TestSplitPart(BaseSplitPart):
     pass
+
+
+class TestSplitPartBoundaries(base_utils.BaseUtils):
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "test_split_part_boundaries.yml": (
+                fixture_split_part.models__test_split_part_boundaries_yml
+            ),
+            "test_split_part_boundaries.sql": self.interpolate_macro_namespace(
+                fixture_split_part.models__test_split_part_boundaries_sql, "split_part"
+            ),
+        }
 
 
 class TestStringLiteral(BaseStringLiteral):


### PR DESCRIPTION
## Description

`databricks__split_part` differs from `spark__split_part` in exactly one way: it extracts the element with `get(split(...), idx)` instead of an array subscript `split(...)[idx]`. That difference is the reason the override exists — `get()` returns `NULL` for an out-of-range index, whereas the `[]` subscript raises `ARRAY_INDEX_OUT_OF_BOUNDS` under ANSI mode (the Databricks default). This behavior had no functional-test coverage.

This PR adds `TestSplitPartBoundaries`, which asserts:
- `part_number = 0` → first element (the `else part_number` branch, distinct from `> 0`)
- a positive index past the end → `NULL` (no error)
- a negative index past the start → `NULL` (no error)

It also strengthens `TestDateAddUppercaseDatepartOnWarehouse`, which previously asserted only that `dbt run` succeeded. It now additionally verifies the computed timestamp equals `2024-01-02`, so the test proves both that the warehouse `timestampadd` path is selected for an uppercase datepart *and* that it produces the right value.

## Notes

- Tests only; no runtime/adapter changes, so no changelog entry.
- The new test class subclasses dbt-core's `base_utils.BaseUtils` (reusing its null-safe `equals`/`assert_equal`); fixtures live in `fixture_split_part.py`, mirroring the existing `fixture_dateadd.py` pattern.

## Testing

Run against `databricks_uc_sql_endpoint`:
- `TestSplitPartBoundaries::test_build_assert_equal` — passed
- `TestDateAddUppercaseDatepartOnWarehouse::test_uppercase_datepart_compiles_and_runs` — passed
- Full `tests/functional/adapter/utils/` collection: 49 tests, no import/namespace breakage
- `pre-commit` (ruff, ruff-format, mypy) on the changed files: passed
