### PR TITLE
perf: fetch table tags through Unity Catalog API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### Under the Hood
 
 - Remove unused internal logging-event classes (`CredentialLoadError`/`CredentialSaveError`/`CredentialShardEvent`, `PipelineEvent`/`PipelineRefresh`/`PipelineRefreshError`, and the `ConnectionReset`/`ConnectionReuse`/`ConnectionIdleClose`/`ConnectionCreated` connection events) that have had no call sites since the cursor-management and pipeline refactors ([#1547](https://github.com/databricks/dbt-databricks/pull/1547))
-- Fetch table tags through the Unity Catalog Entity Tag Assignments API instead of `information_schema`, reducing metadata-query rate-limit pressure.
+- Fetch table tags through the Unity Catalog Entity Tag Assignments API instead of `information_schema`, reducing metadata-query rate-limit pressure. ([#1603](https://github.com/databricks/dbt-databricks/pull/1603))
 
 ## dbt-databricks 1.12.2 (Jul 9, 2026)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Under the Hood
 
 - Remove unused internal logging-event classes (`CredentialLoadError`/`CredentialSaveError`/`CredentialShardEvent`, `PipelineEvent`/`PipelineRefresh`/`PipelineRefreshError`, and the `ConnectionReset`/`ConnectionReuse`/`ConnectionIdleClose`/`ConnectionCreated` connection events) that have had no call sites since the cursor-management and pipeline refactors ([#1547](https://github.com/databricks/dbt-databricks/pull/1547))
+- Fetch table tags through the Unity Catalog Entity Tag Assignments API instead of `information_schema`, reducing metadata-query rate-limit pressure.
 
 ## dbt-databricks 1.12.2 (Jul 9, 2026)
 

--- a/dbt/adapters/databricks/api_client.py
+++ b/dbt/adapters/databricks/api_client.py
@@ -298,6 +298,23 @@ class CurrUserApi:
         return bool(re.match(uuid_pattern, username, re.IGNORECASE))
 
 
+class EntityTagAssignmentsApi:
+    def __init__(self, workspace_client: WorkspaceClient):
+        self.workspace_client = workspace_client
+
+    def list_table_tags(self, entity_name: str) -> dict[str, str]:
+        try:
+            # Unity Catalog allows at most 50 tags per entity, so one page is sufficient.
+            assignments = self.workspace_client.entity_tag_assignments.list(
+                entity_type="tables",
+                entity_name=entity_name,
+                max_results=50,
+            )
+            return {assignment.tag_key: assignment.tag_value or "" for assignment in assignments}
+        except Exception as e:
+            raise DbtRuntimeError(f"Error fetching table tags for {entity_name}: {e}")
+
+
 # Switch to this as part of 2.0.0 release
 class UserFolderApi(FolderApi):
     def __init__(self, user_api: CurrUserApi):
@@ -955,6 +972,7 @@ class DatabricksApiClient:
         self.clusters = ClusterApi(workspace_client, self.libraries)
         self.command_contexts = CommandContextApi(workspace_client, self.clusters, self.libraries)
         self.curr_user = CurrUserApi(workspace_client)
+        self.entity_tag_assignments = EntityTagAssignmentsApi(workspace_client)
         if use_user_folder:
             self.folders: FolderApi = UserFolderApi(self.curr_user)
         else:

--- a/dbt/adapters/databricks/api_client.py
+++ b/dbt/adapters/databricks/api_client.py
@@ -303,8 +303,13 @@ class EntityTagAssignmentsApi:
         self.workspace_client = workspace_client
 
     def list_table_tags(self, entity_name: str) -> dict[str, str]:
+        """List tag assignments for a table-like Unity Catalog entity.
+
+        `entity_type="tables"` covers views, materialized views, and metric views as well.
+        """
         try:
-            # Unity Catalog allows at most 50 tags per entity, so one page is sufficient.
+            # max_results is a page size, not a cap: the SDK returns a generator that follows
+            # next_page_token until it is absent, so consuming it yields every assignment.
             assignments = self.workspace_client.entity_tag_assignments.list(
                 entity_type="tables",
                 entity_name=entity_name,

--- a/dbt/adapters/databricks/impl.py
+++ b/dbt/adapters/databricks/impl.py
@@ -1251,6 +1251,20 @@ class RelationAPIBase(ABC, Generic[DatabricksRelationConfig]):
         return cls.config_type().from_relation_config(relation_config)
 
     @classmethod
+    def _get_table_tags(
+        cls,
+        adapter: DatabricksAdapter,
+        relation: DatabricksRelation,
+    ) -> dict[str, str]:
+        if relation.database is None or relation.schema is None or relation.identifier is None:
+            raise DbtRuntimeError(
+                f"Cannot fetch table tags without a fully qualified relation name: {relation}"
+            )
+
+        entity_name = f"{relation.database}.{relation.schema}.{relation.identifier}"
+        return adapter.connections.api_client.entity_tag_assignments.list_table_tags(entity_name)
+
+    @classmethod
     @abstractmethod
     def _describe_relation(
         cls,
@@ -1310,9 +1324,9 @@ class MaterializedViewAPI(DeltaLiveTableAPIBase[MaterializedViewConfig]):
         # to maintain backward compatibility.
         table_tag_config = model_config.config.get(TagsProcessor.name) if model_config else None
         if table_tag_config is None or table_tag_config.requires_server_metadata_for_diff():
-            results["information_schema.tags"] = adapter.execute_macro("fetch_tags", kwargs=kwargs)
+            results["table_tags"] = cls._get_table_tags(adapter, relation)
         else:
-            results["information_schema.tags"] = None
+            results["table_tags"] = None
 
         if adapter.is_describe_as_json_supported(relation):
             json_metadata = adapter.fetch_json_metadata(relation)
@@ -1378,7 +1392,7 @@ class IncrementalTableAPI(RelationAPIBase[IncrementalTableConfig]):
         relation: DatabricksRelation,
         model_config: Optional[DatabricksRelationConfigBase] = None,
     ) -> RelationResults:
-        results = {}
+        results: RelationResults = {}
         kwargs = {"relation": relation}
 
         if not relation.is_hive_metastore():
@@ -1386,11 +1400,9 @@ class IncrementalTableAPI(RelationAPIBase[IncrementalTableConfig]):
             # fetched to maintain backward compatibility.
             table_tag_config = model_config.config.get(TagsProcessor.name) if model_config else None
             if table_tag_config is None or table_tag_config.requires_server_metadata_for_diff():
-                results["information_schema.tags"] = adapter.execute_macro(
-                    "fetch_tags", kwargs=kwargs
-                )
+                results["table_tags"] = cls._get_table_tags(adapter, relation)
             else:
-                results["information_schema.tags"] = None
+                results["table_tags"] = None
 
             # To be backward compatible model_config can be None. In that case, tags should be
             # fetched to maintain backward compatibility.
@@ -1449,16 +1461,18 @@ class ViewAPI(RelationAPIBase[ViewConfig]):
         relation: DatabricksRelation,
         model_config: Optional[DatabricksRelationConfigBase] = None,
     ) -> RelationResults:
-        results = {}
+        results: RelationResults = {}
         kwargs = {"relation": relation}
 
         # To be backward compatible model_config can be None. In that case, tags should be fetched
         # to maintain backward compatibility.
         table_tag_config = model_config.config.get(TagsProcessor.name) if model_config else None
-        if table_tag_config is None or table_tag_config.requires_server_metadata_for_diff():
-            results["information_schema.tags"] = adapter.execute_macro("fetch_tags", kwargs=kwargs)
+        if relation.is_hive_metastore():
+            results["table_tags"] = None
+        elif table_tag_config is None or table_tag_config.requires_server_metadata_for_diff():
+            results["table_tags"] = cls._get_table_tags(adapter, relation)
         else:
-            results["information_schema.tags"] = None
+            results["table_tags"] = None
 
         column_tag_config = (
             model_config.config.get(ColumnTagsProcessor.name) if model_config else None
@@ -1503,16 +1517,16 @@ class MetricViewAPI(RelationAPIBase[MetricViewConfig]):
         relation: DatabricksRelation,
         model_config: Optional[DatabricksRelationConfigBase] = None,
     ) -> RelationResults:
-        results = {}
+        results: RelationResults = {}
         kwargs = {"relation": relation}
         results["show_tblproperties"] = adapter.execute_macro("fetch_tbl_properties", kwargs=kwargs)
 
         kwargs = {"relation": relation}
         table_tag_config = model_config.config.get(TagsProcessor.name) if model_config else None
         if table_tag_config is None or table_tag_config.requires_server_metadata_for_diff():
-            results["information_schema.tags"] = adapter.execute_macro("fetch_tags", kwargs=kwargs)
+            results["table_tags"] = cls._get_table_tags(adapter, relation)
         else:
-            results["information_schema.tags"] = None
+            results["table_tags"] = None
 
         kwargs = {"table_name": relation}
         results["describe_extended"] = adapter.execute_macro(

--- a/dbt/adapters/databricks/impl.py
+++ b/dbt/adapters/databricks/impl.py
@@ -1256,6 +1256,9 @@ class RelationAPIBase(ABC, Generic[DatabricksRelationConfig]):
         adapter: DatabricksAdapter,
         relation: DatabricksRelation,
     ) -> dict[str, str]:
+        if relation.is_hive_metastore():
+            raise DbtRuntimeError("Tags are only supported for Unity Catalog")
+
         if relation.database is None or relation.schema is None or relation.identifier is None:
             raise DbtRuntimeError(
                 f"Cannot fetch table tags without a fully qualified relation name: {relation}"
@@ -1467,9 +1470,7 @@ class ViewAPI(RelationAPIBase[ViewConfig]):
         # To be backward compatible model_config can be None. In that case, tags should be fetched
         # to maintain backward compatibility.
         table_tag_config = model_config.config.get(TagsProcessor.name) if model_config else None
-        if relation.is_hive_metastore():
-            results["table_tags"] = None
-        elif table_tag_config is None or table_tag_config.requires_server_metadata_for_diff():
+        if table_tag_config is None or table_tag_config.requires_server_metadata_for_diff():
             results["table_tags"] = cls._get_table_tags(adapter, relation)
         else:
             results["table_tags"] = None
@@ -1521,7 +1522,6 @@ class MetricViewAPI(RelationAPIBase[MetricViewConfig]):
         kwargs = {"relation": relation}
         results["show_tblproperties"] = adapter.execute_macro("fetch_tbl_properties", kwargs=kwargs)
 
-        kwargs = {"relation": relation}
         table_tag_config = model_config.config.get(TagsProcessor.name) if model_config else None
         if table_tag_config is None or table_tag_config.requires_server_metadata_for_diff():
             results["table_tags"] = cls._get_table_tags(adapter, relation)

--- a/dbt/adapters/databricks/relation_configs/tags.py
+++ b/dbt/adapters/databricks/relation_configs/tags.py
@@ -34,14 +34,10 @@ class TagsProcessor(DatabricksComponentProcessor[TagsConfig]):
 
     @classmethod
     def from_relation_results(cls, results: RelationResults) -> TagsConfig:
-        table = results.get("information_schema.tags")
-        tags = dict()
-
-        if table:
-            for row in table.rows:
-                tags[str(row[0])] = "" if row[1] is None else str(row[1])
-
-        return TagsConfig(set_tags=tags)
+        tags = results.get("table_tags") or {}
+        return TagsConfig(
+            set_tags={str(key): "" if value is None else str(value) for key, value in tags.items()}
+        )
 
     @classmethod
     def from_relation_config(cls, relation_config: RelationConfig) -> TagsConfig:

--- a/dbt/include/databricks/macros/relations/tags.sql
+++ b/dbt/include/databricks/macros/relations/tags.sql
@@ -1,3 +1,5 @@
+{# Compatibility surface for projects that invoke or override this macro directly.
+   Internal relation metadata reads use the Unity Catalog Entity Tag Assignments API. #}
 {% macro fetch_tags(relation) -%}
   {% if relation.is_hive_metastore() %}
     {{ exceptions.raise_compiler_error("Tags are only supported for Unity Catalog") }}

--- a/tests/functional/adapter/incremental/test_incremental_metadata_fetch_skips.py
+++ b/tests/functional/adapter/incremental/test_incremental_metadata_fetch_skips.py
@@ -37,21 +37,19 @@ class TestIncrementalMetadataFetchRequiresTableTags:
             "schema.yml": fixtures.metadata_fetch_table_tags_schema,
         }
 
-    @pytest.fixture(scope="class")
-    def macros(self):
-        return {"fail_if_tag_fetch_called.sql": fail_if_tag_and_column_tag_fetch_called_macros}
-
-    def test_second_incremental_run_fails_when_table_tag_fetch_is_required(self, project):
+    def test_second_incremental_run_reads_table_tags_from_api(self, project):
         # The first run creates the relation; the second run exercises the existing-relation
         # path where adapter.get_relation_config() may attempt metadata fetches.
         util.run_dbt(["run"])
+        util.run_dbt(["run"])
 
-        run_execution_results = util.run_dbt(["run"], expect_pass=False)
-        assert len(run_execution_results.results) == 1
-        result = run_execution_results.results[0]
-
-        assert result.status == RunStatus.Error
-        assert "tags should not be called" in result.message
+        tags = project.run_sql(
+            "select tag_name, tag_value from `system`.`information_schema`.`table_tags` "
+            "where schema_name = '{schema}' "
+            "and table_name = 'metadata_fetch_incremental'",
+            fetch="all",
+        )
+        assert {(row[0], row[1]) for row in tags} == {("classification", "internal")}
 
 
 @pytest.mark.skip_profile("databricks_cluster")

--- a/tests/functional/adapter/incremental/test_incremental_metadata_fetch_skips.py
+++ b/tests/functional/adapter/incremental/test_incremental_metadata_fetch_skips.py
@@ -37,9 +37,15 @@ class TestIncrementalMetadataFetchRequiresTableTags:
             "schema.yml": fixtures.metadata_fetch_table_tags_schema,
         }
 
+    @pytest.fixture(scope="class")
+    def macros(self):
+        # Fails the run if table-tag reads regress from the UC API to the information_schema macro.
+        # This model declares no column tags, so the column-tag guard is never reached.
+        return {"fail_if_tag_fetch_called.sql": fail_if_tag_and_column_tag_fetch_called_macros}
+
     def test_second_incremental_run_reads_table_tags_from_api(self, project):
         # The first run creates the relation; the second run exercises the existing-relation
-        # path where adapter.get_relation_config() may attempt metadata fetches.
+        # path where adapter.get_relation_config() fetches tags.
         util.run_dbt(["run"])
         util.run_dbt(["run"])
 

--- a/tests/functional/adapter/materialized_view_tests/test_materialized_view_metadata_fetch_skips.py
+++ b/tests/functional/adapter/materialized_view_tests/test_materialized_view_metadata_fetch_skips.py
@@ -1,5 +1,4 @@
 import pytest
-from dbt.artifacts.schemas.results import RunStatus
 from dbt.tests import util
 
 from tests.functional.adapter.fixtures import fail_if_tag_fetch_called_macros
@@ -40,19 +39,16 @@ class TestMaterializedViewMetadataFetchRequiresTags:
     def models(self):
         return {"mv_metadata_fetch.sql": fixtures.metadata_fetch_materialized_view_with_tags_sql}
 
-    @pytest.fixture(scope="class")
-    def macros(self):
-        return {"fail_if_tag_fetch_called.sql": fail_if_tag_fetch_called_macros}
-
-    def test_second_materialized_view_run_fails_when_tag_fetch_is_required(self, project):
+    def test_second_materialized_view_run_reads_tags_from_api(self, project):
         # The first run creates the relation; the second run exercises the existing-relation
         # path where adapter.get_relation_config() may attempt metadata fetches.
         util.run_dbt(["seed"])
         util.run_dbt(["run"])
+        util.run_dbt(["run"])
 
-        run_execution_results = util.run_dbt(["run"], expect_pass=False)
-        assert len(run_execution_results.results) == 1
-        result = run_execution_results.results[0]
-
-        assert result.status == RunStatus.Error
-        assert "fetch_tags should not be called" in result.message
+        tags = project.run_sql(
+            "select tag_name, tag_value from `system`.`information_schema`.`table_tags` "
+            "where schema_name = '{schema}' and table_name = 'mv_metadata_fetch'",
+            fetch="all",
+        )
+        assert {(row[0], row[1]) for row in tags} == {("classification", "internal")}

--- a/tests/functional/adapter/materialized_view_tests/test_materialized_view_metadata_fetch_skips.py
+++ b/tests/functional/adapter/materialized_view_tests/test_materialized_view_metadata_fetch_skips.py
@@ -39,9 +39,14 @@ class TestMaterializedViewMetadataFetchRequiresTags:
     def models(self):
         return {"mv_metadata_fetch.sql": fixtures.metadata_fetch_materialized_view_with_tags_sql}
 
+    @pytest.fixture(scope="class")
+    def macros(self):
+        # Fails the run if table-tag reads regress from the UC API to the information_schema macro.
+        return {"fail_if_tag_fetch_called.sql": fail_if_tag_fetch_called_macros}
+
     def test_second_materialized_view_run_reads_tags_from_api(self, project):
         # The first run creates the relation; the second run exercises the existing-relation
-        # path where adapter.get_relation_config() may attempt metadata fetches.
+        # path where adapter.get_relation_config() fetches tags.
         util.run_dbt(["seed"])
         util.run_dbt(["run"])
         util.run_dbt(["run"])

--- a/tests/functional/adapter/views/test_view_metadata_fetch_skips.py
+++ b/tests/functional/adapter/views/test_view_metadata_fetch_skips.py
@@ -1,5 +1,4 @@
 import pytest
-from dbt.artifacts.schemas.results import RunStatus
 from dbt.tests import util
 
 from tests.functional.adapter.fixtures import fail_if_tag_fetch_called_macros
@@ -39,10 +38,6 @@ class TestViewMetadataFetchRequiresTags:
         return {"view_metadata_fetch.sql": view_with_tags_sql}
 
     @pytest.fixture(scope="class")
-    def macros(self):
-        return {"fail_if_tag_fetch_called.sql": fail_if_tag_fetch_called_macros}
-
-    @pytest.fixture(scope="class")
     def project_config_update(self):
         return {
             "flags": {"use_materialization_v2": True},
@@ -51,14 +46,15 @@ class TestViewMetadataFetchRequiresTags:
             },
         }
 
-    def test_second_view_run_fails_when_tag_fetch_is_required(self, project):
+    def test_second_view_run_reads_tags_from_api(self, project):
         # The first run creates the view; the second run exercises the existing-relation
         # alter/config-diff path where adapter.get_relation_config() may fetch tags.
         util.run_dbt(["run"])
+        util.run_dbt(["run"])
 
-        run_execution_results = util.run_dbt(["run"], expect_pass=False)
-        assert len(run_execution_results.results) == 1
-        result = run_execution_results.results[0]
-
-        assert result.status == RunStatus.Error
-        assert "fetch_tags should not be called" in result.message
+        tags = project.run_sql(
+            "select tag_name, tag_value from `system`.`information_schema`.`table_tags` "
+            "where schema_name = '{schema}' and table_name = 'view_metadata_fetch'",
+            fetch="all",
+        )
+        assert {(row[0], row[1]) for row in tags} == {("classification", "internal")}

--- a/tests/functional/adapter/views/test_view_metadata_fetch_skips.py
+++ b/tests/functional/adapter/views/test_view_metadata_fetch_skips.py
@@ -38,6 +38,11 @@ class TestViewMetadataFetchRequiresTags:
         return {"view_metadata_fetch.sql": view_with_tags_sql}
 
     @pytest.fixture(scope="class")
+    def macros(self):
+        # Fails the run if table-tag reads regress from the UC API to the information_schema macro.
+        return {"fail_if_tag_fetch_called.sql": fail_if_tag_fetch_called_macros}
+
+    @pytest.fixture(scope="class")
     def project_config_update(self):
         return {
             "flags": {"use_materialization_v2": True},
@@ -48,7 +53,7 @@ class TestViewMetadataFetchRequiresTags:
 
     def test_second_view_run_reads_tags_from_api(self, project):
         # The first run creates the view; the second run exercises the existing-relation
-        # alter/config-diff path where adapter.get_relation_config() may fetch tags.
+        # alter/config-diff path where adapter.get_relation_config() fetches tags.
         util.run_dbt(["run"])
         util.run_dbt(["run"])
 

--- a/tests/unit/api_client/test_entity_tag_assignments_api.py
+++ b/tests/unit/api_client/test_entity_tag_assignments_api.py
@@ -1,0 +1,53 @@
+from unittest.mock import Mock, patch
+
+import pytest
+from databricks.sdk.service.catalog import EntityTagAssignment
+from dbt_common.exceptions import DbtRuntimeError
+
+from dbt.adapters.databricks.api_client import DatabricksApiClient, EntityTagAssignmentsApi
+
+
+class TestEntityTagAssignmentsApi:
+    @patch("dbt.adapters.databricks.api_client.DatabricksCredentialManager.create_from")
+    def test_databricks_api_client_exposes_entity_tag_assignments(self, create_from):
+        workspace_client = Mock()
+        create_from.return_value.api_client = workspace_client
+
+        api_client = DatabricksApiClient(Mock(), timeout=60)
+
+        assert api_client.entity_tag_assignments.workspace_client is workspace_client
+
+    def test_list_table_tags(self):
+        workspace_client = Mock()
+        workspace_client.entity_tag_assignments.list.return_value = [
+            EntityTagAssignment(
+                entity_name="main.analytics.orders",
+                entity_type="tables",
+                tag_key="classification",
+                tag_value="internal",
+            ),
+            EntityTagAssignment(
+                entity_name="main.analytics.orders",
+                entity_type="tables",
+                tag_key="key_only",
+            ),
+        ]
+
+        tags = EntityTagAssignmentsApi(workspace_client).list_table_tags("main.analytics.orders")
+
+        assert tags == {"classification": "internal", "key_only": ""}
+        workspace_client.entity_tag_assignments.list.assert_called_once_with(
+            entity_type="tables",
+            entity_name="main.analytics.orders",
+            max_results=50,
+        )
+
+    def test_list_table_tags_wraps_sdk_errors(self):
+        workspace_client = Mock()
+        workspace_client.entity_tag_assignments.list.side_effect = RuntimeError("rate limited")
+
+        with pytest.raises(
+            DbtRuntimeError,
+            match="Error fetching table tags for main.analytics.orders",
+        ):
+            EntityTagAssignmentsApi(workspace_client).list_table_tags("main.analytics.orders")

--- a/tests/unit/relation_configs/test_incremental_config.py
+++ b/tests/unit/relation_configs/test_incremental_config.py
@@ -21,13 +21,10 @@ from dbt.adapters.databricks.relation_configs.tblproperties import TblProperties
 class TestIncrementalConfig:
     def test_from_results(self):
         results = {
-            "information_schema.tags": Table(
-                rows=[
-                    ["tag1", "value1"],
-                    ["tag2", "value2"],
-                ],
-                column_names=["tag_name", "tag_value"],
-            ),
+            "table_tags": {
+                "tag1": "value1",
+                "tag2": "value2",
+            },
             "information_schema.column_tags": Table(
                 rows=[
                     ["column", "sensitive", "true"],

--- a/tests/unit/relation_configs/test_materialized_view_config.py
+++ b/tests/unit/relation_configs/test_materialized_view_config.py
@@ -41,9 +41,7 @@ class TestMaterializedViewConfig:
             "show_tblproperties": Table(
                 rows=[["prop", "1"], ["other", "other"]], column_names=["key", "value"]
             ),
-            "information_schema.tags": Table(
-                rows=[["a", "b"], ["c", "d"]], column_names=["tag_name", "tag_value"]
-            ),
+            "table_tags": {"a": "b", "c": "d"},
         }
 
         config = MaterializedViewConfig.from_results(results)
@@ -163,6 +161,6 @@ class TestMaterializedViewAPIDescribeRelation:
 
         results = MaterializedViewAPI._describe_relation(adapter, MagicMock())
 
-        assert "information_schema.tags" in results
+        assert "table_tags" in results
         macro_names = {call.args[0] for call in adapter.execute_macro.call_args_list}
-        assert "fetch_tags" in macro_names
+        assert "fetch_tags" not in macro_names

--- a/tests/unit/relation_configs/test_materialized_view_config.py
+++ b/tests/unit/relation_configs/test_materialized_view_config.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock, Mock
 from agate import Row, Table
 
 from dbt.adapters.databricks.impl import MaterializedViewAPI
+from dbt.adapters.databricks.relation import DatabricksRelation, DatabricksRelationType
 from dbt.adapters.databricks.relation_configs.comment import CommentConfig
 from dbt.adapters.databricks.relation_configs.liquid_clustering import LiquidClusteringConfig
 from dbt.adapters.databricks.relation_configs.materialized_view import (
@@ -158,8 +159,14 @@ class TestMaterializedViewAPIDescribeRelation:
         # spurious tag diff on every run, routing to ALTER instead of REFRESH.
         adapter = MagicMock()
         adapter.execute_macro.return_value = MagicMock()
+        relation = DatabricksRelation.create(
+            database="main",
+            schema="analytics",
+            identifier="my_mv",
+            type=DatabricksRelationType.MaterializedView,
+        )
 
-        results = MaterializedViewAPI._describe_relation(adapter, MagicMock())
+        results = MaterializedViewAPI._describe_relation(adapter, relation)
 
         assert "table_tags" in results
         macro_names = {call.args[0] for call in adapter.execute_macro.call_args_list}

--- a/tests/unit/relation_configs/test_streaming_table_config.py
+++ b/tests/unit/relation_configs/test_streaming_table_config.py
@@ -1,7 +1,5 @@
 from unittest.mock import Mock
 
-from agate import Table
-
 from dbt.adapters.databricks.relation_configs.comment import CommentConfig
 from dbt.adapters.databricks.relation_configs.liquid_clustering import LiquidClusteringConfig
 from dbt.adapters.databricks.relation_configs.partitioning import PartitionedByConfig
@@ -32,9 +30,7 @@ class TestStreamingTableConfig:
                 ],
             ),
             "show_tblproperties": fixtures.gen_tblproperties([["prop", "1"], ["other", "other"]]),
-            "information_schema.tags": Table(
-                rows=[["a", "b"], ["c", "d"]], column_names=["tag_name", "tag_value"]
-            ),
+            "table_tags": {"a": "b", "c": "d"},
         }
 
         config = StreamingTableConfig.from_results(results)

--- a/tests/unit/relation_configs/test_tags.py
+++ b/tests/unit/relation_configs/test_tags.py
@@ -1,7 +1,6 @@
 from unittest.mock import Mock
 
 import pytest
-from agate import Table
 from dbt.exceptions import DbtRuntimeError
 
 from dbt.adapters.databricks.relation_configs.tags import TagsConfig, TagsProcessor
@@ -9,27 +8,17 @@ from dbt.adapters.databricks.relation_configs.tags import TagsConfig, TagsProces
 
 class TestTagsProcessor:
     def test_from_relation_results__none(self):
-        results = {
-            "information_schema.tags": Table(rows=[], column_names=["tag_name", "tag_value"])
-        }
+        results = {"table_tags": {}}
         spec = TagsProcessor.from_relation_results(results)
         assert spec == TagsConfig(set_tags={})
 
     def test_from_relation_results__some(self):
-        results = {
-            "information_schema.tags": Table(
-                rows=[["a", "valA"], ["b", "valB"]], column_names=["tag_name", "tag_value"]
-            )
-        }
+        results = {"table_tags": {"a": "valA", "b": "valB"}}
         spec = TagsProcessor.from_relation_results(results)
         assert spec == TagsConfig(set_tags={"a": "valA", "b": "valB"})
 
     def test_from_relation_results__key_only(self):
-        results = {
-            "information_schema.tags": Table(
-                rows=[["a", ""]], column_names=["tag_name", "tag_value"]
-            )
-        }
+        results = {"table_tags": {"a": ""}}
         spec = TagsProcessor.from_relation_results(results)
         assert spec == TagsConfig(set_tags={"a": ""})
 

--- a/tests/unit/test_adapter.py
+++ b/tests/unit/test_adapter.py
@@ -31,6 +31,7 @@ from dbt.adapters.databricks.impl import (
     DatabricksRelationInfo,
     IncrementalTableAPI,
     MaterializedViewAPI,
+    MetricViewAPI,
     ViewAPI,
     get_identifier_list_string,
 )
@@ -45,6 +46,7 @@ from dbt.adapters.databricks.relation_configs.column_tags import (
 )
 from dbt.adapters.databricks.relation_configs.incremental import IncrementalTableConfig
 from dbt.adapters.databricks.relation_configs.materialized_view import MaterializedViewConfig
+from dbt.adapters.databricks.relation_configs.metric_view import MetricViewConfig
 from dbt.adapters.databricks.relation_configs.tags import TagsConfig, TagsProcessor
 from dbt.adapters.databricks.relation_configs.view import ViewConfig
 from dbt.adapters.databricks.utils import check_not_found_error
@@ -1499,6 +1501,9 @@ class TestDescribeRelationMetadataFetchPlanning:
     def _create_adapter(describe_as_json_supported: bool = False):
         adapter = Mock()
         adapter.is_describe_as_json_supported.return_value = describe_as_json_supported
+        adapter.connections.api_client.entity_tag_assignments.list_table_tags.return_value = (
+            "table_tags_result"
+        )
 
         def execute_macro(macro_name, kwargs=None):
             if macro_name == "get_view_description":
@@ -1536,6 +1541,15 @@ class TestDescribeRelationMetadataFetchPlanning:
         )
 
     @staticmethod
+    def _create_metric_view_relation(database="main"):
+        return DatabricksRelation.create(
+            database=database,
+            schema="analytics",
+            identifier="my_metric_view_model",
+            type=DatabricksRelationType.MetricView,
+        )
+
+    @staticmethod
     def _create_incremental_config(
         tags: dict[str, str] | None = None,
         column_tags: dict[str, dict[str, str]] | None = None,
@@ -1564,6 +1578,10 @@ class TestDescribeRelationMetadataFetchPlanning:
         return MaterializedViewConfig(config={TagsProcessor.name: TagsConfig(set_tags=tags or {})})
 
     @staticmethod
+    def _create_metric_view_config(tags: dict[str, str] | None = None) -> MetricViewConfig:
+        return MetricViewConfig(config={TagsProcessor.name: TagsConfig(set_tags=tags or {})})
+
+    @staticmethod
     def _called_macro_names(adapter: Mock) -> list[str]:
         return [call.args[0] for call in adapter.execute_macro.call_args_list]
 
@@ -1574,13 +1592,14 @@ class TestDescribeRelationMetadataFetchPlanning:
 
         results = IncrementalTableAPI._describe_relation(adapter, relation, relation_config)
 
-        assert results["information_schema.tags"] is None
+        assert results["table_tags"] is None
         assert results["information_schema.column_tags"] is None
         called_macro_names = self._called_macro_names(adapter)
         assert "fetch_tags" not in called_macro_names
         assert "fetch_column_tags" not in called_macro_names
         assert "fetch_tbl_properties" in called_macro_names
         assert DESCRIBE_TABLE_EXTENDED_MACRO_NAME in called_macro_names
+        adapter.connections.api_client.entity_tag_assignments.list_table_tags.assert_not_called()
 
     def test_incremental_describe_relation_fetches_only_table_tags_when_present(self):
         adapter = self._create_adapter()
@@ -1589,11 +1608,14 @@ class TestDescribeRelationMetadataFetchPlanning:
 
         results = IncrementalTableAPI._describe_relation(adapter, relation, relation_config)
 
-        assert results["information_schema.tags"] == "fetch_tags_result"
+        assert results["table_tags"] == "table_tags_result"
         assert results["information_schema.column_tags"] is None
         called_macro_names = self._called_macro_names(adapter)
-        assert "fetch_tags" in called_macro_names
+        assert "fetch_tags" not in called_macro_names
         assert "fetch_column_tags" not in called_macro_names
+        adapter.connections.api_client.entity_tag_assignments.list_table_tags.assert_called_once_with(
+            "main.analytics.my_incremental_model"
+        )
 
     def test_incremental_describe_relation_fetches_table_tags_from_project_level_cascade(self):
         # Project-level databricks_tags cascade onto a model that doesn't declare
@@ -1612,10 +1634,10 @@ class TestDescribeRelationMetadataFetchPlanning:
 
         results = IncrementalTableAPI._describe_relation(adapter, relation, relation_config)
 
-        assert results["information_schema.tags"] == "fetch_tags_result"
+        assert results["table_tags"] == "table_tags_result"
         assert results["information_schema.column_tags"] is None
         called_macro_names = self._called_macro_names(adapter)
-        assert "fetch_tags" in called_macro_names
+        assert "fetch_tags" not in called_macro_names
         assert "fetch_column_tags" not in called_macro_names
 
     def test_incremental_describe_relation_fetches_only_column_tags_when_present(self):
@@ -1627,11 +1649,12 @@ class TestDescribeRelationMetadataFetchPlanning:
 
         results = IncrementalTableAPI._describe_relation(adapter, relation, relation_config)
 
-        assert results["information_schema.tags"] is None
+        assert results["table_tags"] is None
         assert results["information_schema.column_tags"] == "fetch_column_tags_result"
         called_macro_names = self._called_macro_names(adapter)
         assert "fetch_tags" not in called_macro_names
         assert "fetch_column_tags" in called_macro_names
+        adapter.connections.api_client.entity_tag_assignments.list_table_tags.assert_not_called()
 
     def test_incremental_describe_relation_fetches_both_tag_queries_when_both_present(self):
         adapter = self._create_adapter()
@@ -1643,10 +1666,10 @@ class TestDescribeRelationMetadataFetchPlanning:
 
         results = IncrementalTableAPI._describe_relation(adapter, relation, relation_config)
 
-        assert results["information_schema.tags"] == "fetch_tags_result"
+        assert results["table_tags"] == "table_tags_result"
         assert results["information_schema.column_tags"] == "fetch_column_tags_result"
         called_macro_names = self._called_macro_names(adapter)
-        assert "fetch_tags" in called_macro_names
+        assert "fetch_tags" not in called_macro_names
         assert "fetch_column_tags" in called_macro_names
 
     def test_incremental_describe_relation_fetches_tag_queries_when_relation_config_is_none(self):
@@ -1655,10 +1678,10 @@ class TestDescribeRelationMetadataFetchPlanning:
 
         results = IncrementalTableAPI._describe_relation(adapter, relation, None)
 
-        assert results["information_schema.tags"] == "fetch_tags_result"
+        assert results["table_tags"] == "table_tags_result"
         assert results["information_schema.column_tags"] == "fetch_column_tags_result"
         called_macro_names = self._called_macro_names(adapter)
-        assert "fetch_tags" in called_macro_names
+        assert "fetch_tags" not in called_macro_names
         assert "fetch_column_tags" in called_macro_names
 
     def test_incremental_describe_relation_skips_tag_queries_for_hive_metastore(self):
@@ -1671,13 +1694,14 @@ class TestDescribeRelationMetadataFetchPlanning:
 
         results = IncrementalTableAPI._describe_relation(adapter, relation, relation_config)
 
-        assert "information_schema.tags" not in results
+        assert "table_tags" not in results
         assert "information_schema.column_tags" not in results
         called_macro_names = self._called_macro_names(adapter)
         assert "fetch_tags" not in called_macro_names
         assert "fetch_column_tags" not in called_macro_names
         assert "fetch_tbl_properties" in called_macro_names
         assert DESCRIBE_TABLE_EXTENDED_MACRO_NAME in called_macro_names
+        adapter.connections.api_client.entity_tag_assignments.list_table_tags.assert_not_called()
 
     def test_view_describe_relation_skips_tag_query_without_tags(self):
         adapter = self._create_adapter()
@@ -1686,11 +1710,12 @@ class TestDescribeRelationMetadataFetchPlanning:
 
         results = ViewAPI._describe_relation(adapter, relation, relation_config)
 
-        assert results["information_schema.tags"] is None
+        assert results["table_tags"] is None
         called_macro_names = self._called_macro_names(adapter)
         assert "fetch_tags" not in called_macro_names
         assert "get_view_description" in called_macro_names
         assert "fetch_tbl_properties" in called_macro_names
+        adapter.connections.api_client.entity_tag_assignments.list_table_tags.assert_not_called()
 
     def test_view_describe_relation_fetches_tag_query_when_tags_present(self):
         adapter = self._create_adapter()
@@ -1699,10 +1724,23 @@ class TestDescribeRelationMetadataFetchPlanning:
 
         results = ViewAPI._describe_relation(adapter, relation, relation_config)
 
-        assert results["information_schema.tags"] == "fetch_tags_result"
+        assert results["table_tags"] == "table_tags_result"
         called_macro_names = self._called_macro_names(adapter)
-        assert "fetch_tags" in called_macro_names
+        assert "fetch_tags" not in called_macro_names
         assert "get_view_description" in called_macro_names
+        adapter.connections.api_client.entity_tag_assignments.list_table_tags.assert_called_once_with(
+            "main.analytics.my_view_model"
+        )
+
+    def test_view_describe_relation_skips_table_tag_api_for_hive_metastore(self):
+        adapter = self._create_adapter()
+        relation = self._create_view_relation(database="hive_metastore")
+        relation_config = self._create_view_config(tags={"classification": "internal"})
+
+        results = ViewAPI._describe_relation(adapter, relation, relation_config)
+
+        assert results["table_tags"] is None
+        adapter.connections.api_client.entity_tag_assignments.list_table_tags.assert_not_called()
 
     def test_view_describe_relation_skips_column_tag_query_without_tags(self):
         adapter = self._create_adapter()
@@ -1745,11 +1783,12 @@ class TestDescribeRelationMetadataFetchPlanning:
 
         results = MaterializedViewAPI._describe_relation(adapter, relation, relation_config)
 
-        assert results["information_schema.tags"] is None
+        assert results["table_tags"] is None
         called_macro_names = self._called_macro_names(adapter)
         assert "fetch_tags" not in called_macro_names
         assert "get_view_description" in called_macro_names
         assert "fetch_tbl_properties" in called_macro_names
+        adapter.connections.api_client.entity_tag_assignments.list_table_tags.assert_not_called()
 
     def test_mv_describe_relation_fetches_tag_query_when_tags_present(self):
         adapter = self._create_adapter()
@@ -1758,10 +1797,36 @@ class TestDescribeRelationMetadataFetchPlanning:
 
         results = MaterializedViewAPI._describe_relation(adapter, relation, relation_config)
 
-        assert results["information_schema.tags"] == "fetch_tags_result"
+        assert results["table_tags"] == "table_tags_result"
         called_macro_names = self._called_macro_names(adapter)
-        assert "fetch_tags" in called_macro_names
+        assert "fetch_tags" not in called_macro_names
         assert "get_view_description" in called_macro_names
+        adapter.connections.api_client.entity_tag_assignments.list_table_tags.assert_called_once_with(
+            "main.analytics.my_mv_model"
+        )
+
+    def test_metric_view_describe_relation_fetches_table_tags_from_api(self):
+        adapter = self._create_adapter()
+        relation = self._create_metric_view_relation()
+        relation_config = self._create_metric_view_config(tags={"classification": "internal"})
+
+        results = MetricViewAPI._describe_relation(adapter, relation, relation_config)
+
+        assert results["table_tags"] == "table_tags_result"
+        assert "fetch_tags" not in self._called_macro_names(adapter)
+        adapter.connections.api_client.entity_tag_assignments.list_table_tags.assert_called_once_with(
+            "main.analytics.my_metric_view_model"
+        )
+
+    def test_metric_view_describe_relation_skips_table_tag_api_without_tags(self):
+        adapter = self._create_adapter()
+        relation = self._create_metric_view_relation()
+        relation_config = self._create_metric_view_config()
+
+        results = MetricViewAPI._describe_relation(adapter, relation, relation_config)
+
+        assert results["table_tags"] is None
+        adapter.connections.api_client.entity_tag_assignments.list_table_tags.assert_not_called()
 
 
 class TestManagedIcebergBehaviorFlag(DatabricksAdapterBase):

--- a/tests/unit/test_adapter.py
+++ b/tests/unit/test_adapter.py
@@ -1732,14 +1732,69 @@ class TestDescribeRelationMetadataFetchPlanning:
             "main.analytics.my_view_model"
         )
 
-    def test_view_describe_relation_skips_table_tag_api_for_hive_metastore(self):
+    def test_view_describe_relation_raises_for_hive_metastore_table_tags(self):
         adapter = self._create_adapter()
         relation = self._create_view_relation(database="hive_metastore")
         relation_config = self._create_view_config(tags={"classification": "internal"})
 
-        results = ViewAPI._describe_relation(adapter, relation, relation_config)
+        with pytest.raises(DbtRuntimeError, match="Tags are only supported for Unity Catalog"):
+            ViewAPI._describe_relation(adapter, relation, relation_config)
 
-        assert results["table_tags"] is None
+        adapter.connections.api_client.entity_tag_assignments.list_table_tags.assert_not_called()
+
+    def test_mv_describe_relation_raises_for_hive_metastore_table_tags(self):
+        adapter = self._create_adapter()
+        relation = self._create_mv_relation(database="hive_metastore")
+        relation_config = self._create_mv_config(tags={"classification": "internal"})
+
+        with pytest.raises(DbtRuntimeError, match="Tags are only supported for Unity Catalog"):
+            MaterializedViewAPI._describe_relation(adapter, relation, relation_config)
+
+        adapter.connections.api_client.entity_tag_assignments.list_table_tags.assert_not_called()
+
+    def test_metric_view_describe_relation_raises_for_hive_metastore_table_tags(self):
+        adapter = self._create_adapter()
+        relation = self._create_metric_view_relation(database="hive_metastore")
+        relation_config = self._create_metric_view_config(tags={"classification": "internal"})
+
+        with pytest.raises(DbtRuntimeError, match="Tags are only supported for Unity Catalog"):
+            MetricViewAPI._describe_relation(adapter, relation, relation_config)
+
+        adapter.connections.api_client.entity_tag_assignments.list_table_tags.assert_not_called()
+
+    def test_get_table_tags_raises_for_hive_metastore(self):
+        adapter = self._create_adapter()
+        relation = self._create_view_relation(database="hive_metastore")
+
+        with pytest.raises(DbtRuntimeError, match="Tags are only supported for Unity Catalog"):
+            ViewAPI._get_table_tags(adapter, relation)
+
+        adapter.connections.api_client.entity_tag_assignments.list_table_tags.assert_not_called()
+
+    def test_get_table_tags_treats_missing_database_as_hive_metastore(self):
+        adapter = self._create_adapter()
+        relation = DatabricksRelation.create(
+            schema="analytics",
+            identifier="my_view_model",
+            type=DatabricksRelationType.View,
+        )
+
+        with pytest.raises(DbtRuntimeError, match="Tags are only supported for Unity Catalog"):
+            ViewAPI._get_table_tags(adapter, relation)
+
+        adapter.connections.api_client.entity_tag_assignments.list_table_tags.assert_not_called()
+
+    def test_get_table_tags_raises_without_fully_qualified_relation(self):
+        adapter = self._create_adapter()
+        relation = DatabricksRelation.create(
+            database="main",
+            schema="analytics",
+            type=DatabricksRelationType.View,
+        )
+
+        with pytest.raises(DbtRuntimeError, match="fully qualified relation name"):
+            ViewAPI._get_table_tags(adapter, relation)
+
         adapter.connections.api_client.entity_tag_assignments.list_table_tags.assert_not_called()
 
     def test_view_describe_relation_skips_column_tag_query_without_tags(self):


### PR DESCRIPTION
### Description

Table-tag metadata reads currently use `system.information_schema.table_tags`, which sends each relation lookup through the more restrictive information-schema path. This changes only `table_tags` metadata reads to use the Unity Catalog Entity Tag Assignments API through the adapter existing authenticated `WorkspaceClient`.

- Fetch table assignments with one API request per Unity Catalog relation, requesting the maximum 50 tags supported per entity.
- Use the API for incremental tables, views, materialized views, and metric views while preserving the existing metadata-skip behavior.
- Keep Hive Metastore relations off the Unity Catalog API.
- Keep `column_tags` on its existing `INFORMATION_SCHEMA` path; batching column assignments is outside this PR.
- Retain the public `fetch_tags` macro as a compatibility surface for projects that invoke or override it directly.

### Verification

- [x] Affected unit tests: 43 passed
- [x] Full unit suite on `1.13.latest`: 1,263 passed, 7 skipped
- [x] Live Unity Catalog metadata-fetch tests: 7 passed
- [x] Ruff, Ruff format, mypy, and uv lock consistency

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
- [ ] [Optional] I have run the `dbt-databricks-pr-ready` project skill for this PR and addressed its merge-readiness feedback