### PR TITLE
test: [ci] Pin integration runs to reviewed commit SHA

### DIFF
--- a/.github/workflows/integration-min-deps.yml
+++ b/.github/workflows/integration-min-deps.yml
@@ -31,6 +31,10 @@ on:
         description: "Git ref (branch/tag/commit) to test — used only when pr_numbers is empty"
         required: false
         type: string
+      commit_sha:
+        description: "Immutable 40-character commit SHA for a single PR — set by the integration-test trigger"
+        required: false
+        type: string
 
   schedule:
     - cron: "30 19 * * *"   # 19:30 UTC, 2h before integration.yml's nightly
@@ -68,6 +72,7 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           INPUT_PR_NUMBERS: ${{ github.event.inputs.pr_numbers }}
           INPUT_GIT_REF: ${{ github.event.inputs.git_ref }}
+          INPUT_COMMIT_SHA: ${{ github.event.inputs.commit_sha }}
           DEFAULT_REF: ${{ github.ref }}
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -87,6 +92,17 @@ jobs:
             else
               targets+=$(entry "nightly" "$DEFAULT_REF")
             fi
+          elif [[ -n "${INPUT_COMMIT_SHA//[[:space:]]/}" ]]; then
+            pr_trimmed="${INPUT_PR_NUMBERS//[[:space:]]/}"
+            if [[ ! "$pr_trimmed" =~ ^[0-9]+$ ]]; then
+              echo "::error::commit_sha requires exactly one numeric PR number, got pr_numbers='$INPUT_PR_NUMBERS'."
+              exit 1
+            fi
+            if [[ ! "$INPUT_COMMIT_SHA" =~ ^[0-9a-fA-F]{40}$ ]]; then
+              echo "::error::Invalid commit_sha '$INPUT_COMMIT_SHA' — expected a 40-character hexadecimal SHA."
+              exit 1
+            fi
+            targets+=$(entry "$pr_trimmed" "$INPUT_COMMIT_SHA")
           elif [[ -n "${INPUT_PR_NUMBERS//[[:space:]]/}" ]]; then
             first=1
             IFS=',' read -ra prs <<< "$INPUT_PR_NUMBERS"

--- a/.github/workflows/integration-trigger.yml
+++ b/.github/workflows/integration-trigger.yml
@@ -57,12 +57,18 @@ jobs:
             const workflowId = isMinDeps ? 'integration-min-deps.yml' : 'integration.yml';
             const label = isMinDeps ? 'Min-deps integration tests' : 'Integration tests';
             const prNumber = String(context.payload.issue.number);
+            const pullRequest = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.issue.number,
+            });
+            const commitSha = pullRequest.data.head.sha;
             await github.rest.actions.createWorkflowDispatch({
               owner: context.repo.owner,
               repo: context.repo.repo,
               workflow_id: workflowId,
               ref: 'main',
-              inputs: { pr_numbers: prNumber },
+              inputs: { pr_numbers: prNumber, commit_sha: commitSha },
             });
             const actionsUrl =
               `https://github.com/${context.repo.owner}/${context.repo.repo}` +
@@ -72,6 +78,7 @@ jobs:
               repo: context.repo.repo,
               issue_number: context.payload.issue.number,
               body: `${label} dispatched for PR #${prNumber} by @${context.payload.comment.user.login}. ` +
+                    `Testing commit ${commitSha.slice(0, 7)}. ` +
                     `Track progress in the [Actions tab](${actionsUrl}).`,
             });
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -31,6 +31,10 @@ on:
         description: "Git ref (branch/tag/commit) to test — used only when pr_numbers is empty"
         required: false
         type: string
+      commit_sha:
+        description: "Immutable 40-character commit SHA for a single PR — set by the integration-test trigger"
+        required: false
+        type: string
 
   schedule:
     - cron: "30 21 * * *"   # 21:30 UTC = 03:00 IST
@@ -70,6 +74,7 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           INPUT_PR_NUMBERS: ${{ github.event.inputs.pr_numbers }}
           INPUT_GIT_REF: ${{ github.event.inputs.git_ref }}
+          INPUT_COMMIT_SHA: ${{ github.event.inputs.commit_sha }}
           DEFAULT_REF: ${{ github.ref }}
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -89,6 +94,17 @@ jobs:
             else
               targets+=$(entry "nightly" "$DEFAULT_REF")
             fi
+          elif [[ -n "${INPUT_COMMIT_SHA//[[:space:]]/}" ]]; then
+            pr_trimmed="${INPUT_PR_NUMBERS//[[:space:]]/}"
+            if [[ ! "$pr_trimmed" =~ ^[0-9]+$ ]]; then
+              echo "::error::commit_sha requires exactly one numeric PR number, got pr_numbers='$INPUT_PR_NUMBERS'."
+              exit 1
+            fi
+            if [[ ! "$INPUT_COMMIT_SHA" =~ ^[0-9a-fA-F]{40}$ ]]; then
+              echo "::error::Invalid commit_sha '$INPUT_COMMIT_SHA' — expected a 40-character hexadecimal SHA."
+              exit 1
+            fi
+            targets+=$(entry "$pr_trimmed" "$INPUT_COMMIT_SHA")
           elif [[ -n "${INPUT_PR_NUMBERS//[[:space:]]/}" ]]; then
             first=1
             IFS=',' read -ra prs <<< "$INPUT_PR_NUMBERS"

--- a/tests/unit/test_integration_workflow_dispatch.py
+++ b/tests/unit/test_integration_workflow_dispatch.py
@@ -1,0 +1,116 @@
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+WORKFLOWS = (
+    Path(".github/workflows/integration.yml"),
+    Path(".github/workflows/integration-min-deps.yml"),
+)
+
+
+def _dispatch_inputs_from_trigger(commit_sha: str) -> dict[str, object]:
+    trigger = yaml.safe_load(Path(".github/workflows/integration-trigger.yml").read_text())
+    script = next(
+        step["with"]["script"]
+        for step in trigger["jobs"]["dispatch"]["steps"]
+        if step["name"] == "Dispatch integration workflow"
+    )
+    harness = f"""
+const script = {json.dumps(script)};
+const calls = {{ pulls: [], dispatches: [], comments: [] }};
+const github = {{
+  rest: {{
+    pulls: {{
+      get: async (args) => {{
+        calls.pulls.push(args);
+        return {{ data: {{ head: {{ sha: {json.dumps(commit_sha)} }} }} }};
+      }},
+    }},
+    actions: {{
+      createWorkflowDispatch: async (args) => calls.dispatches.push(args),
+    }},
+    issues: {{
+      createComment: async (args) => calls.comments.push(args),
+    }},
+  }},
+}};
+const context = {{
+  repo: {{ owner: "databricks", repo: "dbt-databricks" }},
+  payload: {{
+    comment: {{ body: "/integration-test", user: {{ login: "maintainer" }} }},
+    issue: {{ number: 123 }},
+  }},
+}};
+await new Function("github", "context", `return (async () => {{${{script}}}})();`)(github, context);
+console.log(JSON.stringify(calls));
+"""
+    result = subprocess.run(
+        ["node", "--input-type=module", "--eval", harness],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return json.loads(result.stdout)
+
+
+def _parse_targets(
+    workflow_path: Path, tmp_path: Path, commit_sha: str, pr_numbers: str = "123"
+) -> list[dict[str, str]]:
+    workflow = yaml.safe_load(workflow_path.read_text())
+    parse_step = next(
+        step for step in workflow["jobs"]["prepare"]["steps"] if step.get("id") == "parse"
+    )
+    output_path = tmp_path / "github-output"
+    result = subprocess.run(
+        ["bash", "-o", "pipefail", "-c", parse_step["run"]],
+        check=True,
+        capture_output=True,
+        env={
+            **os.environ,
+            "EVENT_NAME": "workflow_dispatch",
+            "INPUT_PR_NUMBERS": pr_numbers,
+            "INPUT_COMMIT_SHA": commit_sha,
+            "INPUT_GIT_REF": "",
+            "DEFAULT_REF": "refs/heads/main",
+            "GH_TOKEN": "test-token",
+            "GITHUB_OUTPUT": str(output_path),
+        },
+        text=True,
+    )
+    outputs = dict(line.split("=", 1) for line in output_path.read_text().splitlines())
+    assert "Parsed targets:" in result.stdout
+    return json.loads(outputs["targets"])
+
+
+def test_trigger_dispatches_fetched_pull_request_sha():
+    commit_sha = "b" * 40
+
+    calls = _dispatch_inputs_from_trigger(commit_sha)
+
+    assert calls["pulls"] == [{"owner": "databricks", "repo": "dbt-databricks", "pull_number": 123}]
+    assert calls["dispatches"] == [
+        {
+            "owner": "databricks",
+            "repo": "dbt-databricks",
+            "workflow_id": "integration.yml",
+            "ref": "main",
+            "inputs": {"pr_numbers": "123", "commit_sha": commit_sha},
+        }
+    ]
+
+
+@pytest.mark.parametrize("workflow_path", WORKFLOWS)
+def test_commit_sha_input_rejects_malformed_sha(workflow_path: Path, tmp_path: Path):
+    with pytest.raises(subprocess.CalledProcessError):
+        _parse_targets(workflow_path, tmp_path, "not-a-sha")
+
+
+@pytest.mark.parametrize("workflow_path", WORKFLOWS)
+def test_commit_sha_input_pins_pull_request_target(workflow_path: Path, tmp_path: Path):
+    commit_sha = "a" * 40
+
+    assert _parse_targets(workflow_path, tmp_path, commit_sha) == [{"pr": "123", "ref": commit_sha}]


### PR DESCRIPTION
### Description

Maintainer approval for a fork pull request should authorize the exact commit that was reviewed. Previously, a contributor could push another commit after approval but before the privileged integration workflow checked out the pull request head.

This change captures the pull request head SHA when the integration command is accepted, passes that immutable SHA to both integration workflows, validates it before checkout, and reports the abbreviated SHA in the pull request status comment. Manual `git_ref`, manual pull request number, scheduled, and minimum-dependency execution paths retain their existing behavior.

Regression tests execute the embedded trigger and parser scripts to verify SHA capture and propagation, both workflow checkout targets, and rejection of malformed SHAs.

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section. (Not applicable: CI-only change with no runtime behavior impact.)
- [ ] [Optional] I have run `/dbt-databricks-pr-ready` (AI agent skill in `.claude/skills/`) and addressed its merge-readiness feedback

Verification:

- `hatch run pytest tests/unit/test_integration_workflow_dispatch.py -v` (`5 passed`)
- Full unit suite (`1284 passed, 6 skipped`)
- `hatch run pre-commit run --all-files`
- `git diff --check`
