### PR TITLE
fix: unset column tags before dropping a column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Support `catalog_database` in v2 catalogs.yml to route Unity catalog models to a physical catalog independent of the dbt catalog name (requires `dbt-core>=1.12` and `dbt-adapters>=1.24.4`). ([#1590](https://github.com/databricks/dbt-databricks/pull/1590))
 
 ### Fixes
-- Allow dropping a column that has governed tags ([#PR](https://github.com/databricks/dbt-databricks/pull/PR) resolves [#1323](https://github.com/databricks/dbt-databricks/issues/1323))
+- Allow dropping a column that has governed tags ([#1597](https://github.com/databricks/dbt-databricks/pull/1597) resolves [#1323](https://github.com/databricks/dbt-databricks/issues/1323))
 - Support `dbt clone` and rebuilds over an existing shallow clone ([#1592](https://github.com/databricks/dbt-databricks/pull/1592) resolves [#1165](https://github.com/databricks/dbt-databricks/issues/1165))
 - Fix managed Iceberg Python models failing with `MANAGED_TABLE_FORMAT` by emitting `.format("iceberg")` instead of the `parquet` sentinel from `resolve_file_format` (thanks @Divya-Kovvuru-0802!) ([#1593](https://github.com/databricks/dbt-databricks/pull/1593) resolves [#1591](https://github.com/databricks/dbt-databricks/issues/1591))
 - Quote generated column identifiers in incremental strategies so non-ASCII column names no longer fail on subsequent runs ([#1595](https://github.com/databricks/dbt-databricks/pull/1595) resolves [#1594](https://github.com/databricks/dbt-databricks/issues/1594))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Support `catalog_database` in v2 catalogs.yml to route Unity catalog models to a physical catalog independent of the dbt catalog name (requires `dbt-core>=1.12` and `dbt-adapters>=1.24.4`). ([#1590](https://github.com/databricks/dbt-databricks/pull/1590))
 
 ### Fixes
+- Allow dropping a column that has governed tags ([#PR](https://github.com/databricks/dbt-databricks/pull/PR) resolves [#1323](https://github.com/databricks/dbt-databricks/issues/1323))
 - Support `dbt clone` and rebuilds over an existing shallow clone ([#1592](https://github.com/databricks/dbt-databricks/pull/1592) resolves [#1165](https://github.com/databricks/dbt-databricks/issues/1165))
 - Fix managed Iceberg Python models failing with `MANAGED_TABLE_FORMAT` by emitting `.format("iceberg")` instead of the `parquet` sentinel from `resolve_file_format` (thanks @Divya-Kovvuru-0802!) ([#1593](https://github.com/databricks/dbt-databricks/pull/1593) resolves [#1591](https://github.com/databricks/dbt-databricks/issues/1591))
 - Quote generated column identifiers in incremental strategies so non-ASCII column names no longer fail on subsequent runs ([#1595](https://github.com/databricks/dbt-databricks/pull/1595) resolves [#1594](https://github.com/databricks/dbt-databricks/issues/1594))

--- a/dbt/include/databricks/macros/adapters/columns.sql
+++ b/dbt/include/databricks/macros/adapters/columns.sql
@@ -16,6 +16,7 @@ DESCRIBE TABLE {{ relation.render() }}
 
 {% macro databricks__alter_relation_add_remove_columns(relation, add_columns, remove_columns) %}
   {% if remove_columns %}
+    {{ unset_column_tags(relation, remove_columns) }}
     {{ run_query_as(drop_columns_sql(relation, remove_columns), 'alter_relation_remove_columns', fetch_result=False) }}
   {% endif %}
 

--- a/dbt/include/databricks/macros/relations/components/column_tags.sql
+++ b/dbt/include/databricks/macros/relations/components/column_tags.sql
@@ -74,11 +74,8 @@
 {%- endmacro -%}
 
 {% macro alter_unset_column_tags(relation, column, tag_names) -%}
-  {%- if relation.type == 'view' -%}
-    ALTER TABLE {{ relation.render() }}
-  {%- else -%}
-    ALTER {{ relation.type.render() }} {{ relation.render() }}
-  {%- endif -%}
+  {# Only reached from the DROP COLUMNS path, which never runs on views. #}
+  ALTER {{ relation.type.render() }} {{ relation.render() }}
   ALTER COLUMN `{{ column }}`
   UNSET TAGS (
     {%- for tag_name in tag_names -%}

--- a/dbt/include/databricks/macros/relations/components/column_tags.sql
+++ b/dbt/include/databricks/macros/relations/components/column_tags.sql
@@ -49,28 +49,27 @@
 {%- endmacro -%}
 
 {% macro unset_column_tags(relation, columns) -%}
-  {%- if relation.is_hive_metastore() or not columns -%}
-    {{ return(none) }}
-  {%- endif -%}
-  {%- set column_names = [] -%}
-  {%- for column in columns -%}
-    {%- do column_names.append(column.name | lower) -%}
-  {%- endfor -%}
-  {%- set existing_tags = fetch_column_tags(relation) -%}
-  {%- set tags_by_column = {} -%}
-  {%- for row in existing_tags -%}
-    {%- if (row[0] | lower) in column_names -%}
-      {%- if row[0] not in tags_by_column -%}
-        {%- do tags_by_column.update({row[0]: []}) -%}
+  {%- if not relation.is_hive_metastore() and columns -%}
+    {%- set column_names = [] -%}
+    {%- for column in columns -%}
+      {%- do column_names.append(column.name | lower) -%}
+    {%- endfor -%}
+    {%- set existing_tags = fetch_column_tags(relation) -%}
+    {%- set tags_by_column = {} -%}
+    {%- for row in existing_tags -%}
+      {%- if (row[0] | lower) in column_names -%}
+        {%- if row[0] not in tags_by_column -%}
+          {%- do tags_by_column.update({row[0]: []}) -%}
+        {%- endif -%}
+        {%- do tags_by_column[row[0]].append(row[1]) -%}
       {%- endif -%}
-      {%- do tags_by_column[row[0]].append(row[1]) -%}
-    {%- endif -%}
-  {%- endfor -%}
-  {%- for column, tag_names in tags_by_column.items() -%}
-    {%- call statement('unset_column_tags') -%}
-      {{ alter_unset_column_tags(relation, column, tag_names) }}
-    {%- endcall -%}
-  {%- endfor -%}
+    {%- endfor -%}
+    {%- for column, tag_names in tags_by_column.items() -%}
+      {%- call statement('unset_column_tags') -%}
+        {{ alter_unset_column_tags(relation, column, tag_names) }}
+      {%- endcall -%}
+    {%- endfor -%}
+  {%- endif -%}
 {%- endmacro -%}
 
 {% macro alter_unset_column_tags(relation, column, tag_names) -%}

--- a/dbt/include/databricks/macros/relations/components/column_tags.sql
+++ b/dbt/include/databricks/macros/relations/components/column_tags.sql
@@ -48,6 +48,45 @@
   )
 {%- endmacro -%}
 
+{% macro unset_column_tags(relation, columns) -%}
+  {%- if relation.is_hive_metastore() or not columns -%}
+    {{ return(none) }}
+  {%- endif -%}
+  {%- set column_names = [] -%}
+  {%- for column in columns -%}
+    {%- do column_names.append(column.name | lower) -%}
+  {%- endfor -%}
+  {%- set existing_tags = fetch_column_tags(relation) -%}
+  {%- set tags_by_column = {} -%}
+  {%- for row in existing_tags -%}
+    {%- if (row[0] | lower) in column_names -%}
+      {%- if row[0] not in tags_by_column -%}
+        {%- do tags_by_column.update({row[0]: []}) -%}
+      {%- endif -%}
+      {%- do tags_by_column[row[0]].append(row[1]) -%}
+    {%- endif -%}
+  {%- endfor -%}
+  {%- for column, tag_names in tags_by_column.items() -%}
+    {%- call statement('unset_column_tags') -%}
+      {{ alter_unset_column_tags(relation, column, tag_names) }}
+    {%- endcall -%}
+  {%- endfor -%}
+{%- endmacro -%}
+
+{% macro alter_unset_column_tags(relation, column, tag_names) -%}
+  {%- if relation.type == 'view' -%}
+    ALTER TABLE {{ relation.render() }}
+  {%- else -%}
+    ALTER {{ relation.type.render() }} {{ relation.render() }}
+  {%- endif -%}
+  ALTER COLUMN `{{ column }}`
+  UNSET TAGS (
+    {%- for tag_name in tag_names -%}
+      '{{ tag_name }}'{%- if not loop.last %}, {% endif -%}
+    {%- endfor -%}
+  )
+{%- endmacro -%}
+
 {% macro column_tags_exist() %}
   {% for column_name, column in model.columns.items() %}
     {% if column is mapping and column.get('databricks_tags') %}

--- a/tests/functional/adapter/column_tags/fixtures.py
+++ b/tests/functional/adapter/column_tags/fixtures.py
@@ -89,6 +89,27 @@ models:
           pii: "true"
 """
 
+drop_governed_tagged_column_initial_schema = """
+version: 2
+models:
+  - name: drop_model
+    columns:
+      - name: id
+      - name: account_number
+      - name: email
+        databricks_tags:
+          {tag_key}: "true"
+"""
+
+drop_governed_tagged_column_updated_schema = """
+version: 2
+models:
+  - name: drop_model
+    columns:
+      - name: id
+      - name: account_number
+"""
+
 snapshot_column_tag_sql = """
 {% snapshot snapshot %}
     {{

--- a/tests/functional/adapter/column_tags/fixtures.py
+++ b/tests/functional/adapter/column_tags/fixtures.py
@@ -45,6 +45,50 @@ base_model_streaming_table = """
 SELECT * FROM stream {{ ref('base_model_seed') }}
 """
 
+drop_tagged_column_model = """
+{{ config(
+    materialized='incremental',
+    unique_key='id',
+    on_schema_change='sync_all_columns',
+    tblproperties={
+        'delta.columnMapping.mode': 'name',
+        'delta.minReaderVersion': '2',
+        'delta.minWriterVersion': '5',
+    }
+) }}
+{% if not is_incremental() %}
+select 1 as id, 'abc123' as account_number, 'x@y.com' as email
+{% else %}
+select 1 as id, 'abc123' as account_number
+{% endif %}
+"""
+
+drop_tagged_column_initial_schema = """
+version: 2
+models:
+  - name: drop_model
+    columns:
+      - name: id
+      - name: account_number
+        databricks_tags:
+          pii: "true"
+      - name: email
+        databricks_tags:
+          pii: "true"
+          contact: "true"
+"""
+
+drop_tagged_column_updated_schema = """
+version: 2
+models:
+  - name: drop_model
+    columns:
+      - name: id
+      - name: account_number
+        databricks_tags:
+          pii: "true"
+"""
+
 snapshot_column_tag_sql = """
 {% snapshot snapshot %}
     {{

--- a/tests/functional/adapter/column_tags/test_column_tags.py
+++ b/tests/functional/adapter/column_tags/test_column_tags.py
@@ -1,3 +1,5 @@
+import uuid
+
 import pytest
 from dbt.tests import util
 
@@ -6,6 +8,20 @@ from tests.functional.adapter.fixtures import (
     MaterializationV1Mixin,
     MaterializationV2Mixin,
     RerunSafeMixin,
+)
+
+# CREATE GOVERNED TAG needs account-level CREATE; soft-skip when the identity cannot.
+_GOVERNED_TAG_SETUP_SKIP_MARKERS = (
+    "permission",
+    "privilege",
+    "unauthorized",
+    "access denied",
+    "insufficient",
+    "not supported",
+    "parse_syntax_error",
+    "parse exception",
+    "feature is not enabled",
+    "uc_command_not_supported",
 )
 
 
@@ -204,6 +220,80 @@ class TestDropTaggedColumn(RerunSafeMixin, MaterializationV2Mixin):
         assert {"id", "account_number"}.issubset(columns)
 
         assert self._column_tags(project) == {("account_number", "pii", "true")}
+
+
+@pytest.mark.skip_profile("databricks_cluster")
+class TestDropGovernedTaggedColumn(RerunSafeMixin, MaterializationV2Mixin):
+    @pytest.fixture(scope="class")
+    def relations_to_reset(self):
+        return ("drop_model",)
+
+    @pytest.fixture(scope="class")
+    def governed_tag_key(self):
+        return f"dbt_ft_drop_gov_{uuid.uuid4().hex[:12]}"
+
+    @pytest.fixture(scope="class")
+    def models(self, governed_tag_key):
+        return {
+            "drop_model.sql": fixtures.drop_tagged_column_model,
+            "schema.yml": fixtures.drop_governed_tagged_column_initial_schema.format(
+                tag_key=governed_tag_key
+            ),
+        }
+
+    @pytest.fixture(scope="class", autouse=True)
+    def ensure_governed_tag(self, project, governed_tag_key):
+        try:
+            project.run_sql(f"CREATE GOVERNED TAG {governed_tag_key} VALUES ('true')")
+        except Exception as exc:
+            msg = str(exc).lower()
+            if any(marker in msg for marker in _GOVERNED_TAG_SETUP_SKIP_MARKERS):
+                pytest.skip(
+                    "Cannot CREATE GOVERNED TAG (need account-level CREATE / "
+                    f"supported SQL warehouse): {exc}"
+                )
+            raise
+
+        yield
+
+        try:
+            project.run_sql(f"DROP GOVERNED TAG {governed_tag_key}")
+        except Exception:
+            pass
+
+    def _column_tags(self, project):
+        rows = project.run_sql(
+            f"""
+            SELECT column_name, tag_name, tag_value
+            FROM `system`.`information_schema`.`column_tags`
+            WHERE catalog_name = '{project.database}'
+              AND schema_name = '{project.test_schema}'
+              AND table_name = 'drop_model'
+            ORDER BY column_name, tag_name
+            """,
+            fetch="all",
+        )
+        return {(row[0], row[1], row[2]) for row in rows}
+
+    def test_drop_governed_tagged_column(self, project, governed_tag_key):
+        util.run_dbt(["run"])
+        assert self._column_tags(project) == {("email", governed_tag_key, "true")}
+
+        util.write_file(
+            fixtures.drop_governed_tagged_column_updated_schema,
+            "models",
+            "schema.yml",
+        )
+        util.run_dbt(["run"])
+
+        columns = {
+            row[0]
+            for row in project.run_sql("DESCRIBE TABLE drop_model", fetch="all")
+            if row[0] and not row[0].startswith("#")
+        }
+        assert "email" not in columns
+        assert {"id", "account_number"}.issubset(columns)
+        assert self._column_tags(project) == set()
 
 
 @pytest.mark.skip_profile("databricks_cluster")

--- a/tests/functional/adapter/column_tags/test_column_tags.py
+++ b/tests/functional/adapter/column_tags/test_column_tags.py
@@ -158,6 +158,55 @@ class TestColumnTagsViewUpdateViaAlter(ColumnTagsMixin):
 
 
 @pytest.mark.skip_profile("databricks_cluster")
+class TestDropTaggedColumn(RerunSafeMixin, MaterializationV2Mixin):
+    @pytest.fixture(scope="class")
+    def relations_to_reset(self):
+        return ("drop_model",)
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "drop_model.sql": fixtures.drop_tagged_column_model,
+            "schema.yml": fixtures.drop_tagged_column_initial_schema,
+        }
+
+    def _column_tags(self, project):
+        rows = project.run_sql(
+            f"""
+            SELECT column_name, tag_name, tag_value
+            FROM `system`.`information_schema`.`column_tags`
+            WHERE catalog_name = '{project.database}'
+              AND schema_name = '{project.test_schema}'
+              AND table_name = 'drop_model'
+            ORDER BY column_name, tag_name
+            """,
+            fetch="all",
+        )
+        return {(row[0], row[1], row[2]) for row in rows}
+
+    def test_drop_tagged_column(self, project):
+        util.run_dbt(["run"])
+        assert self._column_tags(project) == {
+            ("account_number", "pii", "true"),
+            ("email", "pii", "true"),
+            ("email", "contact", "true"),
+        }
+
+        util.write_file(fixtures.drop_tagged_column_updated_schema, "models", "schema.yml")
+        util.run_dbt(["run"])
+
+        columns = {
+            row[0]
+            for row in project.run_sql("DESCRIBE TABLE drop_model", fetch="all")
+            if row[0] and not row[0].startswith("#")
+        }
+        assert "email" not in columns
+        assert {"id", "account_number"}.issubset(columns)
+
+        assert self._column_tags(project) == {("account_number", "pii", "true")}
+
+
+@pytest.mark.skip_profile("databricks_cluster")
 class TestColumnTagsTableV1(ColumnTagsMixin):
     relation_type = "table"
 

--- a/tests/unit/macros/relations/components/test_column_tags_macros.py
+++ b/tests/unit/macros/relations/components/test_column_tags_macros.py
@@ -66,10 +66,3 @@ class TestColumnTagsMacros(MacroTestBase):
         )
         assert "alter table `some_database`.`some_schema`.`some_table`" in sql
         assert "alter column `email` unset tags ('pii', 'team')" in sql
-
-    def test_alter_unset_column_tags_view_uses_alter_table(self, template_bundle):
-        template_bundle.relation.type = DatabricksRelationType.View
-        sql = self.render_bundle(template_bundle, "alter_unset_column_tags", "email", ["pii"])
-        assert "alter table" in sql
-        assert "alter view" not in sql
-        assert "alter column `email` unset tags ('pii')" in sql

--- a/tests/unit/macros/relations/components/test_column_tags_macros.py
+++ b/tests/unit/macros/relations/components/test_column_tags_macros.py
@@ -1,5 +1,6 @@
 import pytest
 
+from dbt.adapters.databricks.column import DatabricksColumn
 from dbt.adapters.databricks.relation import DatabricksRelationType
 from dbt.adapters.databricks.relation_configs.column_tags import ColumnTagsConfig
 from tests.unit.macros.base import MacroTestBase
@@ -66,3 +67,29 @@ class TestColumnTagsMacros(MacroTestBase):
         )
         assert "alter table `some_database`.`some_schema`.`some_table`" in sql
         assert "alter column `email` unset tags ('pii', 'team')" in sql
+
+    def test_unset_column_tags_noop_on_hive_metastore(self, passthrough_statement):
+        passthrough_statement.relation.is_hive_metastore = lambda: True
+
+        def boom(name):
+            raise AssertionError("must not query column tags on hive metastore")
+
+        passthrough_statement.context["load_result"] = boom
+        columns = [DatabricksColumn("email", "string")]
+        sql = self.run_macro(
+            passthrough_statement.template,
+            "unset_column_tags",
+            passthrough_statement.relation,
+            columns,
+        )
+        assert "unset tags" not in sql
+
+    def test_unset_column_tags_noop_when_no_columns(self, passthrough_statement):
+        def boom(name):
+            raise AssertionError("must not query column tags when there is nothing to drop")
+
+        passthrough_statement.context["load_result"] = boom
+        sql = self.run_macro(
+            passthrough_statement.template, "unset_column_tags", passthrough_statement.relation, []
+        )
+        assert "unset tags" not in sql

--- a/tests/unit/macros/relations/components/test_column_tags_macros.py
+++ b/tests/unit/macros/relations/components/test_column_tags_macros.py
@@ -22,7 +22,7 @@ class TestColumnTagsMacros(MacroTestBase):
         apply_* wrappers we need the inner ALTER SQL so we can assert on it. Also
         force the UC path (apply_column_tags raises on hive_metastore).
         """
-        template_bundle.context["statement"] = lambda label, caller=None: (
+        template_bundle.context["statement"] = lambda label, fetch_result=False, caller=None: (
             caller() if caller else label
         )
         template_bundle.relation.is_hive_metastore = lambda: False
@@ -59,3 +59,17 @@ class TestColumnTagsMacros(MacroTestBase):
         sql = self.render_bundle(passthrough_statement, "apply_column_tags", config)
         assert "alter" not in sql
         assert "set tags" not in sql
+
+    def test_alter_unset_column_tags_table(self, template_bundle):
+        sql = self.render_bundle(
+            template_bundle, "alter_unset_column_tags", "email", ["pii", "team"]
+        )
+        assert "alter table `some_database`.`some_schema`.`some_table`" in sql
+        assert "alter column `email` unset tags ('pii', 'team')" in sql
+
+    def test_alter_unset_column_tags_view_uses_alter_table(self, template_bundle):
+        template_bundle.relation.type = DatabricksRelationType.View
+        sql = self.render_bundle(template_bundle, "alter_unset_column_tags", "email", ["pii"])
+        assert "alter table" in sql
+        assert "alter view" not in sql
+        assert "alter column `email` unset tags ('pii')" in sql


### PR DESCRIPTION
<!-- Please review our pull request review process in CONTRIBUTING.md before your proceed. -->

Resolves #1323 

<!---
  Include the number of the issue addressed by this PR above if applicable.

  Example:
    resolves #1234

  Please review our pull request review process in CONTRIBUTING.md before your proceed.
-->

### Description

<!--- Describe the Pull Request here -->
Dropping a column that carries a governed tag fails with CANNOT_DROP_TAGGED_COLUMN, because Unity Catalog requires the tag be removed before the column. This unsets any tags on the columns being dropped (via on_schema_change='sync_all_columns') before issuing DROP COLUMNS, so tagged columns can be dropped cleanly.

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
- [ ] [Optional] I have run `/dbt-databricks-pr-ready` (AI agent skill in `.claude/skills/`) and addressed its merge-readiness feedback
