### PR TITLE
fix: diff Streaming Table tags against existing tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Fixes
 
+- Avoid treating unchanged Streaming Table `databricks_tags` as configuration changes by diffing against existing table tags. ([#1602](https://github.com/databricks/dbt-databricks/pull/1602) resolves [#1601](https://github.com/databricks/dbt-databricks/issues/1601))
 - Allow dropping a column that has governed tags ([#1597](https://github.com/databricks/dbt-databricks/pull/1597) resolves [#1323](https://github.com/databricks/dbt-databricks/issues/1323))
 - Fix view materialization incorrectly producing a no-op instead of forcing recreation when `--full-refresh` is provided alongside `view_update_via_alter: true` and `use_materialization_v2: true` ([#1456](https://github.com/databricks/dbt-databricks/pull/1456) resolves [#1404](https://github.com/databricks/dbt-databricks/issues/1404))
 - Support `dbt clone` and rebuilds over an existing shallow clone ([#1592](https://github.com/databricks/dbt-databricks/pull/1592) resolves [#1165](https://github.com/databricks/dbt-databricks/issues/1165))

--- a/dbt/adapters/databricks/impl.py
+++ b/dbt/adapters/databricks/impl.py
@@ -1353,6 +1353,12 @@ class StreamingTableAPI(DeltaLiveTableAPIBase[StreamingTableConfig]):
 
         kwargs = {"relation": relation}
 
+        table_tag_config = model_config.config.get(TagsProcessor.name) if model_config else None
+        if table_tag_config is None or table_tag_config.requires_server_metadata_for_diff():
+            results["information_schema.tags"] = adapter.execute_macro("fetch_tags", kwargs=kwargs)
+        else:
+            results["information_schema.tags"] = None
+
         results["show_tblproperties"] = adapter.execute_macro("fetch_tbl_properties", kwargs=kwargs)
 
         if adapter.is_describe_as_json_supported(relation):

--- a/tests/functional/adapter/tags/test_databricks_tags.py
+++ b/tests/functional/adapter/tags/test_databricks_tags.py
@@ -158,6 +158,10 @@ class TestStreamingTableTags(BaseTestTags):
             "tags.sql": fixtures.streaming_table_tags_sql,
         }
 
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {"models": {"+on_configuration_change": "fail"}}
+
     def test_tags(self, project):
         util.run_dbt(["seed"])
         super().test_tags(project)

--- a/tests/unit/test_adapter.py
+++ b/tests/unit/test_adapter.py
@@ -31,6 +31,7 @@ from dbt.adapters.databricks.impl import (
     DatabricksRelationInfo,
     IncrementalTableAPI,
     MaterializedViewAPI,
+    StreamingTableAPI,
     ViewAPI,
     get_identifier_list_string,
 )
@@ -45,6 +46,7 @@ from dbt.adapters.databricks.relation_configs.column_tags import (
 )
 from dbt.adapters.databricks.relation_configs.incremental import IncrementalTableConfig
 from dbt.adapters.databricks.relation_configs.materialized_view import MaterializedViewConfig
+from dbt.adapters.databricks.relation_configs.streaming_table import StreamingTableConfig
 from dbt.adapters.databricks.relation_configs.tags import TagsConfig, TagsProcessor
 from dbt.adapters.databricks.relation_configs.view import ViewConfig
 from dbt.adapters.databricks.utils import check_not_found_error
@@ -1536,6 +1538,15 @@ class TestDescribeRelationMetadataFetchPlanning:
         )
 
     @staticmethod
+    def _create_st_relation(database="main"):
+        return DatabricksRelation.create(
+            database=database,
+            schema="analytics",
+            identifier="my_st_model",
+            type=DatabricksRelationType.StreamingTable,
+        )
+
+    @staticmethod
     def _create_incremental_config(
         tags: dict[str, str] | None = None,
         column_tags: dict[str, dict[str, str]] | None = None,
@@ -1562,6 +1573,10 @@ class TestDescribeRelationMetadataFetchPlanning:
     @staticmethod
     def _create_mv_config(tags: dict[str, str] | None = None) -> MaterializedViewConfig:
         return MaterializedViewConfig(config={TagsProcessor.name: TagsConfig(set_tags=tags or {})})
+
+    @staticmethod
+    def _create_st_config(tags: dict[str, str] | None = None) -> StreamingTableConfig:
+        return StreamingTableConfig(config={TagsProcessor.name: TagsConfig(set_tags=tags or {})})
 
     @staticmethod
     def _called_macro_names(adapter: Mock) -> list[str]:
@@ -1762,6 +1777,40 @@ class TestDescribeRelationMetadataFetchPlanning:
         called_macro_names = self._called_macro_names(adapter)
         assert "fetch_tags" in called_macro_names
         assert "get_view_description" in called_macro_names
+
+    def test_st_describe_relation_skips_tag_query_without_tags(self):
+        adapter = self._create_adapter()
+        relation = self._create_st_relation()
+        relation_config = self._create_st_config()
+
+        results = StreamingTableAPI._describe_relation(adapter, relation, relation_config)
+
+        assert results["information_schema.tags"] is None
+        called_macro_names = self._called_macro_names(adapter)
+        assert "fetch_tags" not in called_macro_names
+        assert "fetch_tbl_properties" in called_macro_names
+        assert DESCRIBE_TABLE_EXTENDED_MACRO_NAME in called_macro_names
+
+    def test_st_describe_relation_fetches_tag_query_when_tags_present(self):
+        adapter = self._create_adapter()
+        relation = self._create_st_relation()
+        relation_config = self._create_st_config(tags={"classification": "internal"})
+
+        results = StreamingTableAPI._describe_relation(adapter, relation, relation_config)
+
+        assert results["information_schema.tags"] == "fetch_tags_result"
+        called_macro_names = self._called_macro_names(adapter)
+        assert "fetch_tags" in called_macro_names
+
+    def test_st_describe_relation_fetches_tags_when_relation_config_is_none(self):
+        adapter = self._create_adapter()
+        relation = self._create_st_relation()
+
+        results = StreamingTableAPI._describe_relation(adapter, relation, None)
+
+        assert results["information_schema.tags"] == "fetch_tags_result"
+        called_macro_names = self._called_macro_names(adapter)
+        assert "fetch_tags" in called_macro_names
 
 
 class TestManagedIcebergBehaviorFlag(DatabricksAdapterBase):


### PR DESCRIPTION
Resolves #1601

### Description

Streaming Tables with configured databricks_tags did not fetch their existing table tags during relation metadata planning. On every unchanged rerun, the configured tags were compared with an empty server state and falsely reported as a configuration change.

This had broader effects than the fail case alone:

- With the default apply behavior, the false change entered the alter path, issued an unnecessary CREATE OR REFRESH STREAMING TABLE, and set the configured tags. The common execution wrapper then applied the tags again.
- With fail, the unchanged run aborted.
- With continue, the unchanged run warned and skipped execution.

This change adds the same conditional tag fetch already used by Materialized Views:

- Fetch existing table tags when configured tags require server metadata.
- Skip the Information Schema query when no tags are configured.
- Preserve the safe fetch when model_config is absent.

Identical tags now produce no tag changeset, so Streaming Tables follow their normal no-change refresh policy. Manual and cron refresh behavior remains unchanged, while auto-refreshed EVERY and ON UPDATE modes can remain true no-ops.

The change is limited to table-level tag metadata planning. Column tags, tag removal, and duplicate tag writes for genuine tag changes remain unchanged.

### Verification

- [x] Reproduced the unchanged second-run false change before the fix using on_configuration_change set to fail.
- [x] Added metadata-planning unit coverage for tagged, untagged, and missing-config Streaming Tables.
- [x] Verified unchanged and updated Streaming Table tags and existing Materialized View tag behavior against Databricks.
- [x] Ran the full unit suite: 1,314 passed and 5 skipped.
- [x] Ran all repository pre-commit checks.

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the CHANGELOG.md and added information about my change to the dbt-databricks next section.
- [ ] [Optional] I have run the dbt-databricks-pr-ready project skill for this PR and addressed its merge-readiness feedback