### PR TITLE
fix(ci): skip timing refresh without runs

### DIFF
--- a/scripts/regenerate_timings.py
+++ b/scripts/regenerate_timings.py
@@ -429,6 +429,13 @@ def main() -> int:
             per_run.append(timings)
 
         if not per_run:
+            if not args.run_ids:
+                print(
+                    "No eligible runs yielded timings — skipping this refresh; "
+                    "will retry next run.",
+                    flush=True,
+                )
+                return 0
             print("ERROR: no timings parsed from any run", file=sys.stderr)
             return 1
 

--- a/tests/unit/test_regenerate_timings.py
+++ b/tests/unit/test_regenerate_timings.py
@@ -137,3 +137,17 @@ class TestManualReviewChanges:
         # A newly added file has delta_pct 0.0 -> never manual review.
         changes = [regen.FileChange(profile="p", file="new.py", new=500.0)]
         assert regen.manual_review_changes(changes) == []
+
+
+class TestMain:
+    def test_auto_discovery_with_no_eligible_runs_skips_cleanly(self, monkeypatch, tmp_path):
+        output = tmp_path / "test_timings.json"
+        monkeypatch.setattr(regen, "discover_green_run_ids", lambda *_: [])
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            ["regenerate_timings.py", "--output", str(output)],
+        )
+
+        assert regen.main() == 0
+        assert not output.exists()


### PR DESCRIPTION
Resolves #

### Description

A scheduled timing refresh can legitimately find no eligible integration-test artifacts while the workflow is waiting for a complete sample. Previously, that condition returned a failure and stopped the refresh workflow.

Automatic discovery now exits successfully when no runs yield timing data, allowing the next scheduled refresh to retry. Explicit `--run-ids` requests still fail when they produce no timings, preserving their validation behavior. The change adds regression coverage for the automatic zero-run path.

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section. (not applicable: CI-only timing refresh behavior)

### Verification

- `hatch run pytest tests/unit/test_regenerate_timings.py -v`
- `hatch run pre-commit run --all-files`