### PR TITLE
doc: Add dbt-databricks-pr-ready skill to the repo

### DIFF
--- a/.claude/skills/dbt-databricks-pr-ready/SKILL.md
+++ b/.claude/skills/dbt-databricks-pr-ready/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: dbt-databricks-pr-ready
+description: Use when given a community dbt-databricks PR (link or number) to prepare for merge — assessing what it lacks (changelog, tests, lint, conflicts) and implementing the missing pieces on the contributor's branch. Args: <pr-link-or-number> [--auto] (--auto skips the selection question and pushes automatically; for offline/CI/goal runs).
+---
+
+# dbt-databricks PR merge-readiness driver
+
+Input: a PR URL or bare number for `databricks/dbt-databricks`, optional
+`--auto`. The deliverable is verified commits on the contributor's branch plus
+a report. Pushing those commits is **approval-gated**: in interactive mode wait
+for explicit user approval before pushing; under `--auto` the flag is itself the
+authorization and the push runs automatically (see Phase 5).
+
+Hard rules (apply in both modes, no exceptions):
+
+- Never merge, comment on, or label the PR.
+- Never push without authorization. Interactive mode: push only after explicit
+  user sign-off on the commits. `--auto`: the flag is the authorization — push
+  automatically. Either way, re-verify the head hasn't moved immediately before
+  pushing (Phase 5).
+- Only verified work gets committed (tests run and read, lint clean).
+- No attribution footers on commits.
+- If the PR head moves mid-run (contributor pushed), stop and report —
+  never rebase silently.
+
+## Phase 1 — Setup
+
+Derive the primary checkout once, reused throughout (including later phases):
+`PRIMARY="$(git worktree list --porcelain | head -1 | sed 's/^worktree //')"`
+
+1. Ensure `gh` is authed to the account you use for `databricks/dbt-databricks`,
+   and capture your login once: `ME=$(gh api user -q .login)`. Fetch metadata:
+   `gh pr view <N> --repo databricks/dbt-databricks --json number,title,author,state,isDraft,baseRefName,headRefName,headRepositoryOwner,mergeable,statusCheckRollup,closingIssuesReferences,files,maintainerCanModify`
+   Record the head SHA (`gh pr view <N> --json headRefOid`) — used for the
+   moved-head check before committing. `mergeable` is computed lazily and
+   often comes back `UNKNOWN` on the first fetch — re-query it after a few
+   seconds before treating it as a verdict.
+2. Hard stops: state is MERGED or CLOSED; or the PR author is you (`$ME`) —
+   this tool is for preparing *other* contributors' PRs. Draft PR:
+   ask the user in interactive mode; proceed under `--auto`.
+3. Worktree at `$PRIMARY/.claude/worktrees/pr-<N>`:
+   - If it already exists: re-sync to the current PR head, but first check
+     for leftover local commits from a previous run (`git log
+     <remote-tracking-branch>..HEAD`) and surface them instead of discarding.
+   - Else: `git -C "$PRIMARY" worktree add
+     "$PRIMARY/.claude/worktrees/pr-<N>" --detach`, then
+     `cd "$PRIMARY/.claude/worktrees/pr-<N>" && gh pr checkout <N>` (sets up the
+     fork remote and a tracking branch, so the final push command is exact).
+4. Per-worktree setup (one time) — `.claude` granular symlinks:
+   `cd "$PRIMARY/.claude/worktrees/pr-<N>" && mkdir -p .claude && cd .claude && for item in pr-ready settings.local.json; do ln -sf "$PRIMARY/.claude/$item" "$item"; done`
+   (mirror any other shared `.claude/` items your worktree convention calls
+   for; never `scheduled_tasks.json` / `worktrees/`).
+   Skip `pre-commit install` if `core.hooksPath` is set (the install refuses
+   when it is); lint is enforced by the explicit
+   `hatch run pre-commit run --all-files` runs in the rubric and Phase 5
+   regardless.
+
+Sandbox note: if worktree creation is blocked by a Bash sandbox, disable the
+sandbox for the worktree-creation / checkout / symlink commands (as for
+git/gh commands generally).
+
+## Phase 2 — Assessment
+
+Read `references/rubric.md` (in this skill directory) and walk every item
+against the PR diff and metadata. Produce the gap report:
+
+- one row per rubric item: **met / gap / n-a**, with evidence
+- every gap: one-line recommended fix, rough effort, and whether the rubric
+  marks it *recommended* or *optional* for this PR
+
+Write the report skeleton to
+`$PRIMARY/.claude/pr-ready/pr-<N>/report.md` now (it is
+updated as phases complete). If there are **no gaps**, finish the report as
+"merge-ready as-is" and stop.
+
+## Phase 3 — Selection
+
+- **Interactive (default):** present gaps via AskUserQuestion, multiSelect,
+  one option per gap — label = rubric item, description = recommended fix +
+  effort. Recommended items first. More than 4 gaps → split across multiple
+  questions in the same call.
+- **`--auto`:** select every gap marked *recommended*; skip *optional* gaps
+  and record them in the report as skipped-by-policy. Record the selection
+  set and selector ("user" or "auto") in the report.
+
+## Phase 4 — Execution
+
+Work the selected items as an explicit checklist (TaskCreate one task per
+item) — completion criteria per item come from the rubric's fix recipe.
+Ordering: code-touching items first, lint second-to-last, changelog last.
+
+For each item:
+
+1. Follow the rubric fix recipe, including its verify-then-fix loop. Run the
+   tests and read the output — never assume.
+2. Before committing, confirm the PR head hasn't moved
+   (`gh pr view <N> --json headRefOid` equals the recorded SHA).
+3. Commit just that item's changes with the rubric's commit message style.
+4. Item can't complete after 3 fix attempts (or cluster unavailable): mark it
+   **blocked** in the report, stash or leave the partial diff uncommitted,
+   and move on — a blocked item never blocks the others.
+
+## Phase 5 — Landing & report
+
+1. `cd <worktree> && hatch run pre-commit run --all-files` — must be clean.
+2. Simplify pass over the skill's own additions only (not the contributor's
+   code).
+3. Re-run the full set of tests touched in Phase 4; read the output.
+4. Finalize `$PRIMARY/.claude/pr-ready/pr-<N>/report.md`:
+   assessment table, selection (and selector), per-item outcome with test
+   evidence, blocked items, noise notes (pre-existing lint, base-branch
+   note).
+5. Land the commits — **push is approval-gated**:
+   - **Interactive (default):** output the per-item outcome table and the exact
+     push command (`cd "$PRIMARY/.claude/worktrees/pr-<N>" && git push
+     <fork-remote> HEAD:<headRefName>`), then ask for explicit approval. Push it
+     yourself only on a clear "yes"; otherwise stop and leave the command for the
+     user.
+   - **`--auto`:** push automatically (the flag is the authorization). Report the
+     result.
+   - **Before any push, either mode:** re-confirm `gh` is authed to that same
+     account, then re-confirm the remote PR head still equals the recorded SHA
+     (moved-head check) — if it moved, do **not** push; stop and report
+     (`git push <fork-remote> HEAD:<headRefName>` — push to the *contributor's*
+     fork remote set up by `gh pr checkout`, not a personal push alias that
+     targets your own fork namespace). After pushing, verify the remote head
+     advanced to your commit and record it in the report.

--- a/.claude/skills/dbt-databricks-pr-ready/SKILL.md
+++ b/.claude/skills/dbt-databricks-pr-ready/SKILL.md
@@ -38,16 +38,41 @@ Derive the primary checkout once, reused throughout (including later phases):
 2. Hard stops: state is MERGED or CLOSED; or the PR author is you (`$ME`) —
    this tool is for preparing *other* contributors' PRs. Draft PR:
    ask the user in interactive mode; proceed under `--auto`.
-3. Worktree at `$PRIMARY/.claude/worktrees/pr-<N>`:
-   - If it already exists: re-sync to the current PR head, but first check
-     for leftover local commits from a previous run (`git log
-     <remote-tracking-branch>..HEAD`) and surface them instead of discarding.
-   - Else: `git -C "$PRIMARY" worktree add
-     "$PRIMARY/.claude/worktrees/pr-<N>" --detach`, then
-     `cd "$PRIMARY/.claude/worktrees/pr-<N>" && gh pr checkout <N>` (sets up the
-     fork remote and a tracking branch, so the final push command is exact).
+3. Locate or create the working worktree `$WT`. A branch can be checked out in
+   only one worktree, so `gh pr checkout` fails with "already used by worktree
+   at …" when the branch is already checked out elsewhere — common for your
+   own / in-repo PRs. **Check for an existing worktree on the branch before
+   creating one.** A prior run may have checked it out under `<headRefName>`
+   (non-fork PRs) or, for a fork PR, `<author>-<headRefName>` (`<author>` =
+   `headRepositoryOwner.login` from step 1). Match either:
+
+   `WT="$(git -C "$PRIMARY" worktree list --porcelain | awk -v r1="branch refs/heads/<headRefName>" -v r2="branch refs/heads/<author>-<headRefName>" '/^worktree /{w=$2} $0==r1||$0==r2{print w}')"`
+
+   - **`$WT` non-empty — reuse it** (do NOT create `pr-<N>` or run
+     `gh pr checkout`; both would fail). `cd "$WT"`, then re-sync to the current
+     PR head, fetching first so the compare is against the live server ref:
+     `UP="$(git -C "$WT" rev-parse --abbrev-ref '@{upstream}' 2>/dev/null || echo origin/<headRefName>)"`;
+     `git -C "$WT" fetch "${UP%%/*}" <headRefName>` (refreshes `$UP`);
+     `git -C "$WT" log "$UP"..HEAD --oneline` — any commits are prior-run local
+     work, so report and keep them (never discard); then
+     `git -C "$WT" merge --ff-only "$UP"` (a non-fast-forward failure means the
+     local branch diverges from the head — surface and stop, per the
+     never-rebase rule). Note in the report that an existing worktree was
+     reused instead of `pr-<N>`.
+   - **Else if `$PRIMARY/.claude/worktrees/pr-<N>` already exists:**
+     `WT="$PRIMARY/.claude/worktrees/pr-<N>"`; `cd "$WT" && gh pr checkout <N>`
+     (re-syncs to the current head), first surfacing leftover local commits
+     (`git log <remote-tracking-branch>..HEAD`) instead of discarding.
+   - **Else create one:** `WT="$PRIMARY/.claude/worktrees/pr-<N>"`;
+     `git -C "$PRIMARY" worktree add "$WT" --detach`, then
+     `cd "$WT" && gh pr checkout <N>` (sets up the fork remote and a tracking
+     branch, so the final push command is exact).
+
+   `$WT` is now the working worktree. Record its push remote once (used in
+   Phase 5): `REMOTE="$(git -C "$WT" rev-parse --abbrev-ref '@{upstream}' | sed 's#/.*##')"`
+   — `origin` for in-repo PRs, the fork remote `gh pr checkout` set up otherwise.
 4. Per-worktree setup (one time) — `.claude` granular symlinks:
-   `cd "$PRIMARY/.claude/worktrees/pr-<N>" && mkdir -p .claude && cd .claude && for item in pr-ready settings.local.json; do ln -sf "$PRIMARY/.claude/$item" "$item"; done`
+   `cd "$WT" && mkdir -p .claude && cd .claude && for item in pr-ready settings.local.json; do ln -sf "$PRIMARY/.claude/$item" "$item"; done`
    (mirror any other shared `.claude/` items your worktree convention calls
    for; never `scheduled_tasks.json` / `worktrees/`).
    Skip `pre-commit install` if `core.hooksPath` is set (the install refuses
@@ -102,7 +127,7 @@ For each item:
 
 ## Phase 5 — Landing & report
 
-1. `cd <worktree> && hatch run pre-commit run --all-files` — must be clean.
+1. `cd "$WT" && hatch run pre-commit run --all-files` — must be clean.
 2. Simplify pass over the skill's own additions only (not the contributor's
    code).
 3. Re-run the full set of tests touched in Phase 4; read the output.
@@ -112,16 +137,16 @@ For each item:
    note).
 5. Land the commits — **push is approval-gated**:
    - **Interactive (default):** output the per-item outcome table and the exact
-     push command (`cd "$PRIMARY/.claude/worktrees/pr-<N>" && git push
-     <fork-remote> HEAD:<headRefName>`), then ask for explicit approval. Push it
+     push command (`cd "$WT" && git push "$REMOTE" HEAD:<headRefName>`, `$REMOTE`
+     from Phase 1), then ask for explicit approval. Push it
      yourself only on a clear "yes"; otherwise stop and leave the command for the
      user.
    - **`--auto`:** push automatically (the flag is the authorization). Report the
      result.
    - **Before any push, either mode:** re-confirm `gh` is authed to that same
      account, then re-confirm the remote PR head still equals the recorded SHA
-     (moved-head check) — if it moved, do **not** push; stop and report
-     (`git push <fork-remote> HEAD:<headRefName>` — push to the *contributor's*
-     fork remote set up by `gh pr checkout`, not a personal push alias that
-     targets your own fork namespace). After pushing, verify the remote head
-     advanced to your commit and record it in the report.
+     (moved-head check) — if it moved, do **not** push; stop and report. The
+     push uses the Phase-1 `$REMOTE` (`git push "$REMOTE" HEAD:<headRefName>`),
+     never a personal push alias that targets your own fork namespace. After
+     pushing, verify the remote head advanced to your commit and record it in
+     the report.

--- a/.claude/skills/dbt-databricks-pr-ready/references/rubric.md
+++ b/.claude/skills/dbt-databricks-pr-ready/references/rubric.md
@@ -1,0 +1,113 @@
+# Merge-Readiness Rubric — dbt-databricks community PRs
+
+Walk every item against the PR diff and metadata. Each item yields one verdict:
+**met**, **gap**, or **n-a**. Every gap gets a one-line recommended fix and a
+rough effort estimate — these become the selection-question payload.
+
+Sources of truth: `CHANGELOG.md` conventions in the repo, and maintainer
+follow-up commits mined from 25 merged community PRs (2026-06-12; e.g. #1472:
+functional coverage + ruff format; #1471: changelog entry; #1339: changelog
+placement fixes + edge-case test coverage; #1194: changelog author credit).
+
+## 1. Changelog entry
+
+- **Detection:** Diff touches `CHANGELOG.md`; the entry sits under the topmost
+  version heading (the one marked `(TBD)`); it is in the correct section
+  (`### Features` / `### Fixes` / `### Under the Hood`); it ends with
+  `([#N](https://github.com/databricks/dbt-databricks/pull/N))`; when the PR
+  addresses a tracked issue, the entry also carries — inside the same parens —
+  `resolves [#M](https://github.com/databricks/dbt-databricks/issues/M)`
+  (or `partially resolves [#M](…)` when it only partly addresses the issue);
+  community contributions credit the author with `(thanks @author!)` before
+  the links (repo convention). Older entries use `closes`; leave them, use
+  `resolves` for new ones. Any of these missing or wrong → **gap**.
+  After any merge of main/release-branch into the PR, re-verify placement —
+  bad merges have shifted entries into already-released sections (#1339).
+- **Recommended:** always — even test-only changes get an `Under the Hood`
+  entry with a "(test-only, no runtime impact)" note, per repo history.
+- **Fix recipe:** Add or correct the entry using the canonical format
+  documented in the repo's `AGENTS.md` (CHANGELOG Entries section): one line,
+  present-tense summary of the user-visible effect (not the implementation),
+  correct section, `(thanks @author!)` for community PRs, PR link, and a
+  `resolves` / `partially resolves` issue link when applicable. Do this
+  **last** (content may depend on tests added by other items).
+  Commit: `chore: update CHANGELOG for #N`.
+
+## 2. Functional tests
+
+- **Detection:** The diff changes behavior — files under
+  `dbt/adapters/databricks/` or macros under `dbt/include/databricks/` — but
+  has no corresponding `tests/functional/` change, **or** the functional
+  change doesn't exercise the new branch (e.g. a new config value never set
+  in any fixture). Search `tests/functional/adapter/` for the feature area
+  touched; name the nearest module to extend in the gap description.
+- **Recommended:** when the change is observable against a live warehouse
+  (almost all fixes and features). **Optional** for pure refactors, logging,
+  or dependency bumps.
+- **Fix recipe:** Follow the repo's `docs/testing.md` (§Functional Tests) —
+  server-observable assertions only, no log-substring or generated-SQL text;
+  rerun-safe; fixtures in the section's `fixtures.py`; prefer dbt-labs base
+  classes / section mixins. Extend the nearest existing test module rather
+  than creating a new tree. Verify-then-fix:
+  1. Write the test; run `cd <worktree> && hatch run pytest <test path> -v`
+     against the live cluster (env vars pre-configured; targeted runs may need
+     `--profile databricks_uc_sql_endpoint`). See it pass.
+  2. For bugfix PRs, prove the test pins the fix: `git stash push -- dbt/`,
+     re-run the test, see it **fail**, `git stash pop`, re-run, see it pass.
+  3. If the feature is UC- or warehouse-only, add the repo's standard
+     profile-skip decorator (grep `tests/functional` for `skip_profile`) so
+     cluster profiles skip rather than fail (#1296 pattern).
+  4. Run the surrounding test module for regressions.
+  Commit: `test: add functional coverage for <x>`.
+
+## 3. Unit tests
+
+- **Detection:** Python logic changes (config parsing, API clients, utils,
+  anything with branches) in `dbt/` whose changed functions are not exercised
+  by `tests/unit/` — grep test files for the changed symbols before flagging.
+- **Recommended:** for new or changed pure-Python logic. **Optional** when the
+  behavior is macro/SQL-only and functional tests cover it.
+- **Fix recipe:** Same verify-then-fix loop with
+  `cd <worktree> && hatch run unit <test path> -v`.
+  Commit: `test: add unit coverage for <x>`.
+
+## 4. Lint / format
+
+- **Detection:** `cd <worktree> && hatch run pre-commit run --all-files`
+  reports any failure. (Use `--all-files`, not `--files` — mirrors CI.)
+- **Recommended:** always.
+- **Fix recipe:** Apply hook auto-fixes, hand-fix the rest, re-run until
+  clean. Commit: `style: apply ruff format` or `chore: fix lint`.
+
+## 5. Conflicts / correct base branch
+
+- **Detection:** `mergeable` from `gh pr view` is `CONFLICTING` → **gap**.
+  Separately, note (never auto-fix) when the base branch looks wrong for the
+  release-branch-first flow — features usually land on the active `*.latest`
+  branch (#1339/#1340 targeted `1.12.latest`), fixes often on `main`.
+  Retargeting is a human decision; surface it as a note in the report, not a
+  selectable item.
+- **Recommended:** conflict resolution is recommended; base retarget is
+  note-only.
+- **Fix recipe:** `git merge origin/<base>` in the worktree, resolve, re-run
+  the touched test set, then re-verify changelog placement (item 1). Merge
+  commits are expected here (the one exception to per-item single commits).
+
+## 6. CI status
+
+- **Detection:** `statusCheckRollup` from `gh pr view`. Red Code Quality job →
+  fold into item 4. Red integration tests → check whether the failure is
+  caused by the PR (then it belongs to items 2/3) or is the known transient
+  infra signature (INTERNAL_ERROR + MaxRetryDurationError across workers);
+  report accordingly.
+- **Recommended:** note-only unless it maps onto another item.
+
+## Noise to ignore
+
+- `Merge branch 'main' into ...` commits — never count these against the
+  contributor or replicate them except via item 5.
+- Pre-existing lint debt outside the PR's blast radius that `--all-files`
+  surfaces: still fix it (cheap, CI requires it), but attribute it as
+  pre-existing in the report.
+- Docs follow-ups (docs.getdbt.com) are handled by the separate docs-sync
+  workflow — not a rubric item.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -20,3 +20,4 @@ Resolves #
 - [ ] I have run this code in development and it appears to resolve the stated issue
 - [ ] This PR includes tests, or tests are not required/relevant for this PR
 - [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
+- [ ] [Optional] I have run `/dbt-databricks-pr-ready` (AI agent skill in `.claude/skills/`) and addressed its merge-readiness feedback

--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,8 @@ logs/
 .python-version
 .hatch
 .coverage*
-.claude/
+.claude/*
+!.claude/skills/
 .cursor
 
 docs/plans/


### PR DESCRIPTION
## What

Ships the **pr-ready** skill with the adapter, at `.claude/skills/dbt-databricks-pr-ready/`. It drives a community dbt-databricks PR to merge-readiness: assesses what the PR lacks (changelog, functional/unit tests, lint, conflicts, CI) against a rubric, then implements the missing pieces on the contributor's branch — never merging, commenting, or pushing without explicit approval.