### PR TITLE
test: stabilize the two python-model submission-error tests under min-deps (dbt-core 1.11.2)

### DIFF
--- a/tests/functional/adapter/python_model/test_python_model.py
+++ b/tests/functional/adapter/python_model/test_python_model.py
@@ -586,7 +586,7 @@ class TestAllPurposeClusterCommandAPI(PythonModelDataMixin, BasePythonModelTests
 
 
 @pytest.mark.python
-class TestJobClusterMissingConfig:
+class TestJobClusterMissingConfig(SchemaNameVarMixin):
     """job_cluster submission requires job_cluster_config; omitting it fails the run."""
 
     @pytest.fixture(scope="class")
@@ -594,12 +594,12 @@ class TestJobClusterMissingConfig:
         return {"jc_no_config.py": override_fixtures.job_cluster_missing_config_model}
 
     def test_missing_job_cluster_config_fails(self, project):
-        util.run_dbt(["run"], expect_pass=False)
+        util.run_dbt(["run", *self.schema_name_vars(project)], expect_pass=False)
 
 
 @pytest.mark.python
 @pytest.mark.skip_profile("databricks_cluster", "databricks_uc_cluster")
-class TestAllPurposeClusterMissingClusterId:
+class TestAllPurposeClusterMissingClusterId(SchemaNameVarMixin):
     """all_purpose_cluster needs a resolvable cluster_id; on a SQL warehouse connection
     neither http_path nor cluster_id resolves to one, so the run fails."""
 
@@ -608,4 +608,4 @@ class TestAllPurposeClusterMissingClusterId:
         return {"ap_no_cluster.py": override_fixtures.all_purpose_missing_cluster_model}
 
     def test_missing_cluster_id_fails(self, project):
-        util.run_dbt(["run"], expect_pass=False)
+        util.run_dbt(["run", *self.schema_name_vars(project)], expect_pass=False)


### PR DESCRIPTION
## Description

The **Integration Tests (Min-Deps)** workflow on `main` has failed on every scheduled nightly since 2026-07-02 (green on 07-01 and earlier). `run-sqlwarehouse-e2e-tests` shard 0 fails on exactly two negative python-model tests:

- `TestJobClusterMissingConfig::test_missing_job_cluster_config_fails`
- `TestAllPurposeClusterMissingClusterId::test_missing_cluster_id_fails`

both with `EnvVarMissingError: Env var required but not provided: 'DBT_TEST_SCHEMA_NAME_VARIABLE'`, raised while rendering `models/schema.yml` on a `test_source` whose `schema: "{{ var(env_var('DBT_TEST_SCHEMA_NAME_VARIABLE')) }}"`.

### Root cause

Both classes were added in #1559 as **plain classes** that run `dbt run` with no `--vars`, and define **no schema.yml of their own**. On the dbt-core **1.11.2** min-deps floor, under xdist `--dist=loadfile` a sibling class's `test_source` schema.yml leaks into their parse (a prior `BasePythonModelTests` class sets then deletes `DBT_TEST_SCHEMA_NAME_VARIABLE` on teardown, leaving the var absent while the cached source persists). Parsing then dies before the run can reach the intended submission-time failure. Full-deps is unaffected (newer dbt-core), which is why only the min-deps lane is red.

This is the same test-isolation leak #1488 fixed for the `TestChangingSchema*` classes via `SchemaNameVarMixin`; #1559 added two new vulnerable classes without applying it.

### Fix

Apply the existing `SchemaNameVarMixin` to both classes and pass `*self.schema_name_vars(project)` to their `run_dbt` calls. The mixin's autouse fixture sets `DBT_TEST_SCHEMA_NAME_VARIABLE` (satisfies the inner `env_var(...)`) and supplies `--vars {"test_run_schema": ...}` (satisfies the outer `var(...)`), so a leaked `test_source` renders cleanly. Parsing then succeeds and the run proceeds to its intended failure — `expect_pass=False` still holds (missing `job_cluster_config` / unresolvable warehouse `cluster_id` raise at submission).

### Verification

On min-deps + `databricks_uc_sql_endpoint`:

- Deterministic reproduction (leaked `test_source` schema.yml + env var absent): the **pre-fix shape fails** with the exact `EnvVarMissingError`; the **post-fix shape (mixin) passes**.
- The two target tests pass post-fix; the full `test_python_model.py` runs green CI-style (`--dist=loadfile`).
- `pre-commit` (ruff, ruff-format, mypy) passes.

Test-only; no adapter/runtime code changes.

## Checklist

- [x] I have run this code in development, and it appears to resolve the stated issue.
- [x] This PR includes tests, or tests are not required/relevant for this PR.
- [x] I have updated the `CHANGELOG.md` and added information about my change.
