### PR TITLE
[DRAFT] feat: expose rows_affected in adapter_response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Features
 
+- Expose `rows_affected` in the adapter response for DML operations so the count of affected rows is available in `run_results.json` (resolves [#1607](https://github.com/databricks/dbt-databricks/issues/1607))
 - Support `catalog_database` in v2 catalogs.yml to route Unity catalog models to a physical catalog independent of the dbt catalog name (requires `dbt-core>=1.12` and `dbt-adapters>=1.24.4`). ([#1590](https://github.com/databricks/dbt-databricks/pull/1590))
 
 ### Fixes

--- a/dbt/adapters/databricks/handle.py
+++ b/dbt/adapters/databricks/handle.py
@@ -87,12 +87,15 @@ class DatabricksAdapterResponse(AdapterResponse):
     job_id: Optional[str] = None
     job_run_id: Optional[str] = None
     task_run_id: Optional[str] = None
+    rows_affected: Optional[int] = None
 
     @classmethod
     def from_cursor(cls, cursor: Any) -> "DatabricksAdapterResponse":
+        rowcount = getattr(cursor, "rowcount", None)
         return cls(
             _message="OK",
             query_id=getattr(cursor, "query_id", None) or "N/A",
+            rows_affected=rowcount if isinstance(rowcount, int) and rowcount >= 0 else None,
             **_get_job_run_context(),
         )
 

--- a/tests/unit/test_handle.py
+++ b/tests/unit/test_handle.py
@@ -440,6 +440,22 @@ class TestCursorWrapper:
         assert isinstance(response, DatabricksAdapterResponse)
         assert response.query_id == "id"
 
+    @patch.dict(os.environ, {}, clear=True)
+    def test_get_response__with_rows_affected(self, cursor):
+        cursor.query_id = "id"
+        cursor.rowcount = 358
+        wrapper = CursorWrapper(cursor)
+        response = wrapper.get_response()
+        assert response.rows_affected == 358
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_get_response__rows_affected_none_when_minus_one(self, cursor):
+        cursor.query_id = "id"
+        cursor.rowcount = -1
+        wrapper = CursorWrapper(cursor)
+        response = wrapper.get_response()
+        assert response.rows_affected is None
+
     def test_get_response__with_job_context(self, cursor):
         cursor.query_id = "qid"
         wrapper = CursorWrapper(cursor)
@@ -659,9 +675,26 @@ class TestDatabricksAdapterResponse:
         cursor.query_id = "q1"
         resp = DatabricksAdapterResponse.from_cursor(cursor)
         assert resp.query_id == "q1"
+        assert resp.rows_affected is None
         assert resp.job_id is None
         assert resp.job_run_id is None
         assert resp.task_run_id is None
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_from_cursor__with_rows_affected(self):
+        cursor = Mock()
+        cursor.query_id = "q1"
+        cursor.rowcount = 100
+        resp = DatabricksAdapterResponse.from_cursor(cursor)
+        assert resp.rows_affected == 100
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_from_cursor__rows_affected_minus_one(self):
+        cursor = Mock()
+        cursor.query_id = "q1"
+        cursor.rowcount = -1
+        resp = DatabricksAdapterResponse.from_cursor(cursor)
+        assert resp.rows_affected is None
 
     def test_from_cursor__with_context(self):
         cursor = Mock()


### PR DESCRIPTION
## Description

Add `rows_affected` to `DatabricksAdapterResponse` so downstream consumers (monitoring, validation pipelines) can read the number of rows affected by DML operations (INSERT/UPDATE/DELETE/MERGE) directly from `run_results.json`.

## Changes

- Added `rows_affected: Optional[int]` field to `DatabricksAdapterResponse` dataclass
- Read `cursor.rowcount` from the Databricks SQL connector, using `getattr` with defensive type checking
- Added unit tests to verify the new field is populated correctly
- Updated CHANGELOG.md with the new feature

## Why `cursor.rowcount`?

The value is sourced from the public `cursor.rowcount` attribute, which the `databricks-sql-connector` populates after executing DML statements.

In [`databricks-sql-connector` (client.py, around line 1384-1390)](https://github.com/databricks/databricks-sql-python/blob/main/src/databricks/sql/client.py#L1390), the connector surfaces the affected-row count from the backend:

```python
# Surface the affected-row count for DML (INSERT/UPDATE/DELETE/MERGE) as
# cursor.rowcount instead of the hardcoded -1. num_modified_rows is None
# for SELECT (and statements the server does not report a count for) →
# leave rowcount at its -1 default.
num_modified_rows = getattr(self.active_result_set, "num_modified_rows", None)
if num_modified_rows is not None:
    self.rowcount = num_modified_rows
```

## Implementation Details

- Reads `cursor.rowcount` after execution (no additional query required)
- Uses `getattr` with defensive type checking to handle edge cases (missing attribute, wrong types)
- Returns `None` when `rowcount` is `-1` (default for SELECT/DDL) or not available
- Minimal and focused on the specific use case

## Related Issues
