### PR TITLE
docs: document server-observable / rerun-safe / cheapest-home functional-test norms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,6 @@ logs/
 .python-version
 .hatch
 .coverage*
-CLAUDE.md
 .claude/
 .cursor
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,6 +97,12 @@ Functional tests assert user-visible outcomes: the model materializes and the re
 
 When there is nothing meaningful to assert in either category, the change does not need a test.
 
+Three rules keep functional tests server-truthful and cheap (full detail in [docs/testing.md → Functional Tests](docs/testing.md#functional-tests)):
+
+- **Assert server-observable state only** — query data, `SHOW TBLPROPERTIES`, `DESCRIBE DETAIL`/`EXTENDED`/`HISTORY`, or `information_schema`. Never assert a log substring or generated-SQL text in a functional test (that's unit/macro-test domain), even where existing tests do.
+- **Rerun-safe** — a second run of the test must pass (`RerunSafeMixin` or unique names).
+- **Cheapest home first** — strengthen an existing test > add a case to a class > new class > new file/section; fixtures go in `fixtures.py`, never inlined.
+
 ### Test Environments
 
 - **HMS Cluster** (`databricks_cluster`): Legacy Hive Metastore

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,2 @@
+<!-- Claude Code reads CLAUDE.md, not AGENTS.md. Import the agent guide so both tools share one source. -->
+@./AGENTS.md

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -562,6 +562,44 @@ Functional tests create a complete dbt project environment for each test:
 3. **Verification**: Tests query the database to verify expected results
 4. **Cleanup**: Framework automatically cleans up the test schema
 
+#### Assert server-observable state only
+
+A functional test must assert what the server actually did — never a log line or the generated SQL
+text (those belong in unit / `MacroTestBase` tests). Query the table's data, `SHOW TBLPROPERTIES`,
+`DESCRIBE DETAIL` / `DESCRIBE EXTENDED`, `DESCRIBE HISTORY`, or `information_schema`. This holds even
+where existing tests do otherwise — the suite contains this anti-pattern; do not propagate it. Find
+the server-side observable the log line was a proxy for:
+
+| Instead of asserting… | Assert the server-observable effect |
+|---|---|
+| `"optimize" in logs` | `DESCRIBE HISTORY <tbl>` → a row with `operation = 'OPTIMIZE'` |
+| `"cluster by" in sql` | `SHOW TBLPROPERTIES <tbl>` → `clusteringColumns = '[["col"]]'` |
+| `"GRANT" in logs` | `information_schema.table_privileges` / the tag tables |
+| generated-SQL text for a property | `DESCRIBE DETAIL` / `DESCRIBE EXTENDED` / `SHOW TBLPROPERTIES` for the resulting property |
+
+And assert **at least one real effect** — "run succeeded" or a row count alone is not coverage.
+
+#### Rerun-safety
+
+Any stateful test must pass on a second invocation (the suite is run with `pytest --reruns`). Use the
+shared `RerunSafeMixin` (`tests/functional/adapter/fixtures.py`) or unique names; follow the section's
+existing patterns.
+
+#### Cheapest home first
+
+Every new test class and file is load the CI suite pays on every run and surface a maintainer reads
+forever. Climb this ladder and stop at the first rung that fits without shoehorning:
+
+1. **Strengthen an existing test in place** — add a server-observable assertion to a flow a test already
+   runs but doesn't verify (additive only).
+2. **Add a test/case to an existing class** — reuses its already-built models/fixtures.
+3. **Add a new class to the existing file** — when the behavior needs models/config no existing class
+   builds (prefer inheriting and overriding `project_config_update` / `models` / `seeds`).
+4. **New `test_*.py`, then a new section dir + `fixtures.py`** — only for a genuinely distinct feature area.
+
+Rungs 3–4 are deliberate escalations. Fixtures live in a `fixtures.py` (section-local or the shared
+`tests/functional/adapter/fixtures.py`), never inlined in the test file.
+
 **Common Testing Pattern:**
 A typical functional test uses seeds to define expected final state, runs the dbt project, then compares actual results to the seeded expected data:
 


### PR DESCRIPTION
## What

Writes down three functional-test conventions the team already follows in review but that weren't documented, so contributors (and AI agents) apply them consistently.

- **`docs/testing.md` (§Functional Tests)** — three new subsections:
  - *Assert server-observable state only* — query data / `SHOW TBLPROPERTIES` / `DESCRIBE DETAIL|EXTENDED|HISTORY` / `information_schema`, never a log substring or generated-SQL text in a functional test (that's unit/`MacroTestBase` domain). Includes a forbidden→observable mapping table and the "assert at least one real effect" rule.
  - *Rerun-safety* — stateful tests must pass on a second invocation (`RerunSafeMixin` / unique names).
  - *Cheapest home first* — the placement ladder (strengthen existing → add case → new class → new file/section), fixtures in `fixtures.py`.
- **`AGENTS.md` (§What to Assert)** — a three-bullet summary linking down to the new `docs/testing.md` subsections. AGENTS.md stays a summary; depth lives in the doc.
- **Root `CLAUDE.md`** — imports the agent guide via `@./AGENTS.md`. Claude Code reads `CLAUDE.md`, not `AGENTS.md`, so this makes the guide auto-load for in-repo agent sessions.

## Note on `.gitignore`

This removes the `CLAUDE.md` line from `.gitignore` so the one-line import shim above can be tracked. **`.claude/` stays ignored**, so contributors' personal Claude configs are still never committed — only this repo-level `CLAUDE.md → AGENTS.md` pointer is tracked. Happy to drop the `CLAUDE.md`/`.gitignore` part and keep just the AGENTS.md + docs/testing.md enrichment if you'd prefer to leave `CLAUDE.md` ignored.

## Why

The conventions are real and enforced in review; documenting them reduces back-and-forth and keeps new functional tests server-truthful and cheap. Docs-only change — no runtime impact, no code touched.