### PR TITLE
ci: raise unit test job timeout from 15 to 20 minutes

### DIFF
--- a/.github/workflows/main-min-deps.yml
+++ b/.github/workflows/main-min-deps.yml
@@ -39,7 +39,7 @@ jobs:
     runs-on:
       group: databricks-protected-runner-group
       labels: linux-ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
 
     env:
       UV_FROZEN: "1"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -90,7 +90,7 @@ jobs:
     runs-on:
       group: databricks-protected-runner-group
       labels: linux-ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
 
     permissions:
       id-token: write


### PR DESCRIPTION
## Description

Unit test runs have been hitting the 15-minute job timeout in CI, causing spurious failures. This raises the timeout to 20 minutes for both unit test jobs:

- `main.yml` — the latest-deps unit test matrix (Python 3.10 / 3.11 / 3.12 / 3.13, `test:unit-with-cov`)
- `main-min-deps.yml` — the min-deps unit test (Python 3.10, `min-deps:unit`)

No other jobs are touched. Code Quality (10 min), the lock-drift check (5 min), and the integration workflows (240 min) are unchanged.

## Checklist

- [x] CI-only change (no runtime behavior change); no CHANGELOG entry per the repo's `ci:` convention
- [x] No test code changed