### PR TITLE
test: harden HMS clone matrix coverage after #1608

### DIFF
--- a/tests/functional/adapter/dbt_clone/test_dbt_clone.py
+++ b/tests/functional/adapter/dbt_clone/test_dbt_clone.py
@@ -103,6 +103,14 @@ class TestClonePersistDocs(BaseClone):
         assert view_comment == "This is a view model"
 
 
+def _delta_history(project, relation):
+    """Return (latest_version, operations, versions) from DESCRIBE HISTORY."""
+    history = project.run_sql(f"describe history {relation}", fetch="all")
+    versions = {row[0] for row in history}
+    operations = {row[4] for row in history}
+    return max(versions), operations, versions
+
+
 class TestCloneShallowClone(BaseClone, CleanupMixin):
     @pytest.fixture(scope="class")
     def models(self):
@@ -116,11 +124,6 @@ class TestCloneShallowClone(BaseClone, CleanupMixin):
     def seeds(self):
         return {}
 
-    def _latest_version(self, project, relation):
-        history = project.run_sql(f"describe history {relation}", fetch="all")
-        operations = {row[4] for row in history}
-        return max(row[0] for row in history), operations
-
     def test_shallow_clone(self, project, unique_schema, other_schema):
         project.create_test_schema(other_schema)
         run_dbt(["run"])
@@ -133,24 +136,38 @@ class TestCloneShallowClone(BaseClone, CleanupMixin):
 
         # the table branch materializes via CREATE OR REPLACE ... SHALLOW CLONE,
         # which Delta records as a CLONE operation rather than a full rewrite
-        version, operations = self._latest_version(project, cloned)
+        version, operations, versions_before = _delta_history(project, cloned)
         assert "CLONE" in operations, f"clone history operations: {operations}"
 
         # an existing target is left untouched without --full-refresh
         run_dbt(clone_args)
-        noop_version, _ = self._latest_version(project, cloned)
+        noop_version, _, versions_before = _delta_history(project, cloned)
         assert noop_version == version
 
         # --full-refresh re-clones in place, adding a fresh CLONE version
         run_dbt([*clone_args, "--full-refresh"])
-        refreshed_version, refreshed_operations = self._latest_version(project, cloned)
+        refreshed_version, refreshed_operations, refreshed_versions = _delta_history(
+            project, cloned
+        )
         assert refreshed_version > version
+        assert versions_before.issubset(refreshed_versions), (
+            f"in-place full-refresh must keep prior history versions; "
+            f"lost {versions_before - refreshed_versions} from {refreshed_versions}"
+        )
         assert "CLONE" in refreshed_operations, (
             f"full-refresh history operations: {refreshed_operations}"
         )
 
 
+@pytest.mark.skip_profile("databricks_uc_cluster", "databricks_uc_sql_endpoint")
 class TestCloneHmsRelationMatrix(BaseClone, CleanupMixin):
+    """HMS listing omits Databricks table types, so full-refresh clone must replace
+    unknown-type tables in place (preserving Delta history) rather than drop-first.
+
+    UC profiles skip: a known managed target is intentionally dropped there, which
+    resets history to version 0 and would fail the survival assertions below.
+    """
+
     @pytest.fixture(scope="class")
     def models(self):
         return {
@@ -171,11 +188,6 @@ class TestCloneHmsRelationMatrix(BaseClone, CleanupMixin):
     def _target(self, project, schema, identifier):
         return f"`{project.database}`.`{schema}`.`{identifier}`"
 
-    def _latest_version(self, project, relation):
-        history = project.run_sql(f"describe history {relation}", fetch="all")
-        operations = {row[4] for row in history}
-        return max(row[0] for row in history), operations
-
     def test_clone_full_refresh_over_hms_relation_shapes(
         self, project, unique_schema, other_schema
     ):
@@ -188,7 +200,7 @@ class TestCloneHmsRelationMatrix(BaseClone, CleanupMixin):
         view = self._target(project, other_schema, "hms_clone_view_model")
 
         run_dbt(["run", "--target", "otherschema", "-s", "hms_clone_regular_model"])
-        regular_before, _ = self._latest_version(project, regular)
+        regular_before, _, regular_versions_before = _delta_history(project, regular)
 
         run_dbt(
             [
@@ -201,7 +213,9 @@ class TestCloneHmsRelationMatrix(BaseClone, CleanupMixin):
                 "hms_clone_shallow_model",
             ]
         )
-        shallow_before, shallow_before_operations = self._latest_version(project, shallow)
+        shallow_before, shallow_before_operations, shallow_versions_before = _delta_history(
+            project, shallow
+        )
         assert "CLONE" in shallow_before_operations
 
         project.run_sql(f"create or replace view {view} as select 2 as id")
@@ -209,9 +223,7 @@ class TestCloneHmsRelationMatrix(BaseClone, CleanupMixin):
         run_dbt(["clone", "--state", "state", "--target", "otherschema", "--full-refresh"])
 
         histories = {
-            identifier: self._latest_version(
-                project, self._target(project, other_schema, identifier)
-            )
+            identifier: _delta_history(project, self._target(project, other_schema, identifier))
             for identifier in (
                 "hms_clone_new_model",
                 "hms_clone_regular_model",
@@ -219,11 +231,21 @@ class TestCloneHmsRelationMatrix(BaseClone, CleanupMixin):
                 "hms_clone_view_model",
             )
         }
-        for identifier, (_, operations) in histories.items():
+        for identifier, (_, operations, _) in histories.items():
             assert "CLONE" in operations, f"{identifier} history operations: {operations}"
 
-        assert histories["hms_clone_regular_model"][0] > regular_before
-        assert histories["hms_clone_shallow_model"][0] > shallow_before
+        regular_latest, _, regular_versions = histories["hms_clone_regular_model"]
+        shallow_latest, _, shallow_versions = histories["hms_clone_shallow_model"]
+        assert regular_latest > regular_before
+        assert regular_versions_before.issubset(regular_versions), (
+            f"HMS in-place replace must keep prior history; "
+            f"lost {regular_versions_before - regular_versions}"
+        )
+        assert shallow_latest > shallow_before
+        assert shallow_versions_before.issubset(shallow_versions), (
+            f"HMS in-place replace must keep prior history; "
+            f"lost {shallow_versions_before - shallow_versions}"
+        )
         assert project.run_sql(f"select id from {view}", fetch="all")[0][0] == 1
 
 

--- a/tests/unit/macros/materializations/test_clone_macros.py
+++ b/tests/unit/macros/materializations/test_clone_macros.py
@@ -119,6 +119,13 @@ class TestCloneRequiresDrop(MacroTestBase):
         relation = self._relation(is_table=True, is_shallow_clone=False)
         assert self._requires_drop(template_bundle, relation) == "True"
 
+    def test_external_table_requires_drop(self, template_bundle):
+        # Known UC external tables hit the same UPDATE_TABLE_TYPE constraint as managed.
+        relation = self._relation(
+            is_table=True, is_shallow_clone=False, databricks_table_type="external"
+        )
+        assert self._requires_drop(template_bundle, relation) == "True"
+
     def test_view_requires_drop(self, template_bundle):
         relation = self._relation(is_table=False, is_shallow_clone=False)
         assert self._requires_drop(template_bundle, relation) == "True"


### PR DESCRIPTION
## Summary
- Skip UC profiles for `TestCloneHmsRelationMatrix` so CI does not fail when a known managed target is drop-first replaced (follow-up to #1608 review finding I1).
- Share a module-level `_delta_history` helper and assert prior Delta versions survive in-place full-refresh clone (stronger history-survival check).
- Add unit coverage for `databricks_table_type="external"` requiring drop.

## Test plan
- [x] `hatch run unit tests/unit/macros/materializations/test_clone_macros.py::TestCloneRequiresDrop -v`
- [x] `hatch run pytest tests/functional/adapter/dbt_clone/test_dbt_clone.py::TestCloneHmsRelationMatrix::test_clone_full_refresh_over_hms_relation_shapes tests/functional/adapter/dbt_clone/test_dbt_clone.py::TestCloneShallowClone::test_shallow_clone -v --profile databricks_cluster`