### PR TITLE
test: functional coverage for skip_optimize; strengthen liquid clustering tests

### DIFF
--- a/tests/functional/adapter/liquid_clustering/fixtures.py
+++ b/tests/functional/adapter/liquid_clustering/fixtures.py
@@ -18,6 +18,16 @@ auto_liquid_cluster_table_sql = """
 select 1 as id, 'Joe' as name
 """
 
+table_skip_optimize_sql = """
+{{ config(materialized='table', liquid_clustered_by='id', skip_optimize=true) }}
+select 1 as id, 'Joe' as name
+"""
+
+incremental_skip_optimize_sql = """
+{{ config(materialized='incremental', liquid_clustered_by='id', skip_optimize=true) }}
+select 1 as id, 'Joe' as name
+"""
+
 incremental_three_cols_sql = """
 {{ config(materialized='incremental') }}
 select 1 as id, 'hello' as msg, 'blue' as color

--- a/tests/functional/adapter/liquid_clustering/test_liquid_clustering.py
+++ b/tests/functional/adapter/liquid_clustering/test_liquid_clustering.py
@@ -13,21 +13,29 @@ class TestLiquidClustering:
 
     @pytest.mark.skip_profile("databricks_uc_cluster", "databricks_cluster")
     def test_liquid_clustering(self, project):
-        _, logs = util.run_dbt_and_capture(["--debug", "run"])
-        assert "optimize" in logs
+        util.run_dbt(["run"])
+        operations = project.run_sql(
+            "select operation from (describe history {database}.{schema}.liquid_clustering)",
+            fetch="all",
+        )
+        assert "OPTIMIZE" in [row[0] for row in operations]
 
 
 class TestAutoLiquidClustering:
     @pytest.fixture(scope="class")
     def models(self):
         return {
-            "liquid_clustering.sql": fixtures.liquid_cluster_sql,
+            "auto_liquid_clustering.sql": fixtures.auto_liquid_cluster_sql,
         }
 
     @pytest.mark.skip_profile("databricks_uc_cluster", "databricks_cluster")
     def test_liquid_clustering(self, project):
-        _, logs = util.run_dbt_and_capture(["--debug", "run"])
-        assert "optimize" in logs
+        util.run_dbt(["run"])
+        properties = project.run_sql(
+            "show tblproperties {database}.{schema}.auto_liquid_clustering",
+            fetch="all",
+        )
+        assert ("clusterByAuto", "true") in [(row[0], row[1]) for row in properties]
 
 
 class TestTableV2LiquidClustering:

--- a/tests/functional/adapter/liquid_clustering/test_liquid_clustering_effects.py
+++ b/tests/functional/adapter/liquid_clustering/test_liquid_clustering_effects.py
@@ -75,6 +75,40 @@ class TestAutoLiquidClusteringTableEffect:
 
 
 @pytest.mark.skip_profile("databricks_uc_cluster", "databricks_cluster")
+class TestTableSkipOptimizeEffect:
+    """skip_optimize=true must suppress the post-materialization OPTIMIZE while the
+    liquid_clustered_by declaration stays on the created table."""
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "table_skip_optimize.sql": fixtures.table_skip_optimize_sql,
+        }
+
+    def test_optimize_skipped_clustering_retained(self, project):
+        util.run_dbt(["run"])
+        assert get_clustering_columns(project, "table_skip_optimize") == ["id"]
+        assert "OPTIMIZE" not in get_history_operations(project, "table_skip_optimize")
+
+
+@pytest.mark.skip_profile("databricks_uc_cluster", "databricks_cluster")
+class TestIncrementalSkipOptimizeEffect:
+    """skip_optimize=true on an incremental model must suppress the OPTIMIZE that would
+    otherwise run after the merge, while the clustering columns stay set."""
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "incremental_skip_optimize.sql": fixtures.incremental_skip_optimize_sql,
+        }
+
+    def test_optimize_skipped_clustering_retained(self, project):
+        util.run_dbt(["run"])
+        assert get_clustering_columns(project, "incremental_skip_optimize") == ["id"]
+        assert "OPTIMIZE" not in get_history_operations(project, "incremental_skip_optimize")
+
+
+@pytest.mark.skip_profile("databricks_uc_cluster", "databricks_cluster")
 class TestIncrementalSwitchToAutoCluster(RerunSafeMixin):
     """Changing clustering config on an existing incremental model must be applied via ALTER:
     explicit columns -> auto (CLUSTER BY AUTO) -> removed (CLUSTER BY NONE)."""


### PR DESCRIPTION
## Description

Adds functional-test coverage for the `skip_optimize` model config (#1485) and strengthens two existing liquid-clustering tests to assert server-observable state instead of log substrings. Test-only — no runtime change.

### `skip_optimize` functional coverage (#1485)

`skip_optimize=true` short-circuits `databricks__optimize` to a no-op while the clustering declaration stays on the table. This was previously only unit-tested (`tests/unit/macros/relations/test_optimize_macros.py`). New functional tests assert the end-to-end effect on a live warehouse:

- **`TestTableSkipOptimizeEffect`** — on a `table` model, `liquid_clustered_by` columns are present AND no `OPTIMIZE` appears in `DESCRIBE HISTORY`.
- **`TestIncrementalSkipOptimizeEffect`** — same on an `incremental` model (the high-churn use case from #703), exercising the distinct incremental `optimize()` call site.

The `skip_optimize=false`/unset control (OPTIMIZE still runs) is already covered by the existing `TestTableLiquidClusteringEffect`.

### Test strengthening (log substrings → server state)

- **`TestLiquidClustering`**: replaced `assert "optimize" in logs` with a `DESCRIBE HISTORY` check that an `OPTIMIZE` operation actually ran.
- **`TestAutoLiquidClustering`**: it previously used the non-auto fixture, making it a silent duplicate of `TestLiquidClustering` that never exercised auto clustering. Repointed to the auto fixture; it now asserts `clusterByAuto=true` via `SHOW TBLPROPERTIES`, adding auto-clustering-on-incremental coverage.

### Testing

All pass on `databricks_uc_sql_endpoint`:

- `tests/functional/adapter/liquid_clustering/` (both files) + `tests/functional/adapter/zorder/` — **11 passed**.
- `ruff` / `ruff format` / `mypy` clean on the changed files.

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests
- [x] No `CHANGELOG.md` entry — test-only change with no runtime/user-facing impact
