### PR TITLE
docs: Ignore local .agents directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ logs/
 .coverage*
 .claude/*
 !.claude/skills/
+.agents/
 .cursor
 
 docs/plans/


### PR DESCRIPTION
## Summary

- Add `.agents/` to `.gitignore` so local agent state stays untracked.

## Testing

- `git check-ignore .agents/`
- `hatch run pre-commit run --files .gitignore`