### PR TITLE
feat: add wiring for telemetry v1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## dbt-databricks next
 
+### Features
+
+- Add opt-in invocation telemetry for eligible commands via `connection_parameters.enable_dbt_telemetry` ([#1620](https://github.com/databricks/dbt-databricks/pull/1620))
+
 ### Fixes
 
 - Recreate materialized views when query schema drifts, honoring `on_configuration_change` ([#1621](https://github.com/databricks/dbt-databricks/pull/1621) resolves [#1359](https://github.com/databricks/dbt-databricks/issues/1359))

--- a/dbt/adapters/databricks/connections.py
+++ b/dbt/adapters/databricks/connections.py
@@ -55,6 +55,7 @@ from dbt.adapters.databricks.handle import (
 from dbt.adapters.databricks.logging import logger
 from dbt.adapters.databricks.python_models.run_tracking import PythonRunTracker
 from dbt.adapters.databricks.spog.decision import check_spog_preconditions
+from dbt.adapters.databricks.telemetry import hooks as telemetry_hooks
 from dbt.adapters.databricks.utils import QueryTagsUtils, is_cluster_http_path, redact_credentials
 
 if TYPE_CHECKING:
@@ -517,6 +518,16 @@ class DatabricksConnectionManager(SparkConnectionManager):
                     cls._cache_dbr_capabilities(creds, databricks_connection.http_path)
                     databricks_connection.capabilities = cls._get_capabilities_for_http_path(
                         databricks_connection.http_path
+                    )
+                    
+                    telemetry_hooks.on_connection_open(
+                        creds,
+                        cls.credentials_manager,
+                        session_id=conn.session_id,
+                        http_path=databricks_connection.http_path,
+                        is_cluster=is_cluster_http_path(
+                            databricks_connection.http_path, creds.cluster_id
+                        ),
                     )
                     return conn
                 else:

--- a/dbt/adapters/databricks/connections.py
+++ b/dbt/adapters/databricks/connections.py
@@ -519,16 +519,8 @@ class DatabricksConnectionManager(SparkConnectionManager):
                     databricks_connection.capabilities = cls._get_capabilities_for_http_path(
                         databricks_connection.http_path
                     )
-                    
-                    telemetry_hooks.on_connection_open(
-                        creds,
-                        cls.credentials_manager,
-                        session_id=conn.session_id,
-                        http_path=databricks_connection.http_path,
-                        is_cluster=is_cluster_http_path(
-                            databricks_connection.http_path, creds.cluster_id
-                        ),
-                    )
+
+                    telemetry_hooks.on_connection_open(creds, cls.credentials_manager)
                     return conn
                 else:
                     raise DbtDatabaseError("Failed to create connection")

--- a/dbt/adapters/databricks/connections.py
+++ b/dbt/adapters/databricks/connections.py
@@ -483,7 +483,10 @@ class DatabricksConnectionManager(SparkConnectionManager):
         creds: DatabricksCredentials = connection.credentials
         timeout = creds.connect_timeout
 
-        cls.credentials_manager = creds.authenticate()
+        # Keep the manager used to build this connection local. The class-level
+        # compatibility slot can be replaced by another concurrent open.
+        credentials_manager = creds.authenticate()
+        cls.credentials_manager = credentials_manager
 
         # SPOG decision matrix: collect every http_path in play (default +
         # per-compute) and validate them against the host's discovery probe.
@@ -503,7 +506,7 @@ class DatabricksConnectionManager(SparkConnectionManager):
             merged_query_tags = QueryConfigUtils.get_merged_query_tags(query_header_context, creds)
 
         conn_args = SqlUtils.prepare_connection_arguments(
-            creds, cls.credentials_manager, databricks_connection.http_path, merged_query_tags
+            creds, credentials_manager, databricks_connection.http_path, merged_query_tags
         )
 
         def connect() -> DatabricksHandle:
@@ -520,7 +523,7 @@ class DatabricksConnectionManager(SparkConnectionManager):
                         databricks_connection.http_path
                     )
 
-                    telemetry_hooks.on_connection_open(creds, cls.credentials_manager)
+                    telemetry_hooks.on_connection_open(creds, credentials_manager)
                     return conn
                 else:
                     raise DbtDatabaseError("Failed to create connection")

--- a/dbt/adapters/databricks/connections.py
+++ b/dbt/adapters/databricks/connections.py
@@ -483,8 +483,7 @@ class DatabricksConnectionManager(SparkConnectionManager):
         creds: DatabricksCredentials = connection.credentials
         timeout = creds.connect_timeout
 
-        # Keep the manager used to build this connection local. The class-level
-        # compatibility slot can be replaced by another concurrent open.
+        # Avoid a manager overwritten by another concurrent open.
         credentials_manager = creds.authenticate()
         cls.credentials_manager = credentials_manager
 

--- a/dbt/adapters/databricks/handle.py
+++ b/dbt/adapters/databricks/handle.py
@@ -394,8 +394,6 @@ class SqlUtils:
 
         connection_parameters = creds.connection_parameters.copy()  # type: ignore[union-attr]
 
-        # dbt telemetry opt-in lives in connection_parameters but is consumed by
-        # the adapter's own collector; drop it so it never reaches dbsql.connect.
         connection_parameters.pop("enable_dbt_telemetry", None)
 
         http_headers: list[tuple[str, str]] = list(

--- a/dbt/adapters/databricks/handle.py
+++ b/dbt/adapters/databricks/handle.py
@@ -394,6 +394,10 @@ class SqlUtils:
 
         connection_parameters = creds.connection_parameters.copy()  # type: ignore[union-attr]
 
+        # dbt telemetry opt-in lives in connection_parameters but is consumed by
+        # the adapter's own collector; drop it so it never reaches dbsql.connect.
+        connection_parameters.pop("enable_dbt_telemetry", None)
+
         http_headers: list[tuple[str, str]] = list(
             creds.get_all_http_headers(connection_parameters.pop("http_headers", {})).items()
         )

--- a/dbt/adapters/databricks/impl.py
+++ b/dbt/adapters/databricks/impl.py
@@ -101,6 +101,7 @@ from dbt.adapters.databricks.spog.capabilities import (
     sdk_supports_workspace_id,
 )
 from dbt.adapters.databricks.spog.extract import extract_workspace_id
+from dbt.adapters.databricks.telemetry import hooks as telemetry_hooks
 from dbt.adapters.databricks.utils import (
     get_first_row,
     handle_missing_objects,
@@ -901,6 +902,11 @@ class DatabricksAdapter(SparkAdapter):
         # As intended - This method will error out if the behavior flag is missing.
         behavior_flag = getattr(self.behavior, behavior_flag_name)
         return behavior_flag.no_warn
+
+    def set_macro_resolver(self, macro_resolver: Any) -> None:
+        # dbt-core passes the in-memory manifest here post-parse; telemetry hook.
+        super().set_macro_resolver(macro_resolver)
+        telemetry_hooks.on_post_parse(self, macro_resolver)
 
     @available.parse(lambda *a, **k: (None, None))
     @record_function(

--- a/dbt/adapters/databricks/impl.py
+++ b/dbt/adapters/databricks/impl.py
@@ -296,7 +296,6 @@ class DatabricksAdapter(SparkAdapter):
             self.get_behavior_flag_no_warn(USE_MANAGED_ICEBERG["name"])
         )
 
-        # Start the invocation duration timer as early as the adapter exists.
         telemetry_hooks.on_adapter_init(self)
 
         # Warehouses always meet capability cutoffs at parse time; clusters keep the
@@ -907,12 +906,10 @@ class DatabricksAdapter(SparkAdapter):
         return behavior_flag.no_warn
 
     def set_macro_resolver(self, macro_resolver: Any) -> None:
-        # dbt-core passes the in-memory manifest here post-parse; telemetry hook.
         super().set_macro_resolver(macro_resolver)
         telemetry_hooks.on_post_parse(self, macro_resolver)
 
     def cleanup_connections(self) -> None:
-        # dbt-core's teardown finally; the adapter's POST_RUN telemetry point.
         telemetry_hooks.on_run_end(self)
         super().cleanup_connections()
 

--- a/dbt/adapters/databricks/impl.py
+++ b/dbt/adapters/databricks/impl.py
@@ -296,6 +296,9 @@ class DatabricksAdapter(SparkAdapter):
             self.get_behavior_flag_no_warn(USE_MANAGED_ICEBERG["name"])
         )
 
+        # Start the invocation duration timer as early as the adapter exists.
+        telemetry_hooks.on_adapter_init(self)
+
         # Warehouses always meet capability cutoffs at parse time; clusters keep the
         # conservative False until a real connection is available.
         # `_parse_replacements_` is injected by AdapterMeta, so mypy can't resolve it here.
@@ -907,6 +910,11 @@ class DatabricksAdapter(SparkAdapter):
         # dbt-core passes the in-memory manifest here post-parse; telemetry hook.
         super().set_macro_resolver(macro_resolver)
         telemetry_hooks.on_post_parse(self, macro_resolver)
+
+    def cleanup_connections(self) -> None:
+        # dbt-core's teardown finally; the adapter's POST_RUN telemetry point.
+        telemetry_hooks.on_run_end(self)
+        super().cleanup_connections()
 
     @available.parse(lambda *a, **k: (None, None))
     @record_function(

--- a/dbt/adapters/databricks/telemetry/__init__.py
+++ b/dbt/adapters/databricks/telemetry/__init__.py
@@ -1,27 +1,9 @@
-from typing import Optional
+"""Opt-in dbt-databricks adapter telemetry. Emits a best-effort POST_PARSE
+event (sanitized invocation, connection, project, and manifest-size aggregates)
+to the authenticated workspace endpoint. Wiring lives in ``hooks``:
+set_macro_resolver -> on_post_parse, first connection open -> on_connection_open.
+"""
 
-from dbt.adapters.databricks.logging import logger
-from dbt.adapters.databricks.telemetry import builder, client, encoder
-from dbt.adapters.databricks.telemetry.client import HeaderFactory
 from dbt.adapters.databricks.telemetry.config import is_enabled
 
-__all__ = ["is_enabled", "send_connection_log"]
-
-
-def send_connection_log(
-    host: Optional[str],
-    header_factory: Optional[HeaderFactory] = None,
-    workspace_id: Optional[int] = None,
-    session_id: Optional[str] = None,
-    http_path: Optional[str] = None,
-    is_cluster: Optional[bool] = None,
-) -> None:
-    """Encode a single connection log and POST it."""
-    try:
-        log = builder.build_connection_log(
-            session_id=session_id, http_path=http_path, is_cluster=is_cluster
-        )
-        body = encoder.encode_request(log, workspace_id=workspace_id)
-        client.send(host, body, header_factory=header_factory, workspace_id=workspace_id)
-    except Exception as e:  # pragma: no cover - defensive
-        logger.debug(f"dbt telemetry: send_connection_log failed (ignored): {e}")
+__all__ = ["is_enabled"]

--- a/dbt/adapters/databricks/telemetry/__init__.py
+++ b/dbt/adapters/databricks/telemetry/__init__.py
@@ -1,5 +1,6 @@
 """Opt-in dbt-databricks adapter telemetry. Wiring lives in ``hooks``:
-set_macro_resolver -> on_post_parse, first connection open -> on_connection_open.
+set_macro_resolver -> on_post_parse, first connection open -> on_connection_open,
+cleanup_connections -> on_run_end.
 """
 
 from dbt.adapters.databricks.telemetry.config import is_enabled

--- a/dbt/adapters/databricks/telemetry/__init__.py
+++ b/dbt/adapters/databricks/telemetry/__init__.py
@@ -1,8 +1,3 @@
-"""Opt-in dbt-databricks adapter telemetry. Wiring lives in ``hooks``:
-set_macro_resolver -> on_post_parse, first connection open -> on_connection_open,
-cleanup_connections -> on_run_end.
-"""
-
 from dbt.adapters.databricks.telemetry.config import is_enabled
 
 __all__ = ["is_enabled"]

--- a/dbt/adapters/databricks/telemetry/__init__.py
+++ b/dbt/adapters/databricks/telemetry/__init__.py
@@ -1,6 +1,4 @@
-"""Opt-in dbt-databricks adapter telemetry. Emits a best-effort POST_PARSE
-event (sanitized invocation, connection, project, and manifest-size aggregates)
-to the authenticated workspace endpoint. Wiring lives in ``hooks``:
+"""Opt-in dbt-databricks adapter telemetry. Wiring lives in ``hooks``:
 set_macro_resolver -> on_post_parse, first connection open -> on_connection_open.
 """
 

--- a/dbt/adapters/databricks/telemetry/__init__.py
+++ b/dbt/adapters/databricks/telemetry/__init__.py
@@ -1,0 +1,27 @@
+from typing import Optional
+
+from dbt.adapters.databricks.logging import logger
+from dbt.adapters.databricks.telemetry import builder, client, encoder
+from dbt.adapters.databricks.telemetry.client import HeaderFactory
+from dbt.adapters.databricks.telemetry.config import is_enabled
+
+__all__ = ["is_enabled", "send_connection_log"]
+
+
+def send_connection_log(
+    host: Optional[str],
+    header_factory: Optional[HeaderFactory] = None,
+    workspace_id: Optional[int] = None,
+    session_id: Optional[str] = None,
+    http_path: Optional[str] = None,
+    is_cluster: Optional[bool] = None,
+) -> None:
+    """Encode a single connection log and POST it."""
+    try:
+        log = builder.build_connection_log(
+            session_id=session_id, http_path=http_path, is_cluster=is_cluster
+        )
+        body = encoder.encode_request(log, workspace_id=workspace_id)
+        client.send(host, body, header_factory=header_factory, workspace_id=workspace_id)
+    except Exception as e:  # pragma: no cover - defensive
+        logger.debug(f"dbt telemetry: send_connection_log failed (ignored): {e}")

--- a/dbt/adapters/databricks/telemetry/builder.py
+++ b/dbt/adapters/databricks/telemetry/builder.py
@@ -34,9 +34,6 @@ _COMMAND_MAP = {
 
 
 def classify_compute_type(http_path: Optional[str]) -> models.ComputeType:
-    """Only the two canonical http_path shapes classify; else OTHER. Stricter
-    than the adapter's permissive cluster-path helper, which mislabels unknowns.
-    """
     if not http_path:
         return models.ComputeType.TYPE_UNSPECIFIED
     path = http_path.split("?", 1)[0]
@@ -48,31 +45,25 @@ def classify_compute_type(http_path: Optional[str]) -> models.ComputeType:
 
 
 def classify_auth_family(creds: DatabricksCredentials) -> models.AuthFamily:
-    """Mirrors the credential manager's dispatch order, from config fields only.
-    A bare client_secret is fallback-capable (manager tries M2M and legacy
-    Azure), so it maps to ambiguous rather than OAUTH_M2M.
-    """
     if getattr(creds, "token", None):
         return models.AuthFamily.PAT
     if getattr(creds, "azure_client_id", None) and getattr(creds, "azure_client_secret", None):
         return models.AuthFamily.AZURE_SERVICE_PRINCIPAL
     if not getattr(creds, "client_secret", None):
-        # No secret -> interactive browser (U2M).
         return models.AuthFamily.OAUTH_U2M
+    # client_secret can select M2M or legacy Azure auth.
     return models.AuthFamily.LEGACY_CLIENT_SECRET_AMBIGUOUS
 
 
 def classify_command(which: Optional[str]) -> models.DbtCommand:
     if not which:
         return models.DbtCommand.TYPE_UNSPECIFIED
-    # Normalize e.g. run-operation, docs generate, source freshness.
     token = str(which).strip().lower().replace("-", "_").split()[0]
     return _COMMAND_MAP.get(token, models.DbtCommand.OTHER)
 
 
 def classify_warn_error_policy(warn_error: Any, warn_error_options: Any) -> models.WarnErrorPolicy:
-    # dbt-core evaluates the legacy boolean first, so it promotes every warning
-    # even if a WARN_ERROR_OPTIONS object is also present.
+    # dbt-core gives the legacy boolean precedence.
     if warn_error:
         return models.WarnErrorPolicy.WARN_ERROR_ALL
     if warn_error_options:
@@ -83,8 +74,7 @@ def classify_warn_error_policy(warn_error: Any, warn_error_options: Any) -> mode
         error = get("error") or get("include") or []
         warn = get("warn") or get("exclude") or []
         silence = get("silence") or []
-        # `error: all` (or `*`) with no exceptions is semantically identical
-        # to --warn-error. Named warn/silence overrides make it custom.
+        # Named overrides make `error: all` a custom policy.
         if error in ("all", "*") and not warn and not silence:
             return models.WarnErrorPolicy.WARN_ERROR_ALL
         has_policy = bool(error or warn or silence)
@@ -120,21 +110,16 @@ def _bump(counts: models.ResourceCounts, node: Any, resource_type: str) -> None:
     elif resource_type == "unit_test":
         counts.unit_test_count += 1
     else:
-        # metrics, semantic models, and any other enabled type.
         counts.other_count += 1
 
 
 def aggregate_manifest(manifest: Any) -> models.ManifestStats:
-    """Count enabled resources, split root-project vs installed-package.
-    manifest.disabled is a separate dict and is never counted.
-    """
     stats = models.ManifestStats()
     project_name = None
     metadata = getattr(manifest, "metadata", None)
     if metadata is not None:
         project_name = getattr(metadata, "project_name", None)
 
-    # Executable nodes live in .nodes; other types have their own top-level dicts.
     collections = [
         "nodes",
         "sources",
@@ -223,7 +208,6 @@ def build_post_parse_log(
     creds: DatabricksCredentials,
     behavior_flag: Callable[[str], bool],
 ) -> models.TelemetryLog:
-    """Assemble the complete POST_PARSE event from live runtime objects."""
     invocation_id = _invocation_id(manifest)
     payload = models.PostParsePayload(
         invocation_config=build_invocation_config(config),
@@ -259,7 +243,6 @@ def _dbt_core_version() -> str:
         return ""
 
 
-# dbt node_status strings -> NodeStatusCounts field (pass_ escapes the keyword).
 _STATUS_ATTR = {
     "success": "success",
     "error": "error",
@@ -286,7 +269,6 @@ _RESOURCE_TYPE = {
     "saved_query": models.ResourceType.SAVED_QUERY,
 }
 
-# on-run hooks surface as "operation" results; auxiliary, not selected resources.
 _AUXILIARY_TYPES = {"operation", "hook"}
 
 
@@ -307,18 +289,10 @@ def _bump_status(counts: models.NodeStatusCounts, status: Any) -> bool:
 
 
 def _resource_from_uid(unique_id: Any) -> str:
-    # dbt unique_ids are "resource_type.package.name"; the prefix is the type.
     return _norm(str(unique_id).split(".", 1)[0])
 
 
 def aggregate_node_results(results: list) -> tuple:
-    """Reduce (unique_id, status) results into the POST_RUN aggregates.
-
-    Resource type comes from the unique_id prefix. Auxiliary (hook/operation)
-    results stay out of result_counts and results_by_resource_type; a
-    non-auxiliary result whose type is unrecognized is still in result_counts and
-    increments unknown_resource_type_results.
-    """
     result_counts = models.NodeStatusCounts()
     auxiliary = models.NodeStatusCounts()
     by_type: dict = {}
@@ -352,7 +326,6 @@ def _classify_outcome(
     fail_fast_triggered: bool,
     task_success: Optional[bool],
 ) -> tuple[models.InvocationStatus, models.TerminationReason]:
-    # exc_type is whatever is propagating through dbt-core's teardown finally.
     if exc_type is not None:
         if issubclass(exc_type, (KeyboardInterrupt, SystemExit)):
             return models.InvocationStatus.INTERRUPTED, models.TerminationReason.INTERRUPTED
@@ -388,12 +361,7 @@ def build_post_run_log(
     fail_fast_triggered: bool = False,
     task_success: Optional[bool] = None,
 ) -> models.TelemetryLog:
-    """Assemble the POST_RUN event from the run's final node results.
-
-    ``results`` is a list of (unique_id, status). It comes from the authoritative
-    RunExecutionResult (via EndRunResult), which includes fail-fast synthesized
-    skips; on interrupt it is the partial per-node set instead.
-    """
+    """Build POST_RUN from authoritative or interrupt-fallback results."""
     result_counts, by_type, auxiliary, unknown = aggregate_node_results(results)
     has_failures = bool(
         result_counts.error

--- a/dbt/adapters/databricks/telemetry/builder.py
+++ b/dbt/adapters/databricks/telemetry/builder.py
@@ -16,60 +16,60 @@ _BEHAVIOR_FLAGS = (
 )
 
 _COMMAND_MAP = {
-    "run": "RUN",
-    "build": "BUILD",
-    "test": "TEST",
-    "seed": "SEED",
-    "snapshot": "SNAPSHOT",
-    "compile": "COMPILE",
-    "docs": "DOCS",
-    "clone": "CLONE",
-    "retry": "RETRY",
-    "show": "SHOW",
-    "list": "LIST",
-    "source": "SOURCE",
-    "run_operation": "RUN_OPERATION",
+    "run": models.DbtCommand.RUN,
+    "build": models.DbtCommand.BUILD,
+    "test": models.DbtCommand.TEST,
+    "seed": models.DbtCommand.SEED,
+    "snapshot": models.DbtCommand.SNAPSHOT,
+    "compile": models.DbtCommand.COMPILE,
+    "docs": models.DbtCommand.DOCS,
+    "clone": models.DbtCommand.CLONE,
+    "retry": models.DbtCommand.RETRY,
+    "show": models.DbtCommand.SHOW,
+    "list": models.DbtCommand.LIST,
+    "source": models.DbtCommand.SOURCE,
+    "run_operation": models.DbtCommand.RUN_OPERATION,
 }
 
 
-def classify_compute_type(http_path: Optional[str]) -> str:
+def classify_compute_type(http_path: Optional[str]) -> models.ComputeType:
     """Only the two canonical http_path shapes classify; else OTHER. Stricter
     than the adapter's permissive cluster-path helper, which mislabels unknowns.
     """
     if not http_path:
-        return models.COMPUTE_TYPE_UNSPECIFIED
+        return models.ComputeType.TYPE_UNSPECIFIED
     path = http_path.split("?", 1)[0]
     if path.startswith(("/sql/1.0/warehouses/", "/sql/1.0/endpoints/")):
-        return models.COMPUTE_TYPE_SQL_WAREHOUSE
+        return models.ComputeType.SQL_WAREHOUSE
     if path.startswith("/sql/protocolv1/"):
-        return models.COMPUTE_TYPE_ALL_PURPOSE_CLUSTER
-    return models.COMPUTE_TYPE_OTHER
+        return models.ComputeType.ALL_PURPOSE_CLUSTER
+    return models.ComputeType.OTHER
 
 
-def classify_auth_family(creds: DatabricksCredentials) -> str:
+def classify_auth_family(creds: DatabricksCredentials) -> models.AuthFamily:
     """Mirrors the credential manager's dispatch order, from config fields only.
     A bare client_secret is fallback-capable (manager tries M2M and legacy
     Azure), so it maps to ambiguous rather than OAUTH_M2M.
     """
     if getattr(creds, "token", None):
-        return models.AUTH_FAMILY_PAT
+        return models.AuthFamily.PAT
     if getattr(creds, "azure_client_id", None) and getattr(creds, "azure_client_secret", None):
-        return models.AUTH_FAMILY_AZURE_SERVICE_PRINCIPAL
+        return models.AuthFamily.AZURE_SERVICE_PRINCIPAL
     if not getattr(creds, "client_secret", None):
         # No secret -> interactive browser (U2M).
-        return models.AUTH_FAMILY_OAUTH_U2M
-    return models.AUTH_FAMILY_LEGACY_CLIENT_SECRET_AMBIGUOUS
+        return models.AuthFamily.OAUTH_U2M
+    return models.AuthFamily.LEGACY_CLIENT_SECRET_AMBIGUOUS
 
 
-def classify_command(which: Optional[str]) -> str:
+def classify_command(which: Optional[str]) -> models.DbtCommand:
     if not which:
-        return models.COMMAND_UNSPECIFIED
+        return models.DbtCommand.TYPE_UNSPECIFIED
     # Normalize e.g. run-operation, docs generate, source freshness.
     token = str(which).strip().lower().replace("-", "_").split()[0]
-    return _COMMAND_MAP.get(token, models.COMMAND_OTHER)
+    return _COMMAND_MAP.get(token, models.DbtCommand.OTHER)
 
 
-def classify_warn_error_policy(warn_error: Any, warn_error_options: Any) -> str:
+def classify_warn_error_policy(warn_error: Any, warn_error_options: Any) -> models.WarnErrorPolicy:
     if warn_error_options:
         # Any include/exclude/silence policy is a custom policy.
         opts = warn_error_options
@@ -78,10 +78,10 @@ def classify_warn_error_policy(warn_error: Any, warn_error_options: Any) -> str:
             for attr in ("include", "error", "warn", "silence", "exclude")
         )
         if has_policy:
-            return models.WARN_ERROR_CUSTOM_POLICY
+            return models.WarnErrorPolicy.WARN_ERROR_CUSTOM_POLICY
     if warn_error:
-        return models.WARN_ERROR_ALL
-    return models.WARN_ERROR_DISABLED
+        return models.WarnErrorPolicy.WARN_ERROR_ALL
+    return models.WarnErrorPolicy.WARN_ERROR_DISABLED
 
 
 def _resource_type(node: Any) -> str:

--- a/dbt/adapters/databricks/telemetry/builder.py
+++ b/dbt/adapters/databricks/telemetry/builder.py
@@ -3,6 +3,7 @@ from typing import Any, Callable, Optional
 
 from dbt.adapters.databricks.__version__ import version as _adapter_version
 from dbt.adapters.databricks.credentials import DatabricksCredentials
+from dbt.adapters.databricks.spog.extract import extract_workspace_id
 from dbt.adapters.databricks.telemetry import models
 
 # Mirrored from impl.py to avoid an import cycle.
@@ -70,17 +71,25 @@ def classify_command(which: Optional[str]) -> models.DbtCommand:
 
 
 def classify_warn_error_policy(warn_error: Any, warn_error_options: Any) -> models.WarnErrorPolicy:
-    if warn_error_options:
-        # Any include/exclude/silence policy is a custom policy.
-        opts = warn_error_options
-        has_policy = any(
-            bool(getattr(opts, attr, None) or (opts.get(attr) if isinstance(opts, dict) else None))
-            for attr in ("include", "error", "warn", "silence", "exclude")
-        )
-        if has_policy:
-            return models.WarnErrorPolicy.WARN_ERROR_CUSTOM_POLICY
+    # dbt-core evaluates the legacy boolean first, so it promotes every warning
+    # even if a WARN_ERROR_OPTIONS object is also present.
     if warn_error:
         return models.WarnErrorPolicy.WARN_ERROR_ALL
+    if warn_error_options:
+        opts = warn_error_options
+        get = lambda name: (  # noqa: E731 - keeps object/dict compatibility together
+            opts.get(name) if isinstance(opts, dict) else getattr(opts, name, None)
+        )
+        error = get("error") or get("include") or []
+        warn = get("warn") or get("exclude") or []
+        silence = get("silence") or []
+        # `error: all` (or `*`) with no exceptions is semantically identical
+        # to --warn-error. Named warn/silence overrides make it custom.
+        if error in ("all", "*") and not warn and not silence:
+            return models.WarnErrorPolicy.WARN_ERROR_ALL
+        has_policy = bool(error or warn or silence)
+        if has_policy:
+            return models.WarnErrorPolicy.WARN_ERROR_CUSTOM_POLICY
     return models.WarnErrorPolicy.WARN_ERROR_DISABLED
 
 
@@ -126,7 +135,16 @@ def aggregate_manifest(manifest: Any) -> models.ManifestStats:
         project_name = getattr(metadata, "project_name", None)
 
     # Executable nodes live in .nodes; other types have their own top-level dicts.
-    collections = ["nodes", "sources", "exposures", "metrics", "saved_queries", "functions"]
+    collections = [
+        "nodes",
+        "sources",
+        "exposures",
+        "metrics",
+        "semantic_models",
+        "saved_queries",
+        "functions",
+        "unit_tests",
+    ]
     for collection in collections:
         items = getattr(manifest, collection, None)
         if not items:
@@ -141,6 +159,20 @@ def aggregate_manifest(manifest: Any) -> models.ManifestStats:
                 resource_type,
             )
     return stats
+
+
+def ephemeral_resource_ids(manifest: Any) -> set[str]:
+    """Return only selected-count metadata; IDs are never serialized."""
+    result = set()
+    for node in (getattr(manifest, "nodes", None) or {}).values():
+        config = getattr(node, "config", None)
+        is_ephemeral = bool(getattr(node, "is_ephemeral_model", False)) or (
+            getattr(config, "materialized", None) == "ephemeral"
+        )
+        unique_id = getattr(node, "unique_id", None)
+        if is_ephemeral and unique_id:
+            result.add(str(unique_id))
+    return result
 
 
 def _get_flags() -> Any:
@@ -174,8 +206,8 @@ def build_connection_config(creds: DatabricksCredentials) -> models.ConnectionCo
         default_compute_type=classify_compute_type(http_path),
         configured_auth_family=classify_auth_family(creds),
         named_compute_count=len(getattr(creds, "compute", None) or {}),
-        # `?o=<id>` is the recognized workspace-routing parameter; value discarded.
-        spog_routing_configured="?o=" in http_path if http_path else False,
+        # Only the parsed `o` query parameter is recognized; its value is discarded.
+        spog_routing_configured=extract_workspace_id(http_path) is not None,
         use_kernel=bool(connection_parameters.get("use_kernel")),
     )
 
@@ -274,19 +306,25 @@ def _bump_status(counts: models.NodeStatusCounts, status: Any) -> bool:
     return True
 
 
-def aggregate_node_results(node_results: list) -> tuple:
-    """Reduce (resource_type, status) pairs into the POST_RUN aggregates.
+def _resource_from_uid(unique_id: Any) -> str:
+    # dbt unique_ids are "resource_type.package.name"; the prefix is the type.
+    return _norm(str(unique_id).split(".", 1)[0])
 
-    Auxiliary (hook) results stay out of result_counts and
-    results_by_resource_type; a non-auxiliary result whose type is unrecognized
-    is still in result_counts and increments unknown_resource_type_results.
+
+def aggregate_node_results(results: list) -> tuple:
+    """Reduce (unique_id, status) results into the POST_RUN aggregates.
+
+    Resource type comes from the unique_id prefix. Auxiliary (hook/operation)
+    results stay out of result_counts and results_by_resource_type; a
+    non-auxiliary result whose type is unrecognized is still in result_counts and
+    increments unknown_resource_type_results.
     """
     result_counts = models.NodeStatusCounts()
     auxiliary = models.NodeStatusCounts()
     by_type: dict = {}
     unknown = 0
-    for resource_type, status in node_results:
-        rtype = _norm(resource_type)
+    for unique_id, status in results:
+        rtype = _resource_from_uid(unique_id)
         if rtype in _AUXILIARY_TYPES:
             _bump_status(auxiliary, status)
             continue
@@ -309,15 +347,32 @@ def aggregate_node_results(node_results: list) -> tuple:
 
 
 def _classify_outcome(
-    exc_type: Optional[type], has_failures: bool
+    exc_type: Optional[type],
+    has_failures: bool,
+    fail_fast_triggered: bool,
+    task_success: Optional[bool],
 ) -> tuple[models.InvocationStatus, models.TerminationReason]:
     # exc_type is whatever is propagating through dbt-core's teardown finally.
     if exc_type is not None:
-        if issubclass(exc_type, KeyboardInterrupt):
+        if issubclass(exc_type, (KeyboardInterrupt, SystemExit)):
             return models.InvocationStatus.INTERRUPTED, models.TerminationReason.INTERRUPTED
+        try:
+            from dbt_common.exceptions import DbtBaseException, DbtInternalError
+
+            if issubclass(exc_type, DbtBaseException) and not issubclass(
+                exc_type, DbtInternalError
+            ):
+                return models.InvocationStatus.HANDLED_ERROR, models.TerminationReason.TASK_ERROR
+        except Exception:
+            pass
         return models.InvocationStatus.INTERNAL_ERROR, models.TerminationReason.INTERNAL_ERROR
-    if has_failures:
-        return models.InvocationStatus.HANDLED_ERROR, models.TerminationReason.NORMAL
+    if task_success is False or (task_success is None and has_failures):
+        reason = (
+            models.TerminationReason.FAIL_FAST
+            if fail_fast_triggered
+            else models.TerminationReason.NORMAL
+        )
+        return models.InvocationStatus.HANDLED_ERROR, reason
     return models.InvocationStatus.SUCCESS, models.TerminationReason.NORMAL
 
 
@@ -325,18 +380,34 @@ def build_post_run_log(
     invocation_id: str,
     elapsed_ms: int,
     exc_type: Optional[type],
-    node_results: list,
+    results: list,
+    expected_result_resources: int,
+    coverage_complete: bool,
     results_captured: bool,
+    selected_resources: Optional[int] = None,
+    fail_fast_triggered: bool = False,
+    task_success: Optional[bool] = None,
 ) -> models.TelemetryLog:
-    """Assemble the POST_RUN event from the per-node results captured during the run."""
-    result_counts, by_type, auxiliary, unknown = aggregate_node_results(node_results)
+    """Assemble the POST_RUN event from the run's final node results.
+
+    ``results`` is a list of (unique_id, status). It comes from the authoritative
+    RunExecutionResult (via EndRunResult), which includes fail-fast synthesized
+    skips; on interrupt it is the partial per-node set instead.
+    """
+    result_counts, by_type, auxiliary, unknown = aggregate_node_results(results)
     has_failures = bool(
         result_counts.error
         or result_counts.fail
         or result_counts.runtime_error
         or result_counts.partial_success
     )
-    status, reason = _classify_outcome(exc_type, has_failures)
+    status, reason = _classify_outcome(
+        exc_type,
+        has_failures,
+        fail_fast_triggered,
+        task_success,
+    )
+    aggregates_available = bool(results_captured)
     return models.TelemetryLog(
         invocation_id=invocation_id,
         adapter_version=_adapter_version,
@@ -347,11 +418,16 @@ def build_post_run_log(
                 invocation_status=status,
                 termination_reason=reason,
                 invocation_duration_ms=elapsed_ms,
-                result_aggregates_available=results_captured,
+                result_aggregates_available=aggregates_available,
+                expected_result_coverage_complete=(
+                    coverage_complete if aggregates_available else None
+                ),
             ),
-            result_counts=result_counts,
-            results_by_resource_type=by_type,
-            auxiliary_hook_results=auxiliary,
-            unknown_resource_type_results=unknown,
+            selected_resources=selected_resources,
+            expected_result_resources=expected_result_resources,
+            result_counts=result_counts if aggregates_available else None,
+            results_by_resource_type=by_type if aggregates_available else None,
+            auxiliary_hook_results=auxiliary if aggregates_available else None,
+            unknown_resource_type_results=unknown if aggregates_available else None,
         ),
     )

--- a/dbt/adapters/databricks/telemetry/builder.py
+++ b/dbt/adapters/databricks/telemetry/builder.py
@@ -1,27 +1,233 @@
-"""Build the initial connection telemetry log from connection facts."""
+"""Reduce live runtime objects (manifest, credentials, flags, behavior flags)
+to the sanitized POST_PARSE aggregates. Classification is configuration-only;
+it never authenticates or hits the warehouse.
+"""
 
 from importlib.metadata import version as _pkg_version
-from typing import Optional
+from typing import Any, Callable, Optional
 
-from databricks.sql import __version__ as dbsql_version
-from dbt.adapters.databricks.__version__ import version as __version__
-from dbt.adapters.databricks.telemetry.models import ConnectionLog
+from dbt.adapters.databricks.__version__ import version as _adapter_version
+from dbt.adapters.databricks.credentials import DatabricksCredentials
+from dbt.adapters.databricks.telemetry import models
+
+# Mirrored from impl.py to avoid an import cycle.
+_BEHAVIOR_FLAGS = (
+    "use_user_folder_for_python",
+    "use_materialization_v2",
+    "use_replace_on_for_insert_overwrite",
+    "use_managed_iceberg",
+    "use_concurrent_microbatch",
+    "use_describe_as_json_for_relation_metadata",
+)
+
+_COMMAND_MAP = {
+    "run": "RUN",
+    "build": "BUILD",
+    "test": "TEST",
+    "seed": "SEED",
+    "snapshot": "SNAPSHOT",
+    "compile": "COMPILE",
+    "docs": "DOCS",
+    "clone": "CLONE",
+    "retry": "RETRY",
+    "show": "SHOW",
+    "list": "LIST",
+    "source": "SOURCE",
+    "run_operation": "RUN_OPERATION",
+}
 
 
-def build_connection_log(
-    session_id: Optional[str] = None,
-    http_path: Optional[str] = None,
-    is_cluster: Optional[bool] = None,
-) -> ConnectionLog:
-    """Assemble the connection log; only non-sensitive metadata."""
-    compute_type = None
-    if is_cluster is not None:
-        compute_type = "cluster" if is_cluster else "sql_warehouse"
-    return ConnectionLog(
-        dbt_databricks_version=__version__,
-        dbt_core_version=_pkg_version("dbt-core"),
-        databricks_sql_connector_version=dbsql_version,
-        session_id=session_id,
-        http_path=http_path,
-        compute_type=compute_type,
+def classify_compute_type(http_path: Optional[str]) -> str:
+    """Only the two canonical http_path shapes classify; else OTHER. Stricter
+    than the adapter's permissive cluster-path helper, which mislabels unknowns.
+    """
+    if not http_path:
+        return models.COMPUTE_TYPE_UNSPECIFIED
+    path = http_path.split("?", 1)[0]
+    if path.startswith(("/sql/1.0/warehouses/", "/sql/1.0/endpoints/")):
+        return models.COMPUTE_TYPE_SQL_WAREHOUSE
+    if path.startswith("/sql/protocolv1/"):
+        return models.COMPUTE_TYPE_ALL_PURPOSE_CLUSTER
+    return models.COMPUTE_TYPE_OTHER
+
+
+def classify_auth_family(creds: DatabricksCredentials) -> str:
+    """Mirrors the credential manager's dispatch order, from config fields only.
+    A bare client_secret is fallback-capable (manager tries M2M and legacy
+    Azure), so it maps to ambiguous rather than OAUTH_M2M.
+    """
+    if getattr(creds, "token", None):
+        return models.AUTH_FAMILY_PAT
+    if getattr(creds, "azure_client_id", None) and getattr(creds, "azure_client_secret", None):
+        return models.AUTH_FAMILY_AZURE_SERVICE_PRINCIPAL
+    if not getattr(creds, "client_secret", None):
+        # No secret -> interactive browser (U2M).
+        return models.AUTH_FAMILY_OAUTH_U2M
+    return models.AUTH_FAMILY_LEGACY_CLIENT_SECRET_AMBIGUOUS
+
+
+def classify_command(which: Optional[str]) -> str:
+    if not which:
+        return models.COMMAND_UNSPECIFIED
+    # Normalize e.g. run-operation, docs generate, source freshness.
+    token = str(which).strip().lower().replace("-", "_").split()[0]
+    return _COMMAND_MAP.get(token, models.COMMAND_OTHER)
+
+
+def classify_warn_error_policy(warn_error: Any, warn_error_options: Any) -> str:
+    if warn_error_options:
+        # Any include/exclude/silence policy is a custom policy.
+        opts = warn_error_options
+        has_policy = any(
+            bool(getattr(opts, attr, None) or (opts.get(attr) if isinstance(opts, dict) else None))
+            for attr in ("include", "error", "warn", "silence", "exclude")
+        )
+        if has_policy:
+            return models.WARN_ERROR_CUSTOM_POLICY
+    if warn_error:
+        return models.WARN_ERROR_ALL
+    return models.WARN_ERROR_DISABLED
+
+
+def _resource_type(node: Any) -> str:
+    rt = getattr(node, "resource_type", None)
+    return str(getattr(rt, "value", rt))
+
+
+def _bump(counts: models.ResourceCounts, node: Any, resource_type: str) -> None:
+    if resource_type == "model":
+        counts.model_count += 1
+    elif resource_type == "test":
+        counts.data_test_count += 1
+        if getattr(node, "test_metadata", None) is not None:
+            counts.generic_data_test_count += 1
+    elif resource_type == "seed":
+        counts.seed_count += 1
+    elif resource_type == "snapshot":
+        counts.snapshot_count += 1
+    elif resource_type == "source":
+        counts.source_count += 1
+    elif resource_type == "function":
+        counts.function_count += 1
+    elif resource_type == "exposure":
+        counts.exposure_count += 1
+    elif resource_type == "saved_query":
+        counts.saved_query_count += 1
+    elif resource_type == "unit_test":
+        # No proto field for unit tests.
+        return
+    else:
+        # metrics, semantic models, and any other enabled type.
+        counts.other_count += 1
+
+
+def aggregate_manifest(manifest: Any) -> models.ManifestStats:
+    """Count enabled resources, split root-project vs installed-package.
+    manifest.disabled is a separate dict and is never counted.
+    """
+    stats = models.ManifestStats()
+    project_name = None
+    metadata = getattr(manifest, "metadata", None)
+    if metadata is not None:
+        project_name = getattr(metadata, "project_name", None)
+
+    # Executable nodes live in .nodes; other types have their own top-level dicts.
+    collections = ["nodes", "sources", "exposures", "metrics", "saved_queries", "functions"]
+    for collection in collections:
+        items = getattr(manifest, collection, None)
+        if not items:
+            continue
+        for node in items.values():
+            resource_type = _resource_type(node)
+            _bump(stats.enabled_total, node, resource_type)
+            is_root = getattr(node, "package_name", None) == project_name
+            _bump(
+                stats.enabled_root_project if is_root else stats.enabled_installed_packages,
+                node,
+                resource_type,
+            )
+    return stats
+
+
+def _get_flags() -> Any:
+    try:
+        from dbt.flags import get_flags
+
+        return get_flags()
+    except Exception:
+        return None
+
+
+def build_invocation_config(config: Any) -> models.InvocationConfig:
+    flags = _get_flags()
+    thread_count = getattr(config, "threads", None) or getattr(flags, "THREADS", None) or 0
+    return models.InvocationConfig(
+        thread_count=int(thread_count),
+        dbt_command=classify_command(getattr(flags, "WHICH", None)),
+        full_refresh=bool(getattr(flags, "FULL_REFRESH", False)),
+        empty=bool(getattr(flags, "EMPTY", False)),
+        fail_fast=bool(getattr(flags, "FAIL_FAST", False)),
+        warn_error_policy=classify_warn_error_policy(
+            getattr(flags, "WARN_ERROR", None), getattr(flags, "WARN_ERROR_OPTIONS", None)
+        ),
     )
+
+
+def build_connection_config(creds: DatabricksCredentials) -> models.ConnectionConfig:
+    http_path = getattr(creds, "http_path", None)
+    connection_parameters = getattr(creds, "connection_parameters", None) or {}
+    return models.ConnectionConfig(
+        default_compute_type=classify_compute_type(http_path),
+        configured_auth_family=classify_auth_family(creds),
+        named_compute_count=len(getattr(creds, "compute", None) or {}),
+        # `?o=<id>` marks a SPOG unified endpoint; value discarded.
+        uses_spog_routing="?o=" in http_path if http_path else False,
+        use_kernel=bool(connection_parameters.get("use_kernel")),
+    )
+
+
+def build_project_config(behavior_flag: Callable[[str], bool]) -> models.ProjectConfig:
+    values = {name: bool(behavior_flag(name)) for name in _BEHAVIOR_FLAGS}
+    return models.ProjectConfig(**values)
+
+
+def build_post_parse_log(
+    manifest: Any,
+    config: Any,
+    creds: DatabricksCredentials,
+    behavior_flag: Callable[[str], bool],
+) -> models.TelemetryLog:
+    """Assemble the complete POST_PARSE event from live runtime objects."""
+    invocation_id = _invocation_id(manifest)
+    payload = models.PostParsePayload(
+        invocation_config=build_invocation_config(config),
+        manifest_stats=aggregate_manifest(manifest),
+        connection_config=build_connection_config(creds),
+        project_config=build_project_config(behavior_flag),
+    )
+    return models.TelemetryLog(
+        invocation_id=invocation_id,
+        adapter_version=_adapter_version,
+        dbt_core_version=_dbt_core_version(),
+        post_parse=payload,
+    )
+
+
+def _invocation_id(manifest: Any) -> str:
+    try:
+        from dbt_common.invocation import get_invocation_id
+
+        invocation_id = get_invocation_id()
+        if invocation_id:
+            return str(invocation_id)
+    except Exception:
+        pass
+    metadata = getattr(manifest, "metadata", None)
+    return str(getattr(metadata, "invocation_id", "") or "")
+
+
+def _dbt_core_version() -> str:
+    try:
+        return _pkg_version("dbt-core")
+    except Exception:
+        return ""

--- a/dbt/adapters/databricks/telemetry/builder.py
+++ b/dbt/adapters/databricks/telemetry/builder.py
@@ -306,8 +306,7 @@ def aggregate_node_results(results: list) -> tuple:
             continue
         enum = _RESOURCE_TYPE.get(rtype)
         if enum is None:
-            if unique_id is not None:
-                unknown += 1
+            unknown += 1
         else:
             _bump_status(by_type.setdefault(enum, models.NodeStatusCounts()), status)
     _set_total(result_counts)

--- a/dbt/adapters/databricks/telemetry/builder.py
+++ b/dbt/adapters/databricks/telemetry/builder.py
@@ -1,8 +1,3 @@
-"""Reduce live runtime objects (manifest, credentials, flags, behavior flags)
-to the sanitized POST_PARSE aggregates. Classification is configuration-only;
-it never authenticates or hits the warehouse.
-"""
-
 from importlib.metadata import version as _pkg_version
 from typing import Any, Callable, Optional
 

--- a/dbt/adapters/databricks/telemetry/builder.py
+++ b/dbt/adapters/databricks/telemetry/builder.py
@@ -51,7 +51,7 @@ def classify_auth_family(creds: DatabricksCredentials) -> models.AuthFamily:
         return models.AuthFamily.AZURE_SERVICE_PRINCIPAL
     if not getattr(creds, "client_secret", None):
         return models.AuthFamily.OAUTH_U2M
-    # client_secret can select M2M or legacy Azure auth.
+    # client_secret is ambiguous between M2M and legacy Azure.
     return models.AuthFamily.LEGACY_CLIENT_SECRET_AMBIGUOUS
 
 
@@ -63,7 +63,7 @@ def classify_command(which: Optional[str]) -> models.DbtCommand:
 
 
 def classify_warn_error_policy(warn_error: Any, warn_error_options: Any) -> models.WarnErrorPolicy:
-    # dbt-core gives the legacy boolean precedence.
+    # The legacy boolean takes precedence.
     if warn_error:
         return models.WarnErrorPolicy.WARN_ERROR_ALL
     if warn_error_options:
@@ -74,7 +74,7 @@ def classify_warn_error_policy(warn_error: Any, warn_error_options: Any) -> mode
         error = get("error") or get("include") or []
         warn = get("warn") or get("exclude") or []
         silence = get("silence") or []
-        # Named overrides make `error: all` a custom policy.
+        # Named overrides make `error: all` custom.
         if error in ("all", "*") and not warn and not silence:
             return models.WarnErrorPolicy.WARN_ERROR_ALL
         has_policy = bool(error or warn or silence)
@@ -147,7 +147,7 @@ def aggregate_manifest(manifest: Any) -> models.ManifestStats:
 
 
 def ephemeral_resource_ids(manifest: Any) -> set[str]:
-    """Return only selected-count metadata; IDs are never serialized."""
+    """Return ephemeral IDs for local counting only."""
     result = set()
     for node in (getattr(manifest, "nodes", None) or {}).values():
         config = getattr(node, "config", None)
@@ -191,7 +191,7 @@ def build_connection_config(creds: DatabricksCredentials) -> models.ConnectionCo
         default_compute_type=classify_compute_type(http_path),
         configured_auth_family=classify_auth_family(creds),
         named_compute_count=len(getattr(creds, "compute", None) or {}),
-        # Only the parsed `o` query parameter is recognized; its value is discarded.
+        # Parse only the `o` parameter; discard its value.
         spog_routing_configured=extract_workspace_id(http_path) is not None,
         use_kernel=bool(connection_parameters.get("use_kernel")),
     )
@@ -306,7 +306,8 @@ def aggregate_node_results(results: list) -> tuple:
             continue
         enum = _RESOURCE_TYPE.get(rtype)
         if enum is None:
-            unknown += 1
+            if unique_id is not None:
+                unknown += 1
         else:
             _bump_status(by_type.setdefault(enum, models.NodeStatusCounts()), status)
     _set_total(result_counts)
@@ -361,7 +362,6 @@ def build_post_run_log(
     fail_fast_triggered: bool = False,
     task_success: Optional[bool] = None,
 ) -> models.TelemetryLog:
-    """Build POST_RUN from authoritative or interrupt-fallback results."""
     result_counts, by_type, auxiliary, unknown = aggregate_node_results(results)
     has_failures = bool(
         result_counts.error

--- a/dbt/adapters/databricks/telemetry/builder.py
+++ b/dbt/adapters/databricks/telemetry/builder.py
@@ -109,8 +109,7 @@ def _bump(counts: models.ResourceCounts, node: Any, resource_type: str) -> None:
     elif resource_type == "saved_query":
         counts.saved_query_count += 1
     elif resource_type == "unit_test":
-        # No proto field for unit tests.
-        return
+        counts.unit_test_count += 1
     else:
         # metrics, semantic models, and any other enabled type.
         counts.other_count += 1
@@ -175,8 +174,8 @@ def build_connection_config(creds: DatabricksCredentials) -> models.ConnectionCo
         default_compute_type=classify_compute_type(http_path),
         configured_auth_family=classify_auth_family(creds),
         named_compute_count=len(getattr(creds, "compute", None) or {}),
-        # `?o=<id>` marks a SPOG unified endpoint; value discarded.
-        uses_spog_routing="?o=" in http_path if http_path else False,
+        # `?o=<id>` is the recognized workspace-routing parameter; value discarded.
+        spog_routing_configured="?o=" in http_path if http_path else False,
         use_kernel=bool(connection_parameters.get("use_kernel")),
     )
 
@@ -226,3 +225,133 @@ def _dbt_core_version() -> str:
         return _pkg_version("dbt-core")
     except Exception:
         return ""
+
+
+# dbt node_status strings -> NodeStatusCounts field (pass_ escapes the keyword).
+_STATUS_ATTR = {
+    "success": "success",
+    "error": "error",
+    "fail": "fail",
+    "warn": "warn",
+    "skipped": "skipped",
+    "partial_success": "partial_success",
+    "pass": "pass_",
+    "runtime_error": "runtime_error",
+    "no_op": "no_op",
+    "reused": "reused",
+}
+_STATUS_BUCKETS = tuple(dict.fromkeys(_STATUS_ATTR.values()))
+
+_RESOURCE_TYPE = {
+    "model": models.ResourceType.MODEL,
+    "test": models.ResourceType.DATA_TEST,
+    "unit_test": models.ResourceType.UNIT_TEST,
+    "seed": models.ResourceType.SEED,
+    "snapshot": models.ResourceType.SNAPSHOT,
+    "source": models.ResourceType.SOURCE,
+    "function": models.ResourceType.FUNCTION,
+    "exposure": models.ResourceType.EXPOSURE,
+    "saved_query": models.ResourceType.SAVED_QUERY,
+}
+
+# on-run hooks surface as "operation" results; auxiliary, not selected resources.
+_AUXILIARY_TYPES = {"operation", "hook"}
+
+
+def _norm(value: Any) -> str:
+    return str(value).strip().lower().replace("-", "_").replace(" ", "_")
+
+
+def _set_total(counts: models.NodeStatusCounts) -> None:
+    counts.total = sum(getattr(counts, b) for b in _STATUS_BUCKETS)
+
+
+def _bump_status(counts: models.NodeStatusCounts, status: Any) -> bool:
+    attr = _STATUS_ATTR.get(_norm(status))
+    if attr is None:
+        return False
+    setattr(counts, attr, getattr(counts, attr) + 1)
+    return True
+
+
+def aggregate_node_results(node_results: list) -> tuple:
+    """Reduce (resource_type, status) pairs into the POST_RUN aggregates.
+
+    Auxiliary (hook) results stay out of result_counts and
+    results_by_resource_type; a non-auxiliary result whose type is unrecognized
+    is still in result_counts and increments unknown_resource_type_results.
+    """
+    result_counts = models.NodeStatusCounts()
+    auxiliary = models.NodeStatusCounts()
+    by_type: dict = {}
+    unknown = 0
+    for resource_type, status in node_results:
+        rtype = _norm(resource_type)
+        if rtype in _AUXILIARY_TYPES:
+            _bump_status(auxiliary, status)
+            continue
+        if not _bump_status(result_counts, status):
+            continue
+        enum = _RESOURCE_TYPE.get(rtype)
+        if enum is None:
+            unknown += 1
+        else:
+            _bump_status(by_type.setdefault(enum, models.NodeStatusCounts()), status)
+    _set_total(result_counts)
+    _set_total(auxiliary)
+    results_by_resource_type = []
+    for enum, counts in by_type.items():
+        _set_total(counts)
+        results_by_resource_type.append(
+            models.ResourceOutcomeStats(resource_type=enum, status_counts=counts)
+        )
+    return result_counts, results_by_resource_type, auxiliary, unknown
+
+
+def _classify_outcome(
+    exc_type: Optional[type], has_failures: bool
+) -> tuple[models.InvocationStatus, models.TerminationReason]:
+    # exc_type is whatever is propagating through dbt-core's teardown finally.
+    if exc_type is not None:
+        if issubclass(exc_type, KeyboardInterrupt):
+            return models.InvocationStatus.INTERRUPTED, models.TerminationReason.INTERRUPTED
+        return models.InvocationStatus.INTERNAL_ERROR, models.TerminationReason.INTERNAL_ERROR
+    if has_failures:
+        return models.InvocationStatus.HANDLED_ERROR, models.TerminationReason.NORMAL
+    return models.InvocationStatus.SUCCESS, models.TerminationReason.NORMAL
+
+
+def build_post_run_log(
+    invocation_id: str,
+    elapsed_ms: int,
+    exc_type: Optional[type],
+    node_results: list,
+    results_captured: bool,
+) -> models.TelemetryLog:
+    """Assemble the POST_RUN event from the per-node results captured during the run."""
+    result_counts, by_type, auxiliary, unknown = aggregate_node_results(node_results)
+    has_failures = bool(
+        result_counts.error
+        or result_counts.fail
+        or result_counts.runtime_error
+        or result_counts.partial_success
+    )
+    status, reason = _classify_outcome(exc_type, has_failures)
+    return models.TelemetryLog(
+        invocation_id=invocation_id,
+        adapter_version=_adapter_version,
+        dbt_core_version=_dbt_core_version(),
+        event_type=models.EventType.POST_RUN,
+        post_run=models.PostRunPayload(
+            run_outcome=models.RunOutcome(
+                invocation_status=status,
+                termination_reason=reason,
+                invocation_duration_ms=elapsed_ms,
+                result_aggregates_available=results_captured,
+            ),
+            result_counts=result_counts,
+            results_by_resource_type=by_type,
+            auxiliary_hook_results=auxiliary,
+            unknown_resource_type_results=unknown,
+        ),
+    )

--- a/dbt/adapters/databricks/telemetry/builder.py
+++ b/dbt/adapters/databricks/telemetry/builder.py
@@ -1,0 +1,27 @@
+"""Build the initial connection telemetry log from connection facts."""
+
+from importlib.metadata import version as _pkg_version
+from typing import Optional
+
+from databricks.sql import __version__ as dbsql_version
+from dbt.adapters.databricks.__version__ import version as __version__
+from dbt.adapters.databricks.telemetry.models import ConnectionLog
+
+
+def build_connection_log(
+    session_id: Optional[str] = None,
+    http_path: Optional[str] = None,
+    is_cluster: Optional[bool] = None,
+) -> ConnectionLog:
+    """Assemble the connection log; only non-sensitive metadata."""
+    compute_type = None
+    if is_cluster is not None:
+        compute_type = "cluster" if is_cluster else "sql_warehouse"
+    return ConnectionLog(
+        dbt_databricks_version=__version__,
+        dbt_core_version=_pkg_version("dbt-core"),
+        databricks_sql_connector_version=dbsql_version,
+        session_id=session_id,
+        http_path=http_path,
+        compute_type=compute_type,
+    )

--- a/dbt/adapters/databricks/telemetry/client.py
+++ b/dbt/adapters/databricks/telemetry/client.py
@@ -2,6 +2,8 @@ from typing import Any, Callable, Optional
 
 import requests
 
+from dbt.adapters.databricks.credentials import BearerAuth
+
 TELEMETRY_AUTHENTICATED_PATH = "/telemetry-ext"
 TELEMETRY_UNAUTHENTICATED_PATH = "/telemetry-unauth"
 
@@ -30,11 +32,9 @@ def send(
         headers = {"Accept": "application/json", "Content-Type": "application/json"}
         path = TELEMETRY_AUTHENTICATED_PATH
         if header_factory is not None:
-            try:
-                headers.update(header_factory())
-            except Exception:
-                return False
+            auth = BearerAuth(header_factory)
         else:
+            auth = None
             path = TELEMETRY_UNAUTHENTICATED_PATH
 
         if workspace_id is not None:
@@ -42,7 +42,13 @@ def send(
 
         url = _normalize_host(host) + path
 
-        response = requests.post(url, json=body, headers=headers, timeout=_TIMEOUT_SECONDS)
+        response = requests.post(
+            url,
+            json=body,
+            headers=headers,
+            auth=auth,
+            timeout=_TIMEOUT_SECONDS,
+        )
 
         if response.status_code // 100 != 2:
             return False

--- a/dbt/adapters/databricks/telemetry/client.py
+++ b/dbt/adapters/databricks/telemetry/client.py
@@ -26,7 +26,6 @@ def send(
     header_factory: Optional[HeaderFactory] = None,
     workspace_id: Optional[int] = None,
 ) -> bool:
-    """POST a TelemetryRequest body."""
     if not host:
         logger.debug("dbt telemetry: no host available; skipping send")
         return False

--- a/dbt/adapters/databricks/telemetry/client.py
+++ b/dbt/adapters/databricks/telemetry/client.py
@@ -1,0 +1,73 @@
+import json
+from typing import Any, Callable, Optional
+
+import requests
+
+from dbt.adapters.databricks.logging import logger
+
+TELEMETRY_AUTHENTICATED_PATH = "/telemetry-ext"
+TELEMETRY_UNAUTHENTICATED_PATH = "/telemetry-unauth"
+
+_TIMEOUT_SECONDS = 10
+
+HeaderFactory = Callable[[], dict[str, str]]
+
+
+def _normalize_host(host: str) -> str:
+    host = host.rstrip("/")
+    if not host.startswith(("http://", "https://")):
+        host = f"https://{host}"
+    return host
+
+
+def send(
+    host: Optional[str],
+    body: dict[str, Any],
+    header_factory: Optional[HeaderFactory] = None,
+    workspace_id: Optional[int] = None,
+) -> bool:
+    """POST a TelemetryRequest body."""
+    if not host:
+        logger.debug("dbt telemetry: no host available; skipping send")
+        return False
+
+    try:
+        headers = {"Accept": "application/json", "Content-Type": "application/json"}
+        path = TELEMETRY_AUTHENTICATED_PATH
+        if header_factory is not None:
+            try:
+                headers.update(header_factory())
+            except Exception as e:
+                logger.debug(f"dbt telemetry: failed to build auth headers: {e}")
+                return False
+        else:
+            path = TELEMETRY_UNAUTHENTICATED_PATH
+
+        if workspace_id is not None:
+            headers["x-databricks-org-id"] = str(workspace_id)
+
+        url = _normalize_host(host) + path
+
+        logger.debug(f"dbt telemetry: log = {json.dumps(body)}")
+        logger.debug(f"dbt telemetry: endpoint = {url}")
+
+        response = requests.post(url, json=body, headers=headers, timeout=_TIMEOUT_SECONDS)
+
+        body_preview = response.text if len(response.text) <= 500 else response.text[:500] + "…"
+        logger.debug(f"dbt telemetry: response = [{response.status_code}] {body_preview}")
+
+        if response.status_code // 100 != 2:
+            logger.debug(f"dbt telemetry: not accepted (status {response.status_code})")
+            return False
+        try:
+            ack = response.json()
+        except ValueError:
+            logger.debug("dbt telemetry: not accepted (non-JSON response)")
+            return False
+        accepted = ack.get("numProtoSuccess", 0) >= 1 and not ack.get("errors")
+        if not accepted:
+            logger.debug(f"dbt telemetry: not accepted (ack: {ack})")
+        return accepted
+    except Exception as e:
+        logger.debug(f"dbt telemetry: send failed (ignored): {e}")
+        return False

--- a/dbt/adapters/databricks/telemetry/client.py
+++ b/dbt/adapters/databricks/telemetry/client.py
@@ -1,9 +1,6 @@
-import json
 from typing import Any, Callable, Optional
 
 import requests
-
-from dbt.adapters.databricks.logging import logger
 
 TELEMETRY_AUTHENTICATED_PATH = "/telemetry-ext"
 TELEMETRY_UNAUTHENTICATED_PATH = "/telemetry-unauth"
@@ -27,7 +24,6 @@ def send(
     workspace_id: Optional[int] = None,
 ) -> bool:
     if not host:
-        logger.debug("dbt telemetry: no host available; skipping send")
         return False
 
     try:
@@ -36,8 +32,7 @@ def send(
         if header_factory is not None:
             try:
                 headers.update(header_factory())
-            except Exception as e:
-                logger.debug(f"dbt telemetry: failed to build auth headers: {e}")
+            except Exception:
                 return False
         else:
             path = TELEMETRY_UNAUTHENTICATED_PATH
@@ -47,26 +42,14 @@ def send(
 
         url = _normalize_host(host) + path
 
-        logger.debug(f"dbt telemetry: log = {json.dumps(body)}")
-        logger.debug(f"dbt telemetry: endpoint = {url}")
-
         response = requests.post(url, json=body, headers=headers, timeout=_TIMEOUT_SECONDS)
 
-        body_preview = response.text if len(response.text) <= 500 else response.text[:500] + "…"
-        logger.debug(f"dbt telemetry: response = [{response.status_code}] {body_preview}")
-
         if response.status_code // 100 != 2:
-            logger.debug(f"dbt telemetry: not accepted (status {response.status_code})")
             return False
         try:
             ack = response.json()
         except ValueError:
-            logger.debug("dbt telemetry: not accepted (non-JSON response)")
             return False
-        accepted = ack.get("numProtoSuccess", 0) >= 1 and not ack.get("errors")
-        if not accepted:
-            logger.debug(f"dbt telemetry: not accepted (ack: {ack})")
-        return accepted
-    except Exception as e:
-        logger.debug(f"dbt telemetry: send failed (ignored): {e}")
+        return ack.get("numProtoSuccess", 0) >= 1 and not ack.get("errors")
+    except Exception:
         return False

--- a/dbt/adapters/databricks/telemetry/config.py
+++ b/dbt/adapters/databricks/telemetry/config.py
@@ -10,7 +10,14 @@ def is_enabled(credentials: Optional[DatabricksCredentials]) -> bool:
     if credentials is None:
         return False
     params = credentials.connection_parameters or {}
-    return bool(params.get(ENABLE_FLAG, False))
+    value = params.get(ENABLE_FLAG, False)
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, int):
+        return value == 1
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+    return False
 
 
 def is_eligible_command() -> bool:

--- a/dbt/adapters/databricks/telemetry/config.py
+++ b/dbt/adapters/databricks/telemetry/config.py
@@ -7,7 +7,6 @@ ELIGIBLE_COMMANDS = {"build", "run", "test", "seed", "snapshot"}
 
 
 def is_enabled(credentials: Optional[DatabricksCredentials]) -> bool:
-    """True only when the user explicitly opted in on this target."""
     if credentials is None:
         return False
     params = credentials.connection_parameters or {}
@@ -15,7 +14,6 @@ def is_enabled(credentials: Optional[DatabricksCredentials]) -> bool:
 
 
 def is_eligible_command() -> bool:
-    """Whether this invocation has the two producer boundaries required by v1."""
     try:
         from dbt.flags import get_flags
 
@@ -31,11 +29,7 @@ def is_enabled_for_invocation(credentials: Optional[DatabricksCredentials]) -> b
 
 
 def has_reusable_transport(credentials: Optional[DatabricksCredentials]) -> bool:
-    """Avoid triggering a second interactive login for kernel OAuth U2M.
-
-    The kernel owns its U2M provider and does not expose it to the adapter. Other
-    paths use a non-interactive or already-initialized credential manager.
-    """
+    """Exclude kernel OAuth U2M, whose credential provider is not exposed."""
     if credentials is None:
         return False
     params = credentials.connection_parameters or {}

--- a/dbt/adapters/databricks/telemetry/config.py
+++ b/dbt/adapters/databricks/telemetry/config.py
@@ -3,6 +3,7 @@ from typing import Optional
 from dbt.adapters.databricks.credentials import DatabricksCredentials
 
 ENABLE_FLAG = "enable_dbt_telemetry"
+ELIGIBLE_COMMANDS = {"build", "run", "test", "seed", "snapshot"}
 
 
 def is_enabled(credentials: Optional[DatabricksCredentials]) -> bool:
@@ -11,3 +12,38 @@ def is_enabled(credentials: Optional[DatabricksCredentials]) -> bool:
         return False
     params = credentials.connection_parameters or {}
     return bool(params.get(ENABLE_FLAG, False))
+
+
+def is_eligible_command() -> bool:
+    """Whether this invocation has the two producer boundaries required by v1."""
+    try:
+        from dbt.flags import get_flags
+
+        which = getattr(get_flags(), "WHICH", None)
+        command = str(which or "").strip().lower().replace("_", "-").split()[0]
+        return command in ELIGIBLE_COMMANDS
+    except Exception:
+        return False
+
+
+def is_enabled_for_invocation(credentials: Optional[DatabricksCredentials]) -> bool:
+    return is_enabled(credentials) and is_eligible_command()
+
+
+def has_reusable_transport(credentials: Optional[DatabricksCredentials]) -> bool:
+    """Avoid triggering a second interactive login for kernel OAuth U2M.
+
+    The kernel owns its U2M provider and does not expose it to the adapter. Other
+    paths use a non-interactive or already-initialized credential manager.
+    """
+    if credentials is None:
+        return False
+    params = credentials.connection_parameters or {}
+    kernel_u2m = (
+        bool(params.get("use_kernel"))
+        and credentials.auth_type == "oauth"
+        and not credentials.token
+        and not credentials.client_secret
+        and not credentials.azure_client_secret
+    )
+    return not kernel_u2m

--- a/dbt/adapters/databricks/telemetry/config.py
+++ b/dbt/adapters/databricks/telemetry/config.py
@@ -29,7 +29,7 @@ def is_enabled_for_invocation(credentials: Optional[DatabricksCredentials]) -> b
 
 
 def has_reusable_transport(credentials: Optional[DatabricksCredentials]) -> bool:
-    """Exclude kernel OAuth U2M, whose credential provider is not exposed."""
+    """Kernel OAuth U2M credentials are not reusable."""
     if credentials is None:
         return False
     params = credentials.connection_parameters or {}

--- a/dbt/adapters/databricks/telemetry/config.py
+++ b/dbt/adapters/databricks/telemetry/config.py
@@ -1,0 +1,13 @@
+from typing import Optional
+
+from dbt.adapters.databricks.credentials import DatabricksCredentials
+
+ENABLE_FLAG = "enable_dbt_telemetry"
+
+
+def is_enabled(credentials: Optional[DatabricksCredentials]) -> bool:
+    """True only when the user explicitly opted in on this target."""
+    if credentials is None:
+        return False
+    params = credentials.connection_parameters or {}
+    return bool(params.get(ENABLE_FLAG, False))

--- a/dbt/adapters/databricks/telemetry/coordinator.py
+++ b/dbt/adapters/databricks/telemetry/coordinator.py
@@ -1,0 +1,130 @@
+"""Per-invocation telemetry coordinator.
+
+Keyed by dbt's invocation_id so sequential dbtRunner runs never cross-pair
+manifest and transport. Parse and first connection open may arrive in either
+order; POST_PARSE sends once both payload and an authenticated transport exist.
+Best-effort: failures are swallowed, never changing dbt command success;
+network calls happen outside the lock.
+"""
+
+import threading
+import uuid
+from typing import Any, Callable, Optional
+
+from dbt.adapters.databricks.logging import logger
+from dbt.adapters.databricks.telemetry import client, encoder
+from dbt.adapters.databricks.telemetry.models import TelemetryLog
+
+HeaderFactory = Callable[[], dict[str, str]]
+
+
+class Transport:
+    """Opaque, non-serializable reusable-transport handle. Never enters a
+    payload or debug output, so it offers no dict conversion and redacts repr.
+    """
+
+    __slots__ = ("host", "header_factory", "workspace_id")
+
+    def __init__(
+        self,
+        host: Optional[str],
+        header_factory: Optional[HeaderFactory],
+        workspace_id: Optional[Any],
+    ) -> None:
+        self.host = host
+        self.header_factory = header_factory
+        self.workspace_id = workspace_id
+
+    def __repr__(self) -> str:  # pragma: no cover - defensive redaction
+        return "<dbt telemetry Transport (redacted)>"
+
+
+class _InvocationState:
+    __slots__ = ("payload", "transport", "event_id", "post_parse_sent", "closed")
+
+    def __init__(self) -> None:
+        self.payload: Optional[TelemetryLog] = None
+        self.transport: Optional[Transport] = None
+        # Stable frontend-log id; reused across retries.
+        self.event_id: str = str(uuid.uuid4())
+        self.post_parse_sent: bool = False
+        self.closed: bool = False
+
+
+class Coordinator:
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._states: dict[str, _InvocationState] = {}
+
+    def _state(self, invocation_id: str) -> Optional[_InvocationState]:
+        state = self._states.get(invocation_id)
+        if state is None:
+            state = _InvocationState()
+            self._states[invocation_id] = state
+        elif state.closed:
+            return None
+        return state
+
+    def set_post_parse(self, invocation_id: str, payload: TelemetryLog) -> None:
+        with self._lock:
+            state = self._state(invocation_id)
+            if state is None:
+                return
+            # Idempotent: repeated parse callbacks keep the first payload.
+            if state.payload is None:
+                state.payload = payload
+        self.send_if_ready(invocation_id)
+
+    def set_transport(self, invocation_id: str, transport: Transport) -> None:
+        with self._lock:
+            state = self._state(invocation_id)
+            if state is None:
+                return
+            # Only the first reusable transport is retained.
+            if state.transport is None:
+                state.transport = transport
+        self.send_if_ready(invocation_id)
+
+    def send_if_ready(self, invocation_id: str) -> None:
+        with self._lock:
+            state = self._states.get(invocation_id)
+            if state is None or state.closed or state.post_parse_sent:
+                return
+            if state.payload is None or state.transport is None:
+                return
+            # Authenticated endpoint only: no auth headers means not ready.
+            if state.transport.header_factory is None:
+                return
+            # Claim the send while holding the lock; do the network call outside.
+            state.post_parse_sent = True
+            payload = state.payload
+            transport = state.transport
+            event_id = state.event_id
+
+        try:
+            body = encoder.encode_request(payload, event_id, workspace_id=transport.workspace_id)
+            client.send(
+                transport.host,
+                body,
+                header_factory=transport.header_factory,
+                workspace_id=transport.workspace_id,
+            )
+        except Exception as e:  # pragma: no cover - best-effort
+            logger.debug(f"dbt telemetry: post-parse send failed (ignored): {e}")
+
+    def close(self, invocation_id: str) -> None:
+        with self._lock:
+            # Leave a closed tombstone so a late callback cannot recreate state.
+            state = self._states.get(invocation_id)
+            if state is None:
+                state = _InvocationState()
+                self._states[invocation_id] = state
+            state.closed = True
+
+
+# Process-wide singleton.
+_COORDINATOR = Coordinator()
+
+
+def coordinator() -> Coordinator:
+    return _COORDINATOR

--- a/dbt/adapters/databricks/telemetry/coordinator.py
+++ b/dbt/adapters/databricks/telemetry/coordinator.py
@@ -11,7 +11,7 @@ HeaderFactory = Callable[[], dict[str, str]]
 
 
 class Transport:
-    """Opaque reusable transport that redacts its representation."""
+    """Reusable transport with a redacted representation."""
 
     __slots__ = ("host", "header_factory", "workspace_id")
 
@@ -136,7 +136,7 @@ class Coordinator:
             state = self._states.get(invocation_id)
             if state is None or state.closed:
                 return
-            # Dedicated error events may precede NodeFinished for the same node.
+            # Error events may precede NodeFinished for the same node.
             for index, (observed_id, _) in enumerate(state.node_results):
                 if str(observed_id) == str(unique_id):
                     state.node_results[index] = (unique_id, status)
@@ -202,7 +202,7 @@ class Coordinator:
                 result for result in state.node_results if str(result[0]) not in state.ephemeral_ids
             ]
             if state.end_run_statuses is not None:
-                # EndRunResult has synthesized statuses but no unique IDs.
+                # EndRunResult statuses have no unique IDs.
                 remaining = Counter(_status_key(status) for status in state.end_run_statuses)
                 typed_results = top_level_results + state.hook_results
                 for _, status in typed_results:
@@ -228,7 +228,7 @@ class Coordinator:
                     len(top_level_results) + len(synthesized) >= state.expected_result_count,
                     True,
                 )
-            # Without EndRunResult, unobserved ephemerals make selection unknown.
+            # Missing ephemeral results make selection unknown.
             partial_selected_count: Optional[int]
             if not state.ephemeral_ids:
                 partial_selected_count = state.expected_result_count
@@ -253,7 +253,7 @@ class Coordinator:
             return int(max(elapsed_seconds, 0.0) * 1000)
 
     def send_if_ready(self, invocation_id: str) -> None:
-        # Keep connection-open off the telemetry network path.
+        # Keep connection-open off the network path.
         with self._lock:
             if not self._ready_to_send(self._states.get(invocation_id)):
                 return
@@ -284,7 +284,7 @@ class Coordinator:
 
     def flush(self, timeout: Optional[float] = None) -> None:
         if timeout is None:
-            timeout = float(client._TIMEOUT_SECONDS)
+            timeout = float(client._TIMEOUT_SECONDS * 2)
         deadline = time.monotonic() + timeout
         while True:
             with self._threads_lock:
@@ -298,7 +298,7 @@ class Coordinator:
             pending[0].join(remaining)
 
     def _drain(self, invocation_id: str) -> None:
-        # A single caller drains phases while network calls remain outside the lock.
+        # Serialize phases without holding the lock during sends.
         while True:
             with self._lock:
                 state = self._states.get(invocation_id)
@@ -359,7 +359,7 @@ class Coordinator:
 
     def close(self, invocation_id: str) -> None:
         with self._lock:
-            # A tombstone rejects late callbacks without retaining sensitive state.
+            # Reject late callbacks and clear sensitive state.
             state = self._states.get(invocation_id)
             if state is None:
                 state = _InvocationState()

--- a/dbt/adapters/databricks/telemetry/coordinator.py
+++ b/dbt/adapters/databricks/telemetry/coordinator.py
@@ -4,7 +4,6 @@ import uuid
 from collections import Counter
 from typing import Any, Callable, Optional
 
-from dbt.adapters.databricks.logging import logger
 from dbt.adapters.databricks.telemetry import client, encoder
 from dbt.adapters.databricks.telemetry.models import TelemetryLog
 
@@ -121,6 +120,16 @@ class Coordinator:
     def mark_start(self, invocation_id: str) -> None:
         with self._lock:
             self._state(invocation_id)
+
+    def is_closed(self, invocation_id: str) -> bool:
+        with self._lock:
+            state = self._states.get(invocation_id)
+            return state is not None and state.closed
+
+    def needs_post_parse(self, invocation_id: str) -> bool:
+        with self._lock:
+            state = self._states.get(invocation_id)
+            return state is None or (not state.closed and state.post_parse is None)
 
     def record_node_result(self, invocation_id: str, unique_id: str, status: str) -> None:
         with self._lock:
@@ -244,8 +253,7 @@ class Coordinator:
             return int(max(elapsed_seconds, 0.0) * 1000)
 
     def send_if_ready(self, invocation_id: str) -> None:
-        # Deliver on a background thread so callers—most importantly the
-        # connection-open path—never block on telemetry network I/O.
+        # Keep connection-open off the telemetry network path.
         with self._lock:
             if not self._ready_to_send(self._states.get(invocation_id)):
                 return
@@ -261,7 +269,6 @@ class Coordinator:
         thread.start()
 
     def _ready_to_send(self, state: Optional[_InvocationState]) -> bool:
-        # Cheap pre-check under the caller's lock to avoid spawning idle threads.
         if state is None or state.closed or state.sending:
             return False
         transport = state.transport
@@ -276,7 +283,6 @@ class Coordinator:
         )
 
     def flush(self, timeout: Optional[float] = None) -> None:
-        # Bounded wait for in-flight background sends before teardown/exit.
         if timeout is None:
             timeout = float(client._TIMEOUT_SECONDS)
         deadline = time.monotonic() + timeout
@@ -348,8 +354,8 @@ class Coordinator:
         try:
             body = encoder.encode_request(payload, event_id, workspace_id=workspace_id)
             client.send(host, body, header_factory=header_factory, workspace_id=workspace_id)
-        except Exception as e:  # pragma: no cover - best-effort
-            logger.debug(f"dbt telemetry: send failed (ignored): {e}")
+        except Exception:  # pragma: no cover - best-effort
+            return
 
     def close(self, invocation_id: str) -> None:
         with self._lock:

--- a/dbt/adapters/databricks/telemetry/coordinator.py
+++ b/dbt/adapters/databricks/telemetry/coordinator.py
@@ -3,11 +3,13 @@
 Keyed by dbt's invocation_id so sequential dbtRunner runs never cross-pair
 manifest and transport. Parse and first connection open may arrive in either
 order; POST_PARSE sends once both payload and an authenticated transport exist.
-Best-effort: failures are swallowed, never changing dbt command success;
-network calls happen outside the lock.
+POST_RUN sends after the POST_PARSE attempt is terminal, reusing the same
+transport. Best-effort: failures are swallowed, never changing dbt command
+success; network calls happen outside the lock.
 """
 
 import threading
+import time
 import uuid
 from typing import Any, Callable, Optional
 
@@ -40,14 +42,33 @@ class Transport:
 
 
 class _InvocationState:
-    __slots__ = ("payload", "transport", "event_id", "post_parse_sent", "closed")
+    __slots__ = (
+        "post_parse",
+        "post_run",
+        "transport",
+        # Separate stable frontend-log ids per phase; reused across retries.
+        "post_parse_event_id",
+        "post_run_event_id",
+        "post_parse_sent",
+        "post_run_sent",
+        "start_monotonic",
+        # Per-node (resource_type, status) captured from run events.
+        "node_results",
+        "results_captured",
+        "closed",
+    )
 
     def __init__(self) -> None:
-        self.payload: Optional[TelemetryLog] = None
+        self.post_parse: Optional[TelemetryLog] = None
+        self.post_run: Optional[TelemetryLog] = None
         self.transport: Optional[Transport] = None
-        # Stable frontend-log id; reused across retries.
-        self.event_id: str = str(uuid.uuid4())
+        self.post_parse_event_id: str = str(uuid.uuid4())
+        self.post_run_event_id: str = str(uuid.uuid4())
         self.post_parse_sent: bool = False
+        self.post_run_sent: bool = False
+        self.start_monotonic: float = time.monotonic()
+        self.node_results: list = []
+        self.results_captured: bool = False
         self.closed: bool = False
 
 
@@ -70,9 +91,18 @@ class Coordinator:
             state = self._state(invocation_id)
             if state is None:
                 return
-            # Idempotent: repeated parse callbacks keep the first payload.
-            if state.payload is None:
-                state.payload = payload
+            # Idempotent: repeated callbacks keep the first payload.
+            if state.post_parse is None:
+                state.post_parse = payload
+        self.send_if_ready(invocation_id)
+
+    def set_post_run(self, invocation_id: str, payload: TelemetryLog) -> None:
+        with self._lock:
+            state = self._state(invocation_id)
+            if state is None:
+                return
+            if state.post_run is None:
+                state.post_run = payload
         self.send_if_ready(invocation_id)
 
     def set_transport(self, invocation_id: str, transport: Transport) -> None:
@@ -85,32 +115,79 @@ class Coordinator:
                 state.transport = transport
         self.send_if_ready(invocation_id)
 
-    def send_if_ready(self, invocation_id: str) -> None:
+    def mark_start(self, invocation_id: str) -> None:
+        # Create the state early so its start timestamp predates parse.
+        with self._lock:
+            self._state(invocation_id)
+
+    def begin_result_capture(self, invocation_id: str) -> None:
+        # Marks that node results are being captured, so POST_RUN can report
+        # result_aggregates_available even when the run produced zero nodes.
+        with self._lock:
+            state = self._state(invocation_id)
+            if state is not None:
+                state.results_captured = True
+
+    def record_node_result(self, invocation_id: str, resource_type: str, status: str) -> None:
+        # Called from run-event callbacks on worker threads.
         with self._lock:
             state = self._states.get(invocation_id)
-            if state is None or state.closed or state.post_parse_sent:
+            if state is None or state.closed:
                 return
-            if state.payload is None or state.transport is None:
-                return
-            # Authenticated endpoint only: no auth headers means not ready.
-            if state.transport.header_factory is None:
-                return
-            # Claim the send while holding the lock; do the network call outside.
-            state.post_parse_sent = True
-            payload = state.payload
-            transport = state.transport
-            event_id = state.event_id
+            state.node_results.append((resource_type, status))
 
+    def result_snapshot(self, invocation_id: str) -> tuple:
+        with self._lock:
+            state = self._states.get(invocation_id)
+            if state is None:
+                return [], False
+            return list(state.node_results), state.results_captured
+
+    def elapsed_ms(self, invocation_id: str) -> int:
+        with self._lock:
+            state = self._states.get(invocation_id)
+            if state is None:
+                return 0
+            return int((time.monotonic() - state.start_monotonic) * 1000)
+
+    def send_if_ready(self, invocation_id: str) -> None:
+        to_send: list = []
+        with self._lock:
+            state = self._states.get(invocation_id)
+            if state is None or state.closed:
+                return
+            transport = state.transport
+            # Authenticated endpoint only: no transport/headers means not ready.
+            if transport is None or transport.header_factory is None:
+                return
+            if state.post_parse is not None and not state.post_parse_sent:
+                state.post_parse_sent = True
+                to_send.append((state.post_parse, state.post_parse_event_id))
+            # POST_RUN waits until the POST_PARSE attempt is terminal.
+            post_parse_terminal = state.post_parse_sent or state.post_parse is None
+            if state.post_run is not None and not state.post_run_sent and post_parse_terminal:
+                state.post_run_sent = True
+                to_send.append((state.post_run, state.post_run_event_id))
+            host = transport.host
+            header_factory = transport.header_factory
+            workspace_id = transport.workspace_id
+
+        for payload, event_id in to_send:
+            self._send(host, payload, event_id, header_factory, workspace_id)
+
+    def _send(
+        self,
+        host: Optional[str],
+        payload: TelemetryLog,
+        event_id: str,
+        header_factory: Optional[HeaderFactory],
+        workspace_id: Optional[Any],
+    ) -> None:
         try:
-            body = encoder.encode_request(payload, event_id, workspace_id=transport.workspace_id)
-            client.send(
-                transport.host,
-                body,
-                header_factory=transport.header_factory,
-                workspace_id=transport.workspace_id,
-            )
+            body = encoder.encode_request(payload, event_id, workspace_id=workspace_id)
+            client.send(host, body, header_factory=header_factory, workspace_id=workspace_id)
         except Exception as e:  # pragma: no cover - best-effort
-            logger.debug(f"dbt telemetry: post-parse send failed (ignored): {e}")
+            logger.debug(f"dbt telemetry: send failed (ignored): {e}")
 
     def close(self, invocation_id: str) -> None:
         with self._lock:

--- a/dbt/adapters/databricks/telemetry/coordinator.py
+++ b/dbt/adapters/databricks/telemetry/coordinator.py
@@ -50,7 +50,6 @@ class _InvocationState:
         "expected_result_count",
         "ephemeral_ids",
         "results_captured",
-        "telemetry_delivery_seconds",
         "closed",
     )
 
@@ -73,7 +72,6 @@ class _InvocationState:
         self.expected_result_count: int = 0
         self.ephemeral_ids: set[str] = set()
         self.results_captured: bool = False
-        self.telemetry_delivery_seconds: float = 0.0
         self.closed: bool = False
 
 
@@ -81,6 +79,8 @@ class Coordinator:
     def __init__(self) -> None:
         self._lock = threading.Lock()
         self._states: dict[str, _InvocationState] = {}
+        self._threads_lock = threading.Lock()
+        self._threads: list[threading.Thread] = []
 
     def _state(self, invocation_id: str) -> Optional[_InvocationState]:
         state = self._states.get(invocation_id)
@@ -241,10 +241,57 @@ class Coordinator:
             if state is None:
                 return 0
             elapsed_seconds = time.monotonic() - state.start_monotonic
-            # The proto excludes telemetry delivery from invocation duration.
-            return int(max(elapsed_seconds - state.telemetry_delivery_seconds, 0.0) * 1000)
+            return int(max(elapsed_seconds, 0.0) * 1000)
 
     def send_if_ready(self, invocation_id: str) -> None:
+        # Deliver on a background thread so callers—most importantly the
+        # connection-open path—never block on telemetry network I/O.
+        with self._lock:
+            if not self._ready_to_send(self._states.get(invocation_id)):
+                return
+        thread = threading.Thread(
+            target=self._drain,
+            args=(invocation_id,),
+            name="dbt-telemetry-send",
+            daemon=True,
+        )
+        with self._threads_lock:
+            self._threads = [t for t in self._threads if t.is_alive()]
+            self._threads.append(thread)
+        thread.start()
+
+    def _ready_to_send(self, state: Optional[_InvocationState]) -> bool:
+        # Cheap pre-check under the caller's lock to avoid spawning idle threads.
+        if state is None or state.closed or state.sending:
+            return False
+        transport = state.transport
+        if transport is None or transport.header_factory is None:
+            return False
+        if state.post_parse is not None and not state.post_parse_sent:
+            return True
+        return (
+            state.post_run is not None
+            and not state.post_run_sent
+            and (state.post_parse_terminal or state.post_parse is None)
+        )
+
+    def flush(self, timeout: Optional[float] = None) -> None:
+        # Bounded wait for in-flight background sends before teardown/exit.
+        if timeout is None:
+            timeout = float(client._TIMEOUT_SECONDS)
+        deadline = time.monotonic() + timeout
+        while True:
+            with self._threads_lock:
+                self._threads = [t for t in self._threads if t.is_alive()]
+                pending = list(self._threads)
+            if not pending:
+                return
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            pending[0].join(remaining)
+
+    def _drain(self, invocation_id: str) -> None:
         # A single caller drains phases while network calls remain outside the lock.
         while True:
             with self._lock:
@@ -298,18 +345,11 @@ class Coordinator:
         header_factory: Optional[HeaderFactory],
         workspace_id: Optional[Any],
     ) -> None:
-        started = time.monotonic()
         try:
             body = encoder.encode_request(payload, event_id, workspace_id=workspace_id)
             client.send(host, body, header_factory=header_factory, workspace_id=workspace_id)
         except Exception as e:  # pragma: no cover - best-effort
             logger.debug(f"dbt telemetry: send failed (ignored): {e}")
-        finally:
-            delivery_seconds = time.monotonic() - started
-            with self._lock:
-                state = self._states.get(payload.invocation_id)
-                if state is not None:
-                    state.telemetry_delivery_seconds += delivery_seconds
 
     def close(self, invocation_id: str) -> None:
         with self._lock:

--- a/dbt/adapters/databricks/telemetry/coordinator.py
+++ b/dbt/adapters/databricks/telemetry/coordinator.py
@@ -1,13 +1,3 @@
-"""Per-invocation telemetry coordinator.
-
-Keyed by dbt's invocation_id so sequential dbtRunner runs never cross-pair
-manifest and transport. Parse and first connection open may arrive in either
-order; POST_PARSE sends once both payload and an authenticated transport exist.
-POST_RUN sends after the POST_PARSE attempt is terminal, reusing the same
-transport. Best-effort: failures are swallowed, never changing dbt command
-success; network calls happen outside the lock.
-"""
-
 import threading
 import time
 import uuid
@@ -22,9 +12,7 @@ HeaderFactory = Callable[[], dict[str, str]]
 
 
 class Transport:
-    """Opaque, non-serializable reusable-transport handle. Never enters a
-    payload or debug output, so it offers no dict conversion and redacts repr.
-    """
+    """Opaque reusable transport that redacts its representation."""
 
     __slots__ = ("host", "header_factory", "workspace_id")
 
@@ -47,7 +35,6 @@ class _InvocationState:
         "post_parse",
         "post_run",
         "transport",
-        # Separate stable frontend-log ids per phase; reused across retries.
         "post_parse_event_id",
         "post_run_event_id",
         "post_parse_sent",
@@ -55,16 +42,15 @@ class _InvocationState:
         "post_run_sent",
         "sending",
         "start_monotonic",
-        # (unique_id, status) results captured from run events.
-        "node_results",  # per-node NodeFinished; interrupt fallback
-        "hook_results",  # LogHookEndLine results; hooks do not fire NodeFinished
-        "end_run_statuses",  # authoritative statuses (None until EndRunResult fires)
-        "end_run_success",  # dbt-core's authoritative interpretation of the result
-        "fail_fast_triggered",  # observed fail-fast result reporting before EndRunResult
-        "expected_result_count",  # ConcurrencyLine node_count
-        "ephemeral_ids",  # sanitized manifest lookup used only for selected count
+        "node_results",
+        "hook_results",
+        "end_run_statuses",
+        "end_run_success",
+        "fail_fast_triggered",
+        "expected_result_count",
+        "ephemeral_ids",
         "results_captured",
-        "telemetry_delivery_seconds",  # excluded from invocation_duration_ms
+        "telemetry_delivery_seconds",
         "closed",
     )
 
@@ -110,7 +96,6 @@ class Coordinator:
             state = self._state(invocation_id)
             if state is None:
                 return
-            # Idempotent: repeated callbacks keep the first payload.
             if state.post_parse is None:
                 state.post_parse = payload
         self.send_if_ready(invocation_id)
@@ -129,24 +114,20 @@ class Coordinator:
             state = self._state(invocation_id)
             if state is None:
                 return
-            # Only the first reusable transport is retained.
             if state.transport is None:
                 state.transport = transport
         self.send_if_ready(invocation_id)
 
     def mark_start(self, invocation_id: str) -> None:
-        # Create the state early so its start timestamp predates parse.
         with self._lock:
             self._state(invocation_id)
 
     def record_node_result(self, invocation_id: str, unique_id: str, status: str) -> None:
-        # Per-node NodeFinished, from run-event callbacks on worker threads.
         with self._lock:
             state = self._states.get(invocation_id)
             if state is None or state.closed:
                 return
-            # Some error/skip paths have a dedicated event in addition to a
-            # NodeFinished event. Keep one terminal observation per resource.
+            # Dedicated error events may precede NodeFinished for the same node.
             for index, (observed_id, _) in enumerate(state.node_results):
                 if str(observed_id) == str(unique_id):
                     state.node_results[index] = (unique_id, status)
@@ -166,9 +147,6 @@ class Coordinator:
     def record_end_run(
         self, invocation_id: str, statuses: list, success: Optional[bool] = None
     ) -> None:
-        # EndRunResult includes fail-fast synthesized skips, but its RunResultMsg
-        # entries have no unique_id. Reconcile these statuses with typed events in
-        # result_snapshot.
         with self._lock:
             state = self._states.get(invocation_id)
             if state is None or state.closed:
@@ -205,10 +183,6 @@ class Coordinator:
                 state.ephemeral_ids = set(unique_ids)
 
     def result_snapshot(self, invocation_id: str) -> tuple:
-        # Returns (results, selected_count, expected_count, coverage_complete,
-        # results_captured).
-        # EndRunResult is authoritative and complete; NodeFinished is the partial
-        # interrupt fallback, so coverage is only complete when EndRunResult fired.
         with self._lock:
             state = self._states.get(invocation_id)
             if state is None:
@@ -219,9 +193,7 @@ class Coordinator:
                 result for result in state.node_results if str(result[0]) not in state.ephemeral_ids
             ]
             if state.end_run_statuses is not None:
-                # Remove statuses already attributable to NodeFinished and hook
-                # events. Any expected-result remainder is a synthesized result
-                # whose type cannot be recovered from EndRunResult.
+                # EndRunResult has synthesized statuses but no unique IDs.
                 remaining = Counter(_status_key(status) for status in state.end_run_statuses)
                 typed_results = top_level_results + state.hook_results
                 for _, status in typed_results:
@@ -247,9 +219,7 @@ class Coordinator:
                     len(top_level_results) + len(synthesized) >= state.expected_result_count,
                     True,
                 )
-            # ConcurrencyLine gives an exact non-ephemeral population. Without
-            # EndRunResult, however, unobserved ephemerals may be selected or may
-            # simply be outside selection. Do not report a lower bound as exact.
+            # Without EndRunResult, unobserved ephemerals make selection unknown.
             partial_selected_count: Optional[int]
             if not state.ephemeral_ids:
                 partial_selected_count = state.expected_result_count
@@ -262,8 +232,6 @@ class Coordinator:
                 partial_selected_count,
                 state.expected_result_count,
                 False,
-                # Public run events are not dbt-core's task-published partial
-                # snapshot. Be conservative on every path lacking EndRunResult.
                 False,
             )
 
@@ -273,20 +241,17 @@ class Coordinator:
             if state is None:
                 return 0
             elapsed_seconds = time.monotonic() - state.start_monotonic
-            # POST_PARSE delivery is synchronous today, so it otherwise inflates
-            # invocation duration even though the proto explicitly excludes it.
+            # The proto excludes telemetry delivery from invocation duration.
             return int(max(elapsed_seconds - state.telemetry_delivery_seconds, 0.0) * 1000)
 
     def send_if_ready(self, invocation_id: str) -> None:
-        # One caller drains ready phases. A concurrent caller returns while a send
-        # is in flight; the drainer re-checks state after that attempt finishes.
+        # A single caller drains phases while network calls remain outside the lock.
         while True:
             with self._lock:
                 state = self._states.get(invocation_id)
                 if state is None or state.closed or state.sending:
                     return
                 transport = state.transport
-                # Authenticated endpoint only: no transport/headers means not ready.
                 if transport is None or transport.header_factory is None:
                     return
 
@@ -348,13 +313,12 @@ class Coordinator:
 
     def close(self, invocation_id: str) -> None:
         with self._lock:
-            # Leave a closed tombstone so a late callback cannot recreate state.
+            # A tombstone rejects late callbacks without retaining sensitive state.
             state = self._states.get(invocation_id)
             if state is None:
                 state = _InvocationState()
                 self._states[invocation_id] = state
             state.closed = True
-            # Keep only the tombstone; do not retain payload or auth state forever.
             state.post_parse = None
             state.post_run = None
             state.transport = None
@@ -378,7 +342,6 @@ def _take_status(remaining: Counter, status: Any) -> bool:
     return True
 
 
-# Process-wide singleton.
 _COORDINATOR = Coordinator()
 
 

--- a/dbt/adapters/databricks/telemetry/coordinator.py
+++ b/dbt/adapters/databricks/telemetry/coordinator.py
@@ -11,6 +11,7 @@ success; network calls happen outside the lock.
 import threading
 import time
 import uuid
+from collections import Counter
 from typing import Any, Callable, Optional
 
 from dbt.adapters.databricks.logging import logger
@@ -50,11 +51,20 @@ class _InvocationState:
         "post_parse_event_id",
         "post_run_event_id",
         "post_parse_sent",
+        "post_parse_terminal",
         "post_run_sent",
+        "sending",
         "start_monotonic",
-        # Per-node (resource_type, status) captured from run events.
-        "node_results",
+        # (unique_id, status) results captured from run events.
+        "node_results",  # per-node NodeFinished; interrupt fallback
+        "hook_results",  # LogHookEndLine results; hooks do not fire NodeFinished
+        "end_run_statuses",  # authoritative statuses (None until EndRunResult fires)
+        "end_run_success",  # dbt-core's authoritative interpretation of the result
+        "fail_fast_triggered",  # observed fail-fast result reporting before EndRunResult
+        "expected_result_count",  # ConcurrencyLine node_count
+        "ephemeral_ids",  # sanitized manifest lookup used only for selected count
         "results_captured",
+        "telemetry_delivery_seconds",  # excluded from invocation_duration_ms
         "closed",
     )
 
@@ -65,10 +75,19 @@ class _InvocationState:
         self.post_parse_event_id: str = str(uuid.uuid4())
         self.post_run_event_id: str = str(uuid.uuid4())
         self.post_parse_sent: bool = False
+        self.post_parse_terminal: bool = False
         self.post_run_sent: bool = False
+        self.sending: bool = False
         self.start_monotonic: float = time.monotonic()
         self.node_results: list = []
+        self.hook_results: list = []
+        self.end_run_statuses: Optional[list] = None
+        self.end_run_success: Optional[bool] = None
+        self.fail_fast_triggered: bool = False
+        self.expected_result_count: int = 0
+        self.ephemeral_ids: set[str] = set()
         self.results_captured: bool = False
+        self.telemetry_delivery_seconds: float = 0.0
         self.closed: bool = False
 
 
@@ -120,60 +139,191 @@ class Coordinator:
         with self._lock:
             self._state(invocation_id)
 
-    def begin_result_capture(self, invocation_id: str) -> None:
-        # Marks that node results are being captured, so POST_RUN can report
-        # result_aggregates_available even when the run produced zero nodes.
-        with self._lock:
-            state = self._state(invocation_id)
-            if state is not None:
-                state.results_captured = True
-
-    def record_node_result(self, invocation_id: str, resource_type: str, status: str) -> None:
-        # Called from run-event callbacks on worker threads.
+    def record_node_result(self, invocation_id: str, unique_id: str, status: str) -> None:
+        # Per-node NodeFinished, from run-event callbacks on worker threads.
         with self._lock:
             state = self._states.get(invocation_id)
             if state is None or state.closed:
                 return
-            state.node_results.append((resource_type, status))
+            # Some error/skip paths have a dedicated event in addition to a
+            # NodeFinished event. Keep one terminal observation per resource.
+            for index, (observed_id, _) in enumerate(state.node_results):
+                if str(observed_id) == str(unique_id):
+                    state.node_results[index] = (unique_id, status)
+                    break
+            else:
+                state.node_results.append((unique_id, status))
+            state.results_captured = True
 
-    def result_snapshot(self, invocation_id: str) -> tuple:
+    def record_hook_result(self, invocation_id: str, status: str) -> None:
+        with self._lock:
+            state = self._states.get(invocation_id)
+            if state is None or state.closed:
+                return
+            state.hook_results.append(("operation", status))
+            state.results_captured = True
+
+    def record_end_run(
+        self, invocation_id: str, statuses: list, success: Optional[bool] = None
+    ) -> None:
+        # EndRunResult includes fail-fast synthesized skips, but its RunResultMsg
+        # entries have no unique_id. Reconcile these statuses with typed events in
+        # result_snapshot.
+        with self._lock:
+            state = self._states.get(invocation_id)
+            if state is None or state.closed:
+                return
+            state.end_run_statuses = list(statuses)
+            state.end_run_success = success
+            state.results_captured = True
+
+    def mark_fail_fast_triggered(self, invocation_id: str) -> None:
+        with self._lock:
+            state = self._states.get(invocation_id)
+            if state is None or state.closed or state.end_run_statuses is not None:
+                return
+            state.fail_fast_triggered = True
+
+    def outcome_snapshot(self, invocation_id: str) -> tuple[Optional[bool], bool]:
         with self._lock:
             state = self._states.get(invocation_id)
             if state is None:
-                return [], False
-            return list(state.node_results), state.results_captured
+                return None, False
+            return state.end_run_success, state.fail_fast_triggered
+
+    def record_expected_count(self, invocation_id: str, count: int) -> None:
+        with self._lock:
+            state = self._states.get(invocation_id)
+            if state is None or state.closed:
+                return
+            state.expected_result_count = count
+
+    def record_ephemeral_ids(self, invocation_id: str, unique_ids: set[str]) -> None:
+        with self._lock:
+            state = self._state(invocation_id)
+            if state is not None:
+                state.ephemeral_ids = set(unique_ids)
+
+    def result_snapshot(self, invocation_id: str) -> tuple:
+        # Returns (results, selected_count, expected_count, coverage_complete,
+        # results_captured).
+        # EndRunResult is authoritative and complete; NodeFinished is the partial
+        # interrupt fallback, so coverage is only complete when EndRunResult fired.
+        with self._lock:
+            state = self._states.get(invocation_id)
+            if state is None:
+                return [], 0, 0, False, False
+            observed_ids = {str(uid) for uid, _ in state.node_results}
+            observed_ephemeral_count = len(observed_ids.intersection(state.ephemeral_ids))
+            top_level_results = [
+                result for result in state.node_results if str(result[0]) not in state.ephemeral_ids
+            ]
+            if state.end_run_statuses is not None:
+                # Remove statuses already attributable to NodeFinished and hook
+                # events. Any expected-result remainder is a synthesized result
+                # whose type cannot be recovered from EndRunResult.
+                remaining = Counter(_status_key(status) for status in state.end_run_statuses)
+                typed_results = top_level_results + state.hook_results
+                for _, status in typed_results:
+                    key = _status_key(status)
+                    if remaining[key] > 0:
+                        remaining[key] -= 1
+                remaining_statuses = [
+                    status for status in state.end_run_statuses if _take_status(remaining, status)
+                ]
+                missing_expected = max(state.expected_result_count - len(top_level_results), 0)
+                synthesized = [(None, status) for status in remaining_statuses[:missing_expected]]
+                synthetic_ephemeral_count = max(len(remaining_statuses) - missing_expected, 0)
+                selected_count = (
+                    state.expected_result_count
+                    + observed_ephemeral_count
+                    + synthetic_ephemeral_count
+                )
+                reconciled_results = top_level_results + synthesized + state.hook_results
+                return (
+                    reconciled_results,
+                    selected_count,
+                    state.expected_result_count,
+                    len(top_level_results) + len(synthesized) >= state.expected_result_count,
+                    True,
+                )
+            # ConcurrencyLine gives an exact non-ephemeral population. Without
+            # EndRunResult, however, unobserved ephemerals may be selected or may
+            # simply be outside selection. Do not report a lower bound as exact.
+            partial_selected_count: Optional[int]
+            if not state.ephemeral_ids:
+                partial_selected_count = state.expected_result_count
+            elif observed_ephemeral_count == len(state.ephemeral_ids):
+                partial_selected_count = state.expected_result_count + observed_ephemeral_count
+            else:
+                partial_selected_count = None
+            return (
+                top_level_results + state.hook_results,
+                partial_selected_count,
+                state.expected_result_count,
+                False,
+                # Public run events are not dbt-core's task-published partial
+                # snapshot. Be conservative on every path lacking EndRunResult.
+                False,
+            )
 
     def elapsed_ms(self, invocation_id: str) -> int:
         with self._lock:
             state = self._states.get(invocation_id)
             if state is None:
                 return 0
-            return int((time.monotonic() - state.start_monotonic) * 1000)
+            elapsed_seconds = time.monotonic() - state.start_monotonic
+            # POST_PARSE delivery is synchronous today, so it otherwise inflates
+            # invocation duration even though the proto explicitly excludes it.
+            return int(max(elapsed_seconds - state.telemetry_delivery_seconds, 0.0) * 1000)
 
     def send_if_ready(self, invocation_id: str) -> None:
-        to_send: list = []
-        with self._lock:
-            state = self._states.get(invocation_id)
-            if state is None or state.closed:
-                return
-            transport = state.transport
-            # Authenticated endpoint only: no transport/headers means not ready.
-            if transport is None or transport.header_factory is None:
-                return
-            if state.post_parse is not None and not state.post_parse_sent:
-                state.post_parse_sent = True
-                to_send.append((state.post_parse, state.post_parse_event_id))
-            # POST_RUN waits until the POST_PARSE attempt is terminal.
-            post_parse_terminal = state.post_parse_sent or state.post_parse is None
-            if state.post_run is not None and not state.post_run_sent and post_parse_terminal:
-                state.post_run_sent = True
-                to_send.append((state.post_run, state.post_run_event_id))
-            host = transport.host
-            header_factory = transport.header_factory
-            workspace_id = transport.workspace_id
+        # One caller drains ready phases. A concurrent caller returns while a send
+        # is in flight; the drainer re-checks state after that attempt finishes.
+        while True:
+            with self._lock:
+                state = self._states.get(invocation_id)
+                if state is None or state.closed or state.sending:
+                    return
+                transport = state.transport
+                # Authenticated endpoint only: no transport/headers means not ready.
+                if transport is None or transport.header_factory is None:
+                    return
 
-        for payload, event_id in to_send:
+                phase = None
+                payload = None
+                event_id = None
+                if state.post_parse is not None and not state.post_parse_sent:
+                    phase = "post_parse"
+                    payload = state.post_parse
+                    event_id = state.post_parse_event_id
+                    state.post_parse_sent = True
+                elif (
+                    state.post_run is not None
+                    and not state.post_run_sent
+                    and (state.post_parse_terminal or state.post_parse is None)
+                ):
+                    phase = "post_run"
+                    payload = state.post_run
+                    event_id = state.post_run_event_id
+                    state.post_run_sent = True
+                if payload is None or event_id is None:
+                    return
+
+                state.sending = True
+                host = transport.host
+                header_factory = transport.header_factory
+                workspace_id = transport.workspace_id
+
             self._send(host, payload, event_id, header_factory, workspace_id)
+
+            with self._lock:
+                state = self._states.get(invocation_id)
+                if state is None or state.closed:
+                    return
+                state.sending = False
+                if phase == "post_parse":
+                    state.post_parse_terminal = True
 
     def _send(
         self,
@@ -183,11 +333,18 @@ class Coordinator:
         header_factory: Optional[HeaderFactory],
         workspace_id: Optional[Any],
     ) -> None:
+        started = time.monotonic()
         try:
             body = encoder.encode_request(payload, event_id, workspace_id=workspace_id)
             client.send(host, body, header_factory=header_factory, workspace_id=workspace_id)
         except Exception as e:  # pragma: no cover - best-effort
             logger.debug(f"dbt telemetry: send failed (ignored): {e}")
+        finally:
+            delivery_seconds = time.monotonic() - started
+            with self._lock:
+                state = self._states.get(payload.invocation_id)
+                if state is not None:
+                    state.telemetry_delivery_seconds += delivery_seconds
 
     def close(self, invocation_id: str) -> None:
         with self._lock:
@@ -197,6 +354,28 @@ class Coordinator:
                 state = _InvocationState()
                 self._states[invocation_id] = state
             state.closed = True
+            # Keep only the tombstone; do not retain payload or auth state forever.
+            state.post_parse = None
+            state.post_run = None
+            state.transport = None
+            state.node_results.clear()
+            state.hook_results.clear()
+            state.end_run_statuses = None
+            state.end_run_success = None
+            state.fail_fast_triggered = False
+            state.ephemeral_ids.clear()
+
+
+def _status_key(status: Any) -> str:
+    return str(status).strip().lower().replace("-", "_").replace(" ", "_")
+
+
+def _take_status(remaining: Counter, status: Any) -> bool:
+    key = _status_key(status)
+    if remaining[key] <= 0:
+        return False
+    remaining[key] -= 1
+    return True
 
 
 # Process-wide singleton.

--- a/dbt/adapters/databricks/telemetry/encoder.py
+++ b/dbt/adapters/databricks/telemetry/encoder.py
@@ -1,0 +1,46 @@
+import json
+import time
+import uuid
+from typing import Any, Optional
+
+from dbt.adapters.databricks.telemetry.models import ConnectionLog
+
+DRIVER_NAME = "dbt-databricks"
+CLIENT_APP_NAME = "dbt"
+
+
+def encode_event(log: ConnectionLog, workspace_id: Optional[int] = None) -> str:
+    """Encode one ConnectionLog as a TelemetryFrontendLog JSON string."""
+    sql_driver_log: dict[str, Any] = {
+        "session_id": log.session_id,
+        "system_configuration": {
+            "driver_name": DRIVER_NAME,
+            "driver_version": log.dbt_databricks_version,
+            "client_app_name": CLIENT_APP_NAME,
+        },
+        "driver_connection_params": {
+            "http_path": log.http_path,
+        },
+    }
+
+    frontend_log: dict[str, Any] = {
+        "frontend_log_event_id": str(uuid.uuid4()),
+        "context": {
+            "client_context": {
+                "timestamp_millis": int(time.time() * 1000),
+                "user_agent": f"{DRIVER_NAME}/{log.dbt_databricks_version}",
+            }
+        },
+        "entry": {"sql_driver_log": sql_driver_log},
+        "workspace_id": workspace_id,
+    }
+    return json.dumps(frontend_log)
+
+
+def encode_request(log: ConnectionLog, workspace_id: Optional[int] = None) -> dict[str, Any]:
+    """Build the TelemetryRequest body wrapping a single connection log."""
+    return {
+        "uploadTime": int(time.time() * 1000),
+        "items": [],
+        "protoLogs": [encode_event(log, workspace_id)],
+    }

--- a/dbt/adapters/databricks/telemetry/encoder.py
+++ b/dbt/adapters/databricks/telemetry/encoder.py
@@ -10,7 +10,6 @@ DRIVER_NAME = "dbt-databricks"
 
 
 def _proto_dict(log: TelemetryLog) -> dict[str, Any]:
-    # Drop unset fields and convert enums and escaped Python names to proto JSON.
     def factory(items: list) -> dict:
         out = {}
         for k, v in items:

--- a/dbt/adapters/databricks/telemetry/encoder.py
+++ b/dbt/adapters/databricks/telemetry/encoder.py
@@ -6,6 +6,7 @@ so asdict yields the proto JSON directly.
 import dataclasses
 import json
 import time
+from enum import Enum
 from typing import Any, Optional
 
 from dbt.adapters.databricks.telemetry.models import TelemetryLog
@@ -14,10 +15,15 @@ DRIVER_NAME = "dbt-databricks"
 
 
 def _proto_dict(log: TelemetryLog) -> dict[str, Any]:
-    # Drop the unset oneof phase (None) and strip the trailing underscore that
-    # escapes the reserved-word field name (pass_ -> pass).
+    # Emit enum values, drop the unset oneof phase (None), and strip the trailing
+    # underscore that escapes the reserved-word field name (pass_ -> pass).
     def factory(items: list) -> dict:
-        return {(k[:-1] if k.endswith("_") else k): v for k, v in items if v is not None}
+        out = {}
+        for k, v in items:
+            if v is None:
+                continue
+            out[k[:-1] if k.endswith("_") else k] = v.value if isinstance(v, Enum) else v
+        return out
 
     return dataclasses.asdict(log, dict_factory=factory)
 

--- a/dbt/adapters/databricks/telemetry/encoder.py
+++ b/dbt/adapters/databricks/telemetry/encoder.py
@@ -1,46 +1,56 @@
+"""Encode an event as a FrontendLog telemetry request via the first-class
+dbt_databricks_telemetry_log field; dataclass field names match the proto,
+so asdict yields the proto JSON directly.
+"""
+
+import dataclasses
 import json
 import time
-import uuid
 from typing import Any, Optional
 
-from dbt.adapters.databricks.telemetry.models import ConnectionLog
+from dbt.adapters.databricks.telemetry.models import TelemetryLog
 
 DRIVER_NAME = "dbt-databricks"
-CLIENT_APP_NAME = "dbt"
 
 
-def encode_event(log: ConnectionLog, workspace_id: Optional[int] = None) -> str:
-    """Encode one ConnectionLog as a TelemetryFrontendLog JSON string."""
-    sql_driver_log: dict[str, Any] = {
-        "session_id": log.session_id,
-        "system_configuration": {
-            "driver_name": DRIVER_NAME,
-            "driver_version": log.dbt_databricks_version,
-            "client_app_name": CLIENT_APP_NAME,
-        },
-        "driver_connection_params": {
-            "http_path": log.http_path,
-        },
-    }
+def _coerce_workspace_id(workspace_id: Optional[Any]) -> Optional[int]:
+    try:
+        return int(workspace_id) if workspace_id is not None else None
+    except (TypeError, ValueError):
+        return None
 
+
+def encode_frontend_log(
+    log: TelemetryLog,
+    frontend_log_event_id: str,
+    workspace_id: Optional[Any] = None,
+) -> str:
+    """Encode one TelemetryLog as a FrontendLog JSON string."""
+    entry = {"dbt_databricks_telemetry_log": dataclasses.asdict(log)}
     frontend_log: dict[str, Any] = {
-        "frontend_log_event_id": str(uuid.uuid4()),
+        "frontend_log_event_id": frontend_log_event_id,
         "context": {
             "client_context": {
                 "timestamp_millis": int(time.time() * 1000),
-                "user_agent": f"{DRIVER_NAME}/{log.dbt_databricks_version}",
+                "user_agent": f"{DRIVER_NAME}/{log.adapter_version}",
             }
         },
-        "entry": {"sql_driver_log": sql_driver_log},
-        "workspace_id": workspace_id,
+        "entry": entry,
     }
+    coerced = _coerce_workspace_id(workspace_id)
+    if coerced is not None:
+        frontend_log["workspace_id"] = coerced
     return json.dumps(frontend_log)
 
 
-def encode_request(log: ConnectionLog, workspace_id: Optional[int] = None) -> dict[str, Any]:
-    """Build the TelemetryRequest body wrapping a single connection log."""
+def encode_request(
+    log: TelemetryLog,
+    frontend_log_event_id: str,
+    workspace_id: Optional[Any] = None,
+) -> dict[str, Any]:
+    """Build the TelemetryRequest body wrapping a single event."""
     return {
         "uploadTime": int(time.time() * 1000),
         "items": [],
-        "protoLogs": [encode_event(log, workspace_id)],
+        "protoLogs": [encode_frontend_log(log, frontend_log_event_id, workspace_id)],
     }

--- a/dbt/adapters/databricks/telemetry/encoder.py
+++ b/dbt/adapters/databricks/telemetry/encoder.py
@@ -1,5 +1,5 @@
 """Encode an event as a FrontendLog telemetry request via the first-class
-dbt_databricks_telemetry_log field; dataclass field names match the proto,
+dbt_databricks_telemetry_log field. Dataclass field names match the proto,
 so asdict yields the proto JSON directly.
 """
 
@@ -11,6 +11,15 @@ from typing import Any, Optional
 from dbt.adapters.databricks.telemetry.models import TelemetryLog
 
 DRIVER_NAME = "dbt-databricks"
+
+
+def _proto_dict(log: TelemetryLog) -> dict[str, Any]:
+    # Drop the unset oneof phase (None) and strip the trailing underscore that
+    # escapes the reserved-word field name (pass_ -> pass).
+    def factory(items: list) -> dict:
+        return {(k[:-1] if k.endswith("_") else k): v for k, v in items if v is not None}
+
+    return dataclasses.asdict(log, dict_factory=factory)
 
 
 def _coerce_workspace_id(workspace_id: Optional[Any]) -> Optional[int]:
@@ -26,7 +35,7 @@ def encode_frontend_log(
     workspace_id: Optional[Any] = None,
 ) -> str:
     """Encode one TelemetryLog as a FrontendLog JSON string."""
-    entry = {"dbt_databricks_telemetry_log": dataclasses.asdict(log)}
+    entry = {"dbt_databricks_telemetry_log": _proto_dict(log)}
     frontend_log: dict[str, Any] = {
         "frontend_log_event_id": frontend_log_event_id,
         "context": {

--- a/dbt/adapters/databricks/telemetry/encoder.py
+++ b/dbt/adapters/databricks/telemetry/encoder.py
@@ -1,8 +1,3 @@
-"""Encode an event as a FrontendLog telemetry request via the first-class
-dbt_databricks_telemetry_log field. Dataclass field names match the proto,
-so asdict yields the proto JSON directly.
-"""
-
 import dataclasses
 import json
 import time
@@ -15,8 +10,7 @@ DRIVER_NAME = "dbt-databricks"
 
 
 def _proto_dict(log: TelemetryLog) -> dict[str, Any]:
-    # Emit enum values, drop the unset oneof phase (None), and strip the trailing
-    # underscore that escapes the reserved-word field name (pass_ -> pass).
+    # Drop unset fields and convert enums and escaped Python names to proto JSON.
     def factory(items: list) -> dict:
         out = {}
         for k, v in items:
@@ -40,7 +34,6 @@ def encode_frontend_log(
     frontend_log_event_id: str,
     workspace_id: Optional[Any] = None,
 ) -> str:
-    """Encode one TelemetryLog as a FrontendLog JSON string."""
     entry = {"dbt_databricks_telemetry_log": _proto_dict(log)}
     frontend_log: dict[str, Any] = {
         "frontend_log_event_id": frontend_log_event_id,
@@ -63,7 +56,6 @@ def encode_request(
     frontend_log_event_id: str,
     workspace_id: Optional[Any] = None,
 ) -> dict[str, Any]:
-    """Build the TelemetryRequest body wrapping a single event."""
     return {
         "uploadTime": int(time.time() * 1000),
         "items": [],

--- a/dbt/adapters/databricks/telemetry/hooks.py
+++ b/dbt/adapters/databricks/telemetry/hooks.py
@@ -2,7 +2,6 @@ import sys
 from typing import Any, Optional
 
 from dbt.adapters.databricks.credentials import DatabricksCredentials
-from dbt.adapters.databricks.logging import logger
 from dbt.adapters.databricks.telemetry import builder, listener
 from dbt.adapters.databricks.telemetry.config import (
     has_reusable_transport,
@@ -33,8 +32,8 @@ def on_adapter_init(adapter: Any) -> None:
         coord.mark_start(invocation_id)
         if not listener.register():
             coord.close(invocation_id)
-    except Exception as e:  # pragma: no cover - best-effort
-        logger.debug(f"dbt telemetry: on_adapter_init failed (ignored): {e}")
+    except Exception:  # pragma: no cover - best-effort
+        return
 
 
 def on_post_parse(adapter: Any, manifest: Any) -> None:
@@ -42,6 +41,10 @@ def on_post_parse(adapter: Any, manifest: Any) -> None:
         config = getattr(adapter, "config", None)
         creds = getattr(config, "credentials", None)
         if not isinstance(creds, DatabricksCredentials) or not is_enabled_for_invocation(creds):
+            return
+        invocation_id = _current_invocation_id()
+        coord = coordinator()
+        if invocation_id and not coord.needs_post_parse(invocation_id):
             return
         log = builder.build_post_parse_log(
             manifest=manifest,
@@ -51,11 +54,10 @@ def on_post_parse(adapter: Any, manifest: Any) -> None:
         )
         if not log.invocation_id:
             return
-        coord = coordinator()
         coord.record_ephemeral_ids(log.invocation_id, builder.ephemeral_resource_ids(manifest))
         coord.set_post_parse(log.invocation_id, log)
-    except Exception as e:  # pragma: no cover - best-effort
-        logger.debug(f"dbt telemetry: on_post_parse failed (ignored): {e}")
+    except Exception:  # pragma: no cover - best-effort
+        return
 
 
 def on_connection_open(
@@ -78,12 +80,14 @@ def on_connection_open(
             workspace_id=getattr(credentials_manager, "workspace_id", None),
         )
         coordinator().set_transport(invocation_id, transport)
-    except Exception as e:  # pragma: no cover - best-effort
-        logger.debug(f"dbt telemetry: on_connection_open failed (ignored): {e}")
+    except Exception:  # pragma: no cover - best-effort
+        return
 
 
 def _finalize_post_run(invocation_id: str, exc_type: Optional[type]) -> None:
     coord = coordinator()
+    if coord.is_closed(invocation_id):
+        return
     results, selected, expected, coverage_complete, results_captured = coord.result_snapshot(
         invocation_id
     )
@@ -101,7 +105,6 @@ def _finalize_post_run(invocation_id: str, exc_type: Optional[type]) -> None:
         task_success=task_success,
     )
     coord.set_post_run(invocation_id, log)
-    # Deliver the queued background sends before tearing down invocation state.
     coord.flush()
     coord.close(invocation_id)
 
@@ -109,8 +112,8 @@ def _finalize_post_run(invocation_id: str, exc_type: Optional[type]) -> None:
 def on_end_run_result(invocation_id: str) -> None:
     try:
         _finalize_post_run(invocation_id, None)
-    except Exception as e:  # pragma: no cover - best-effort
-        logger.debug(f"dbt telemetry: EndRunResult finalization failed (ignored): {e}")
+    except Exception:  # pragma: no cover - best-effort
+        return
 
 
 def on_run_end(adapter: Any) -> None:
@@ -126,5 +129,5 @@ def on_run_end(adapter: Any) -> None:
         exc_type = sys.exc_info()[0]
         if exc_type is not None:
             _finalize_post_run(invocation_id, exc_type)
-    except Exception as e:  # pragma: no cover - best-effort
-        logger.debug(f"dbt telemetry: on_run_end failed (ignored): {e}")
+    except Exception:  # pragma: no cover - best-effort
+        return

--- a/dbt/adapters/databricks/telemetry/hooks.py
+++ b/dbt/adapters/databricks/telemetry/hooks.py
@@ -1,45 +1,62 @@
-"""Thin hooks called from the connection manager.
-
-On the first successful connection we build one initial connection log and POST
-it immediately, using the connection's host + auth.
+"""Adapter lifecycle hooks feeding the coordinator. Both are opt-in gated and
+defensive: any failure is swallowed so telemetry never affects a dbt command.
 """
 
-from typing import Optional
+from typing import Any, Optional
 
-from dbt.adapters.databricks import telemetry
-from dbt.adapters.databricks.credentials import (
-    DatabricksCredentialManager,
-    DatabricksCredentials,
-)
+from dbt.adapters.databricks.credentials import DatabricksCredentials
 from dbt.adapters.databricks.logging import logger
+from dbt.adapters.databricks.telemetry import builder
+from dbt.adapters.databricks.telemetry.config import is_enabled
+from dbt.adapters.databricks.telemetry.coordinator import Transport, coordinator
 
-_sent = False
+
+def _current_invocation_id() -> Optional[str]:
+    try:
+        from dbt_common.invocation import get_invocation_id
+
+        invocation_id = get_invocation_id()
+        return str(invocation_id) if invocation_id else None
+    except Exception:
+        return None
+
+
+def on_post_parse(adapter: Any, manifest: Any) -> None:
+    """Build and register the POST_PARSE payload from the parsed manifest."""
+    try:
+        config = getattr(adapter, "config", None)
+        creds = getattr(config, "credentials", None)
+        if not isinstance(creds, DatabricksCredentials) or not is_enabled(creds):
+            return
+        log = builder.build_post_parse_log(
+            manifest=manifest,
+            config=config,
+            creds=creds,
+            behavior_flag=adapter.get_behavior_flag_no_warn,
+        )
+        if not log.invocation_id:
+            return
+        coordinator().set_post_parse(log.invocation_id, log)
+    except Exception as e:  # pragma: no cover - best-effort
+        logger.debug(f"dbt telemetry: on_post_parse failed (ignored): {e}")
 
 
 def on_connection_open(
     credentials: Optional[DatabricksCredentials],
-    credentials_manager: Optional[DatabricksCredentialManager],
-    session_id: Optional[str] = None,
-    http_path: Optional[str] = None,
-    is_cluster: Optional[bool] = None,
+    credentials_manager: Optional[Any],
 ) -> None:
-    """Send a single initial connection telemetry log on the first opted-in connection."""
-    global _sent
-    if _sent:
-        return
-    if not telemetry.is_enabled(credentials):
-        return
-    if credentials_manager is None:
-        return
+    """Register reusable transport from the first successful connection."""
     try:
-        _sent = True
-        telemetry.send_connection_log(
-            host=credentials_manager.host,
-            header_factory=credentials_manager.header_factory,
+        if not is_enabled(credentials) or credentials_manager is None:
+            return
+        invocation_id = _current_invocation_id()
+        if not invocation_id:
+            return
+        transport = Transport(
+            host=getattr(credentials_manager, "host", None),
+            header_factory=getattr(credentials_manager, "header_factory", None),
             workspace_id=getattr(credentials_manager, "workspace_id", None),
-            session_id=session_id,
-            http_path=http_path,
-            is_cluster=is_cluster,
         )
-    except Exception as e:
+        coordinator().set_transport(invocation_id, transport)
+    except Exception as e:  # pragma: no cover - best-effort
         logger.debug(f"dbt telemetry: on_connection_open failed (ignored): {e}")

--- a/dbt/adapters/databricks/telemetry/hooks.py
+++ b/dbt/adapters/databricks/telemetry/hooks.py
@@ -8,7 +8,10 @@ from typing import Any, Optional
 from dbt.adapters.databricks.credentials import DatabricksCredentials
 from dbt.adapters.databricks.logging import logger
 from dbt.adapters.databricks.telemetry import builder, listener
-from dbt.adapters.databricks.telemetry.config import is_enabled
+from dbt.adapters.databricks.telemetry.config import (
+    has_reusable_transport,
+    is_enabled_for_invocation,
+)
 from dbt.adapters.databricks.telemetry.coordinator import Transport, coordinator
 
 
@@ -26,15 +29,16 @@ def on_adapter_init(adapter: Any) -> None:
     """Start the invocation timer and begin capturing per-node run results."""
     try:
         creds = getattr(getattr(adapter, "config", None), "credentials", None)
-        if not isinstance(creds, DatabricksCredentials) or not is_enabled(creds):
+        if not isinstance(creds, DatabricksCredentials) or not is_enabled_for_invocation(creds):
             return
         invocation_id = _current_invocation_id()
         if not invocation_id:
             return
         coord = coordinator()
         coord.mark_start(invocation_id)
-        coord.begin_result_capture(invocation_id)
-        listener.register()
+        if not listener.register():
+            # Without the task-result producer, do not emit a parse-only half.
+            coord.close(invocation_id)
     except Exception as e:  # pragma: no cover - best-effort
         logger.debug(f"dbt telemetry: on_adapter_init failed (ignored): {e}")
 
@@ -44,7 +48,7 @@ def on_post_parse(adapter: Any, manifest: Any) -> None:
     try:
         config = getattr(adapter, "config", None)
         creds = getattr(config, "credentials", None)
-        if not isinstance(creds, DatabricksCredentials) or not is_enabled(creds):
+        if not isinstance(creds, DatabricksCredentials) or not is_enabled_for_invocation(creds):
             return
         log = builder.build_post_parse_log(
             manifest=manifest,
@@ -54,7 +58,9 @@ def on_post_parse(adapter: Any, manifest: Any) -> None:
         )
         if not log.invocation_id:
             return
-        coordinator().set_post_parse(log.invocation_id, log)
+        coord = coordinator()
+        coord.record_ephemeral_ids(log.invocation_id, builder.ephemeral_resource_ids(manifest))
+        coord.set_post_parse(log.invocation_id, log)
     except Exception as e:  # pragma: no cover - best-effort
         logger.debug(f"dbt telemetry: on_post_parse failed (ignored): {e}")
 
@@ -65,7 +71,11 @@ def on_connection_open(
 ) -> None:
     """Register reusable transport from the first successful connection."""
     try:
-        if not is_enabled(credentials) or credentials_manager is None:
+        if (
+            not is_enabled_for_invocation(credentials)
+            or not has_reusable_transport(credentials)
+            or credentials_manager is None
+        ):
             return
         invocation_id = _current_invocation_id()
         if not invocation_id:
@@ -80,27 +90,54 @@ def on_connection_open(
         logger.debug(f"dbt telemetry: on_connection_open failed (ignored): {e}")
 
 
+def _finalize_post_run(invocation_id: str, exc_type: Optional[type]) -> None:
+    coord = coordinator()
+    results, selected, expected, coverage_complete, results_captured = coord.result_snapshot(
+        invocation_id
+    )
+    task_success, fail_fast_triggered = coord.outcome_snapshot(invocation_id)
+    log = builder.build_post_run_log(
+        invocation_id,
+        coord.elapsed_ms(invocation_id),
+        exc_type,
+        results,
+        expected,
+        coverage_complete,
+        results_captured,
+        selected_resources=selected,
+        fail_fast_triggered=fail_fast_triggered,
+        task_success=task_success,
+    )
+    coord.set_post_run(invocation_id, log)
+    coord.close(invocation_id)
+
+
+def on_end_run_result(invocation_id: str) -> None:
+    """Finalize normal/handled runs after dbt publishes its authoritative result."""
+    try:
+        _finalize_post_run(invocation_id, None)
+    except Exception as e:  # pragma: no cover - best-effort
+        logger.debug(f"dbt telemetry: EndRunResult finalization failed (ignored): {e}")
+
+
 def on_run_end(adapter: Any) -> None:
-    """Build the POST_RUN payload at adapter teardown and close the invocation."""
+    """Finalize exceptional runs at cleanup; normal runs wait for EndRunResult.
+
+    dbt-core calls adapter cleanup before firing EndRunResult, so finalizing every
+    run here would discard the authoritative result set.
+    """
     try:
         config = getattr(adapter, "config", None)
         creds = getattr(config, "credentials", None)
-        if not isinstance(creds, DatabricksCredentials) or not is_enabled(creds):
+        if not isinstance(creds, DatabricksCredentials) or not is_enabled_for_invocation(creds):
             return
         invocation_id = _current_invocation_id()
         if not invocation_id:
             return
-        coord = coordinator()
-        node_results, results_captured = coord.result_snapshot(invocation_id)
-        # sys.exc_info reflects any exception propagating through dbt's teardown.
-        log = builder.build_post_run_log(
-            invocation_id,
-            coord.elapsed_ms(invocation_id),
-            sys.exc_info()[0],
-            node_results,
-            results_captured,
-        )
-        coord.set_post_run(invocation_id, log)
-        coord.close(invocation_id)
+        # sys.exc_info reflects an exception propagating through dbt's teardown.
+        # With no exception, EndRunResult fires after this cleanup callback.
+        exc_type = sys.exc_info()[0]
+        if exc_type is not None:
+            _finalize_post_run(invocation_id, exc_type)
     except Exception as e:  # pragma: no cover - best-effort
         logger.debug(f"dbt telemetry: on_run_end failed (ignored): {e}")

--- a/dbt/adapters/databricks/telemetry/hooks.py
+++ b/dbt/adapters/databricks/telemetry/hooks.py
@@ -2,11 +2,12 @@
 defensive: any failure is swallowed so telemetry never affects a dbt command.
 """
 
+import sys
 from typing import Any, Optional
 
 from dbt.adapters.databricks.credentials import DatabricksCredentials
 from dbt.adapters.databricks.logging import logger
-from dbt.adapters.databricks.telemetry import builder
+from dbt.adapters.databricks.telemetry import builder, listener
 from dbt.adapters.databricks.telemetry.config import is_enabled
 from dbt.adapters.databricks.telemetry.coordinator import Transport, coordinator
 
@@ -19,6 +20,23 @@ def _current_invocation_id() -> Optional[str]:
         return str(invocation_id) if invocation_id else None
     except Exception:
         return None
+
+
+def on_adapter_init(adapter: Any) -> None:
+    """Start the invocation timer and begin capturing per-node run results."""
+    try:
+        creds = getattr(getattr(adapter, "config", None), "credentials", None)
+        if not isinstance(creds, DatabricksCredentials) or not is_enabled(creds):
+            return
+        invocation_id = _current_invocation_id()
+        if not invocation_id:
+            return
+        coord = coordinator()
+        coord.mark_start(invocation_id)
+        coord.begin_result_capture(invocation_id)
+        listener.register()
+    except Exception as e:  # pragma: no cover - best-effort
+        logger.debug(f"dbt telemetry: on_adapter_init failed (ignored): {e}")
 
 
 def on_post_parse(adapter: Any, manifest: Any) -> None:
@@ -60,3 +78,29 @@ def on_connection_open(
         coordinator().set_transport(invocation_id, transport)
     except Exception as e:  # pragma: no cover - best-effort
         logger.debug(f"dbt telemetry: on_connection_open failed (ignored): {e}")
+
+
+def on_run_end(adapter: Any) -> None:
+    """Build the POST_RUN payload at adapter teardown and close the invocation."""
+    try:
+        config = getattr(adapter, "config", None)
+        creds = getattr(config, "credentials", None)
+        if not isinstance(creds, DatabricksCredentials) or not is_enabled(creds):
+            return
+        invocation_id = _current_invocation_id()
+        if not invocation_id:
+            return
+        coord = coordinator()
+        node_results, results_captured = coord.result_snapshot(invocation_id)
+        # sys.exc_info reflects any exception propagating through dbt's teardown.
+        log = builder.build_post_run_log(
+            invocation_id,
+            coord.elapsed_ms(invocation_id),
+            sys.exc_info()[0],
+            node_results,
+            results_captured,
+        )
+        coord.set_post_run(invocation_id, log)
+        coord.close(invocation_id)
+    except Exception as e:  # pragma: no cover - best-effort
+        logger.debug(f"dbt telemetry: on_run_end failed (ignored): {e}")

--- a/dbt/adapters/databricks/telemetry/hooks.py
+++ b/dbt/adapters/databricks/telemetry/hooks.py
@@ -1,7 +1,3 @@
-"""Adapter lifecycle hooks feeding the coordinator. Both are opt-in gated and
-defensive: any failure is swallowed so telemetry never affects a dbt command.
-"""
-
 import sys
 from typing import Any, Optional
 
@@ -26,7 +22,6 @@ def _current_invocation_id() -> Optional[str]:
 
 
 def on_adapter_init(adapter: Any) -> None:
-    """Start the invocation timer and begin capturing per-node run results."""
     try:
         creds = getattr(getattr(adapter, "config", None), "credentials", None)
         if not isinstance(creds, DatabricksCredentials) or not is_enabled_for_invocation(creds):
@@ -37,14 +32,12 @@ def on_adapter_init(adapter: Any) -> None:
         coord = coordinator()
         coord.mark_start(invocation_id)
         if not listener.register():
-            # Without the task-result producer, do not emit a parse-only half.
             coord.close(invocation_id)
     except Exception as e:  # pragma: no cover - best-effort
         logger.debug(f"dbt telemetry: on_adapter_init failed (ignored): {e}")
 
 
 def on_post_parse(adapter: Any, manifest: Any) -> None:
-    """Build and register the POST_PARSE payload from the parsed manifest."""
     try:
         config = getattr(adapter, "config", None)
         creds = getattr(config, "credentials", None)
@@ -69,7 +62,6 @@ def on_connection_open(
     credentials: Optional[DatabricksCredentials],
     credentials_manager: Optional[Any],
 ) -> None:
-    """Register reusable transport from the first successful connection."""
     try:
         if (
             not is_enabled_for_invocation(credentials)
@@ -113,7 +105,6 @@ def _finalize_post_run(invocation_id: str, exc_type: Optional[type]) -> None:
 
 
 def on_end_run_result(invocation_id: str) -> None:
-    """Finalize normal/handled runs after dbt publishes its authoritative result."""
     try:
         _finalize_post_run(invocation_id, None)
     except Exception as e:  # pragma: no cover - best-effort
@@ -121,11 +112,6 @@ def on_end_run_result(invocation_id: str) -> None:
 
 
 def on_run_end(adapter: Any) -> None:
-    """Finalize exceptional runs at cleanup; normal runs wait for EndRunResult.
-
-    dbt-core calls adapter cleanup before firing EndRunResult, so finalizing every
-    run here would discard the authoritative result set.
-    """
     try:
         config = getattr(adapter, "config", None)
         creds = getattr(config, "credentials", None)
@@ -134,8 +120,7 @@ def on_run_end(adapter: Any) -> None:
         invocation_id = _current_invocation_id()
         if not invocation_id:
             return
-        # sys.exc_info reflects an exception propagating through dbt's teardown.
-        # With no exception, EndRunResult fires after this cleanup callback.
+        # Normal runs finalize at EndRunResult, which fires after cleanup.
         exc_type = sys.exc_info()[0]
         if exc_type is not None:
             _finalize_post_run(invocation_id, exc_type)

--- a/dbt/adapters/databricks/telemetry/hooks.py
+++ b/dbt/adapters/databricks/telemetry/hooks.py
@@ -125,7 +125,6 @@ def on_run_end(adapter: Any) -> None:
         invocation_id = _current_invocation_id()
         if not invocation_id:
             return
-        # Normal runs finalize at EndRunResult, which fires after cleanup.
         exc_type = sys.exc_info()[0]
         if exc_type is not None:
             _finalize_post_run(invocation_id, exc_type)

--- a/dbt/adapters/databricks/telemetry/hooks.py
+++ b/dbt/adapters/databricks/telemetry/hooks.py
@@ -101,6 +101,8 @@ def _finalize_post_run(invocation_id: str, exc_type: Optional[type]) -> None:
         task_success=task_success,
     )
     coord.set_post_run(invocation_id, log)
+    # Deliver the queued background sends before tearing down invocation state.
+    coord.flush()
     coord.close(invocation_id)
 
 

--- a/dbt/adapters/databricks/telemetry/hooks.py
+++ b/dbt/adapters/databricks/telemetry/hooks.py
@@ -1,0 +1,45 @@
+"""Thin hooks called from the connection manager.
+
+On the first successful connection we build one initial connection log and POST
+it immediately, using the connection's host + auth.
+"""
+
+from typing import Optional
+
+from dbt.adapters.databricks import telemetry
+from dbt.adapters.databricks.credentials import (
+    DatabricksCredentialManager,
+    DatabricksCredentials,
+)
+from dbt.adapters.databricks.logging import logger
+
+_sent = False
+
+
+def on_connection_open(
+    credentials: Optional[DatabricksCredentials],
+    credentials_manager: Optional[DatabricksCredentialManager],
+    session_id: Optional[str] = None,
+    http_path: Optional[str] = None,
+    is_cluster: Optional[bool] = None,
+) -> None:
+    """Send a single initial connection telemetry log on the first opted-in connection."""
+    global _sent
+    if _sent:
+        return
+    if not telemetry.is_enabled(credentials):
+        return
+    if credentials_manager is None:
+        return
+    try:
+        _sent = True
+        telemetry.send_connection_log(
+            host=credentials_manager.host,
+            header_factory=credentials_manager.header_factory,
+            workspace_id=getattr(credentials_manager, "workspace_id", None),
+            session_id=session_id,
+            http_path=http_path,
+            is_cluster=is_cluster,
+        )
+    except Exception as e:
+        logger.debug(f"dbt telemetry: on_connection_open failed (ignored): {e}")

--- a/dbt/adapters/databricks/telemetry/listener.py
+++ b/dbt/adapters/databricks/telemetry/listener.py
@@ -1,18 +1,3 @@
-"""Run-event listener that captures run results for POST_RUN.
-
-Added to dbt's event manager after setup_event_logger (which resets callbacks
-in preflight), so it survives for the invocation. It captures:
-- EndRunResult: the authoritative final result set (includes fail-fast
-  synthesized skips); does not fire on keyboard interrupt.
-- NodeFinished: per-node results, the partial fallback used on interrupt.
-- LogHookEndLine: auxiliary on-run-start/on-run-end results.
-- ConcurrencyLine: node_count, the expected-result population.
-- GenericExceptionOnRun/SkippingDetails: typed results that do not fire
-  NodeFinished.
-- RunResultFailure/RunResultError before EndRunResult: dbt-core's observable
-  fail-fast catch path.
-"""
-
 from typing import Any
 
 from dbt.adapters.databricks.logging import logger
@@ -35,7 +20,6 @@ def _fail_fast_enabled() -> bool:
 
 
 def _on_event(msg: Any) -> None:
-    # Runs for every fired event; keep the uninteresting path cheap.
     try:
         name = msg.info.name
         if name not in (
@@ -54,50 +38,37 @@ def _on_event(msg: Any) -> None:
             return
         coord = coordinator()
         if name == "EndRunResult":
-            # The authoritative status list includes fail-fast synthesized skips,
-            # but RunResultMsg intentionally does not contain unique_id.
             coord.record_end_run(
                 invocation_id,
                 [r.status for r in msg.data.results],
                 success=getattr(msg.data, "success", None),
             )
-            # cleanup_connections ran immediately before this event, so this is
-            # the normal/handled-run finalizer boundary.
             from dbt.adapters.databricks.telemetry import hooks
 
             hooks.on_end_run_result(invocation_id)
         elif name == "NodeFinished":
-            # Partial per-node fallback used when EndRunResult never fires (interrupt).
             info = msg.data.node_info
             coord.record_node_result(invocation_id, info.unique_id, info.node_status)
         elif name == "LogHookEndLine":
             coord.record_hook_result(invocation_id, msg.data.status)
         elif name == "ConcurrencyLine":
-            # node_count == selected non-ephemeral nodes == expected-result count.
             coord.record_expected_count(invocation_id, msg.data.node_count)
         elif name == "GenericExceptionOnRun":
-            # dbt-core creates an error RunResult after this event but does not
-            # subsequently fire NodeFinished for it.
+            # This path does not subsequently fire NodeFinished.
             unique_id = msg.data.unique_id or msg.data.node_info.unique_id
             if unique_id:
                 coord.record_node_result(invocation_id, unique_id, "error")
         elif name == "SkippingDetails":
-            # Used when an on-run-start failure prevents selected nodes from
-            # entering their normal runner/NodeFinished lifecycle.
             unique_id = msg.data.node_info.unique_id
             if unique_id:
                 coord.record_node_result(invocation_id, unique_id, "skipped")
         elif name in ("RunResultFailure", "RunResultError") and _fail_fast_enabled():
-            # In GraphRunnableTask, the caught FailFastError is printed before
-            # EndRunResult. Normal end-of-run failure printing occurs afterward,
-            # when the invocation has already been closed.
             coord.mark_fail_fast_triggered(invocation_id)
     except Exception:  # pragma: no cover - best-effort
         pass
 
 
 def register() -> bool:
-    """Idempotently add the result listener to the event manager."""
     try:
         from dbt_common.events.event_manager_client import (
             add_callback_to_manager,

--- a/dbt/adapters/databricks/telemetry/listener.py
+++ b/dbt/adapters/databricks/telemetry/listener.py
@@ -1,8 +1,16 @@
-"""Run-event listener that captures per-node results for POST_RUN.
+"""Run-event listener that captures run results for POST_RUN.
 
 Added to dbt's event manager after setup_event_logger (which resets callbacks
-in preflight), so it survives for the invocation. dbt fires NodeFinished once
-per executed node with its resource_type and terminal status.
+in preflight), so it survives for the invocation. It captures:
+- EndRunResult: the authoritative final result set (includes fail-fast
+  synthesized skips); does not fire on keyboard interrupt.
+- NodeFinished: per-node results, the partial fallback used on interrupt.
+- LogHookEndLine: auxiliary on-run-start/on-run-end results.
+- ConcurrencyLine: node_count, the expected-result population.
+- GenericExceptionOnRun/SkippingDetails: typed results that do not fire
+  NodeFinished.
+- RunResultFailure/RunResultError before EndRunResult: dbt-core's observable
+  fail-fast catch path.
 """
 
 from typing import Any
@@ -17,22 +25,78 @@ def _current_invocation_id() -> str:
     return str(get_invocation_id() or "")
 
 
-def _on_event(msg: Any) -> None:
-    # Runs for every fired event; keep the non-NodeFinished path cheap.
+def _fail_fast_enabled() -> bool:
     try:
-        if msg.info.name != "NodeFinished":
+        from dbt.flags import get_flags
+
+        return bool(getattr(get_flags(), "FAIL_FAST", False))
+    except Exception:
+        return False
+
+
+def _on_event(msg: Any) -> None:
+    # Runs for every fired event; keep the uninteresting path cheap.
+    try:
+        name = msg.info.name
+        if name not in (
+            "NodeFinished",
+            "EndRunResult",
+            "LogHookEndLine",
+            "ConcurrencyLine",
+            "GenericExceptionOnRun",
+            "SkippingDetails",
+            "RunResultFailure",
+            "RunResultError",
+        ):
             return
-        node_info = msg.data.node_info
         invocation_id = _current_invocation_id()
-        if invocation_id:
-            coordinator().record_node_result(
-                invocation_id, node_info.resource_type, node_info.node_status
+        if not invocation_id:
+            return
+        coord = coordinator()
+        if name == "EndRunResult":
+            # The authoritative status list includes fail-fast synthesized skips,
+            # but RunResultMsg intentionally does not contain unique_id.
+            coord.record_end_run(
+                invocation_id,
+                [r.status for r in msg.data.results],
+                success=getattr(msg.data, "success", None),
             )
+            # cleanup_connections ran immediately before this event, so this is
+            # the normal/handled-run finalizer boundary.
+            from dbt.adapters.databricks.telemetry import hooks
+
+            hooks.on_end_run_result(invocation_id)
+        elif name == "NodeFinished":
+            # Partial per-node fallback used when EndRunResult never fires (interrupt).
+            info = msg.data.node_info
+            coord.record_node_result(invocation_id, info.unique_id, info.node_status)
+        elif name == "LogHookEndLine":
+            coord.record_hook_result(invocation_id, msg.data.status)
+        elif name == "ConcurrencyLine":
+            # node_count == selected non-ephemeral nodes == expected-result count.
+            coord.record_expected_count(invocation_id, msg.data.node_count)
+        elif name == "GenericExceptionOnRun":
+            # dbt-core creates an error RunResult after this event but does not
+            # subsequently fire NodeFinished for it.
+            unique_id = msg.data.unique_id or msg.data.node_info.unique_id
+            if unique_id:
+                coord.record_node_result(invocation_id, unique_id, "error")
+        elif name == "SkippingDetails":
+            # Used when an on-run-start failure prevents selected nodes from
+            # entering their normal runner/NodeFinished lifecycle.
+            unique_id = msg.data.node_info.unique_id
+            if unique_id:
+                coord.record_node_result(invocation_id, unique_id, "skipped")
+        elif name in ("RunResultFailure", "RunResultError") and _fail_fast_enabled():
+            # In GraphRunnableTask, the caught FailFastError is printed before
+            # EndRunResult. Normal end-of-run failure printing occurs afterward,
+            # when the invocation has already been closed.
+            coord.mark_fail_fast_triggered(invocation_id)
     except Exception:  # pragma: no cover - best-effort
         pass
 
 
-def register() -> None:
+def register() -> bool:
     """Idempotently add the result listener to the event manager."""
     try:
         from dbt_common.events.event_manager_client import (
@@ -42,5 +106,7 @@ def register() -> None:
 
         if _on_event not in get_event_manager().callbacks:
             add_callback_to_manager(_on_event)
+        return True
     except Exception as e:  # pragma: no cover - best-effort
         logger.debug(f"dbt telemetry: listener register failed (ignored): {e}")
+        return False

--- a/dbt/adapters/databricks/telemetry/listener.py
+++ b/dbt/adapters/databricks/telemetry/listener.py
@@ -1,6 +1,5 @@
 from typing import Any
 
-from dbt.adapters.databricks.logging import logger
 from dbt.adapters.databricks.telemetry.coordinator import coordinator
 
 
@@ -65,7 +64,7 @@ def _on_event(msg: Any) -> None:
         elif name in ("RunResultFailure", "RunResultError") and _fail_fast_enabled():
             coord.mark_fail_fast_triggered(invocation_id)
     except Exception:  # pragma: no cover - best-effort
-        pass
+        return
 
 
 def register() -> bool:
@@ -78,6 +77,5 @@ def register() -> bool:
         if _on_event not in get_event_manager().callbacks:
             add_callback_to_manager(_on_event)
         return True
-    except Exception as e:  # pragma: no cover - best-effort
-        logger.debug(f"dbt telemetry: listener register failed (ignored): {e}")
+    except Exception:  # pragma: no cover - best-effort
         return False

--- a/dbt/adapters/databricks/telemetry/listener.py
+++ b/dbt/adapters/databricks/telemetry/listener.py
@@ -1,0 +1,46 @@
+"""Run-event listener that captures per-node results for POST_RUN.
+
+Added to dbt's event manager after setup_event_logger (which resets callbacks
+in preflight), so it survives for the invocation. dbt fires NodeFinished once
+per executed node with its resource_type and terminal status.
+"""
+
+from typing import Any
+
+from dbt.adapters.databricks.logging import logger
+from dbt.adapters.databricks.telemetry.coordinator import coordinator
+
+
+def _current_invocation_id() -> str:
+    from dbt_common.invocation import get_invocation_id
+
+    return str(get_invocation_id() or "")
+
+
+def _on_event(msg: Any) -> None:
+    # Runs for every fired event; keep the non-NodeFinished path cheap.
+    try:
+        if msg.info.name != "NodeFinished":
+            return
+        node_info = msg.data.node_info
+        invocation_id = _current_invocation_id()
+        if invocation_id:
+            coordinator().record_node_result(
+                invocation_id, node_info.resource_type, node_info.node_status
+            )
+    except Exception:  # pragma: no cover - best-effort
+        pass
+
+
+def register() -> None:
+    """Idempotently add the result listener to the event manager."""
+    try:
+        from dbt_common.events.event_manager_client import (
+            add_callback_to_manager,
+            get_event_manager,
+        )
+
+        if _on_event not in get_event_manager().callbacks:
+            add_callback_to_manager(_on_event)
+    except Exception as e:  # pragma: no cover - best-effort
+        logger.debug(f"dbt telemetry: listener register failed (ignored): {e}")

--- a/dbt/adapters/databricks/telemetry/listener.py
+++ b/dbt/adapters/databricks/telemetry/listener.py
@@ -53,7 +53,7 @@ def _on_event(msg: Any) -> None:
         elif name == "ConcurrencyLine":
             coord.record_expected_count(invocation_id, msg.data.node_count)
         elif name == "GenericExceptionOnRun":
-            # This path does not subsequently fire NodeFinished.
+            # No NodeFinished event follows.
             unique_id = msg.data.unique_id or msg.data.node_info.unique_id
             if unique_id:
                 coord.record_node_result(invocation_id, unique_id, "error")

--- a/dbt/adapters/databricks/telemetry/models.py
+++ b/dbt/adapters/databricks/telemetry/models.py
@@ -97,6 +97,7 @@ class ResourceCounts:
     exposure_count: int = 0
     saved_query_count: int = 0
     other_count: int = 0
+    unit_test_count: int = 0
 
 
 @dataclass
@@ -127,7 +128,7 @@ class ConnectionConfig:
     default_compute_type: ComputeType = ComputeType.TYPE_UNSPECIFIED
     configured_auth_family: AuthFamily = AuthFamily.TYPE_UNSPECIFIED
     named_compute_count: int = 0
-    uses_spog_routing: bool = False
+    spog_routing_configured: bool = False
     use_kernel: bool = False
 
 

--- a/dbt/adapters/databricks/telemetry/models.py
+++ b/dbt/adapters/databricks/telemetry/models.py
@@ -1,54 +1,86 @@
 from dataclasses import dataclass, field
+from enum import Enum
 from typing import Optional
 
-# Closed-enum value names; must match the proto enum members.
-EVENT_TYPE_POST_PARSE = "POST_PARSE"
-EVENT_TYPE_POST_RUN = "POST_RUN"
 
-COMPUTE_TYPE_UNSPECIFIED = "TYPE_UNSPECIFIED"
-COMPUTE_TYPE_SQL_WAREHOUSE = "SQL_WAREHOUSE"
-COMPUTE_TYPE_ALL_PURPOSE_CLUSTER = "ALL_PURPOSE_CLUSTER"
-COMPUTE_TYPE_OTHER = "OTHER"
+# Closed enums; values are the proto enum member names.
+class EventType(Enum):
+    TYPE_UNSPECIFIED = "TYPE_UNSPECIFIED"
+    POST_PARSE = "POST_PARSE"
+    POST_RUN = "POST_RUN"
 
-AUTH_FAMILY_UNSPECIFIED = "TYPE_UNSPECIFIED"
-AUTH_FAMILY_PAT = "PAT"
-AUTH_FAMILY_OAUTH_U2M = "OAUTH_U2M"
-AUTH_FAMILY_OAUTH_M2M = "OAUTH_M2M"
-AUTH_FAMILY_AZURE_SERVICE_PRINCIPAL = "AZURE_SERVICE_PRINCIPAL"
-AUTH_FAMILY_LEGACY_CLIENT_SECRET_AMBIGUOUS = "LEGACY_CLIENT_SECRET_AMBIGUOUS"
-AUTH_FAMILY_OTHER = "OTHER"
 
-COMMAND_UNSPECIFIED = "TYPE_UNSPECIFIED"
-COMMAND_OTHER = "OTHER"
+class ComputeType(Enum):
+    TYPE_UNSPECIFIED = "TYPE_UNSPECIFIED"
+    SQL_WAREHOUSE = "SQL_WAREHOUSE"
+    ALL_PURPOSE_CLUSTER = "ALL_PURPOSE_CLUSTER"
+    OTHER = "OTHER"
 
-WARN_ERROR_DISABLED = "WARN_ERROR_DISABLED"
-WARN_ERROR_ALL = "WARN_ERROR_ALL"
-WARN_ERROR_CUSTOM_POLICY = "WARN_ERROR_CUSTOM_POLICY"
 
-RESOURCE_TYPE_UNSPECIFIED = "TYPE_UNSPECIFIED"
-RESOURCE_TYPE_MODEL = "MODEL"
-RESOURCE_TYPE_DATA_TEST = "DATA_TEST"
-RESOURCE_TYPE_UNIT_TEST = "UNIT_TEST"
-RESOURCE_TYPE_SEED = "SEED"
-RESOURCE_TYPE_SNAPSHOT = "SNAPSHOT"
-RESOURCE_TYPE_SOURCE = "SOURCE"
-RESOURCE_TYPE_FUNCTION = "FUNCTION"
-RESOURCE_TYPE_EXPOSURE = "EXPOSURE"
-RESOURCE_TYPE_SAVED_QUERY = "SAVED_QUERY"
-RESOURCE_TYPE_OTHER = "OTHER"
+class AuthFamily(Enum):
+    TYPE_UNSPECIFIED = "TYPE_UNSPECIFIED"
+    PAT = "PAT"
+    OAUTH_U2M = "OAUTH_U2M"
+    OAUTH_M2M = "OAUTH_M2M"
+    AZURE_SERVICE_PRINCIPAL = "AZURE_SERVICE_PRINCIPAL"
+    LEGACY_CLIENT_SECRET_AMBIGUOUS = "LEGACY_CLIENT_SECRET_AMBIGUOUS"
+    OTHER = "OTHER"
 
-INVOCATION_STATUS_UNSPECIFIED = "TYPE_UNSPECIFIED"
-INVOCATION_STATUS_SUCCESS = "SUCCESS"
-INVOCATION_STATUS_HANDLED_ERROR = "HANDLED_ERROR"
-INVOCATION_STATUS_INTERRUPTED = "INTERRUPTED"
-INVOCATION_STATUS_INTERNAL_ERROR = "INTERNAL_ERROR"
 
-TERMINATION_REASON_UNSPECIFIED = "TYPE_UNSPECIFIED"
-TERMINATION_REASON_NORMAL = "NORMAL"
-TERMINATION_REASON_FAIL_FAST = "FAIL_FAST"
-TERMINATION_REASON_INTERRUPTED = "INTERRUPTED"
-TERMINATION_REASON_TASK_ERROR = "TASK_ERROR"
-TERMINATION_REASON_INTERNAL_ERROR = "INTERNAL_ERROR"
+class DbtCommand(Enum):
+    TYPE_UNSPECIFIED = "TYPE_UNSPECIFIED"
+    RUN = "RUN"
+    BUILD = "BUILD"
+    TEST = "TEST"
+    SEED = "SEED"
+    SNAPSHOT = "SNAPSHOT"
+    COMPILE = "COMPILE"
+    DOCS = "DOCS"
+    CLONE = "CLONE"
+    RETRY = "RETRY"
+    SHOW = "SHOW"
+    LIST = "LIST"
+    SOURCE = "SOURCE"
+    RUN_OPERATION = "RUN_OPERATION"
+    OTHER = "OTHER"
+
+
+class WarnErrorPolicy(Enum):
+    TYPE_UNSPECIFIED = "TYPE_UNSPECIFIED"
+    WARN_ERROR_DISABLED = "WARN_ERROR_DISABLED"
+    WARN_ERROR_ALL = "WARN_ERROR_ALL"
+    WARN_ERROR_CUSTOM_POLICY = "WARN_ERROR_CUSTOM_POLICY"
+
+
+class ResourceType(Enum):
+    TYPE_UNSPECIFIED = "TYPE_UNSPECIFIED"
+    MODEL = "MODEL"
+    DATA_TEST = "DATA_TEST"
+    UNIT_TEST = "UNIT_TEST"
+    SEED = "SEED"
+    SNAPSHOT = "SNAPSHOT"
+    SOURCE = "SOURCE"
+    FUNCTION = "FUNCTION"
+    EXPOSURE = "EXPOSURE"
+    SAVED_QUERY = "SAVED_QUERY"
+    OTHER = "OTHER"
+
+
+class InvocationStatus(Enum):
+    TYPE_UNSPECIFIED = "TYPE_UNSPECIFIED"
+    SUCCESS = "SUCCESS"
+    HANDLED_ERROR = "HANDLED_ERROR"
+    INTERRUPTED = "INTERRUPTED"
+    INTERNAL_ERROR = "INTERNAL_ERROR"
+
+
+class TerminationReason(Enum):
+    TYPE_UNSPECIFIED = "TYPE_UNSPECIFIED"
+    NORMAL = "NORMAL"
+    FAIL_FAST = "FAIL_FAST"
+    INTERRUPTED = "INTERRUPTED"
+    TASK_ERROR = "TASK_ERROR"
+    INTERNAL_ERROR = "INTERNAL_ERROR"
 
 
 @dataclass
@@ -81,19 +113,19 @@ class InvocationConfig:
     """Invocation CLI flags; no customer-defined values."""
 
     thread_count: int = 0
-    dbt_command: str = COMMAND_UNSPECIFIED
+    dbt_command: DbtCommand = DbtCommand.TYPE_UNSPECIFIED
     full_refresh: bool = False
     empty: bool = False
     fail_fast: bool = False
-    warn_error_policy: str = WARN_ERROR_DISABLED
+    warn_error_policy: WarnErrorPolicy = WarnErrorPolicy.WARN_ERROR_DISABLED
 
 
 @dataclass
 class ConnectionConfig:
     """Connection classification derived from the profile; no http_path."""
 
-    default_compute_type: str = COMPUTE_TYPE_UNSPECIFIED
-    configured_auth_family: str = AUTH_FAMILY_UNSPECIFIED
+    default_compute_type: ComputeType = ComputeType.TYPE_UNSPECIFIED
+    configured_auth_family: AuthFamily = AuthFamily.TYPE_UNSPECIFIED
     named_compute_count: int = 0
     uses_spog_routing: bool = False
     use_kernel: bool = False
@@ -142,14 +174,14 @@ class NodeStatusCounts:
 class ResourceOutcomeStats:
     """Status counts for one resource type."""
 
-    resource_type: str = RESOURCE_TYPE_UNSPECIFIED
+    resource_type: ResourceType = ResourceType.TYPE_UNSPECIFIED
     status_counts: NodeStatusCounts = field(default_factory=NodeStatusCounts)
 
 
 @dataclass
 class RunOutcome:
-    invocation_status: str = INVOCATION_STATUS_UNSPECIFIED
-    termination_reason: str = TERMINATION_REASON_UNSPECIFIED
+    invocation_status: InvocationStatus = InvocationStatus.TYPE_UNSPECIFIED
+    termination_reason: TerminationReason = TerminationReason.TYPE_UNSPECIFIED
     invocation_duration_ms: int = 0
     result_aggregates_available: bool = False
     expected_result_coverage_complete: bool = False
@@ -175,6 +207,6 @@ class TelemetryLog:
     invocation_id: str
     adapter_version: str
     dbt_core_version: str
-    event_type: str = EVENT_TYPE_POST_PARSE
+    event_type: EventType = EventType.POST_PARSE
     post_parse: Optional[PostParsePayload] = None
     post_run: Optional[PostRunPayload] = None

--- a/dbt/adapters/databricks/telemetry/models.py
+++ b/dbt/adapters/databricks/telemetry/models.py
@@ -185,7 +185,7 @@ class RunOutcome:
     termination_reason: TerminationReason = TerminationReason.TYPE_UNSPECIFIED
     invocation_duration_ms: int = 0
     result_aggregates_available: bool = False
-    expected_result_coverage_complete: bool = False
+    expected_result_coverage_complete: Optional[bool] = None
 
 
 @dataclass
@@ -193,12 +193,12 @@ class PostRunPayload:
     """The ``DbtPostRun`` payload."""
 
     run_outcome: RunOutcome = field(default_factory=RunOutcome)
-    selected_resources: int = 0
+    selected_resources: Optional[int] = None
     expected_result_resources: int = 0
-    result_counts: NodeStatusCounts = field(default_factory=NodeStatusCounts)
-    results_by_resource_type: list[ResourceOutcomeStats] = field(default_factory=list)
-    auxiliary_hook_results: NodeStatusCounts = field(default_factory=NodeStatusCounts)
-    unknown_resource_type_results: int = 0
+    result_counts: Optional[NodeStatusCounts] = None
+    results_by_resource_type: Optional[list[ResourceOutcomeStats]] = None
+    auxiliary_hook_results: Optional[NodeStatusCounts] = None
+    unknown_resource_type_results: Optional[int] = None
 
 
 @dataclass

--- a/dbt/adapters/databricks/telemetry/models.py
+++ b/dbt/adapters/databricks/telemetry/models.py
@@ -1,12 +1,9 @@
-"""Sanitized POST_PARSE payload models, mirroring the DbtDatabricksTelemetryLog
-proto. Fixed scalars and closed-enum value names only; no raw credentials,
-paths, names, SQL, or open maps.
-"""
-
 from dataclasses import dataclass, field
+from typing import Optional
 
 # Closed-enum value names; must match the proto enum members.
 EVENT_TYPE_POST_PARSE = "POST_PARSE"
+EVENT_TYPE_POST_RUN = "POST_RUN"
 
 COMPUTE_TYPE_UNSPECIFIED = "TYPE_UNSPECIFIED"
 COMPUTE_TYPE_SQL_WAREHOUSE = "SQL_WAREHOUSE"
@@ -27,6 +24,31 @@ COMMAND_OTHER = "OTHER"
 WARN_ERROR_DISABLED = "WARN_ERROR_DISABLED"
 WARN_ERROR_ALL = "WARN_ERROR_ALL"
 WARN_ERROR_CUSTOM_POLICY = "WARN_ERROR_CUSTOM_POLICY"
+
+RESOURCE_TYPE_UNSPECIFIED = "TYPE_UNSPECIFIED"
+RESOURCE_TYPE_MODEL = "MODEL"
+RESOURCE_TYPE_DATA_TEST = "DATA_TEST"
+RESOURCE_TYPE_UNIT_TEST = "UNIT_TEST"
+RESOURCE_TYPE_SEED = "SEED"
+RESOURCE_TYPE_SNAPSHOT = "SNAPSHOT"
+RESOURCE_TYPE_SOURCE = "SOURCE"
+RESOURCE_TYPE_FUNCTION = "FUNCTION"
+RESOURCE_TYPE_EXPOSURE = "EXPOSURE"
+RESOURCE_TYPE_SAVED_QUERY = "SAVED_QUERY"
+RESOURCE_TYPE_OTHER = "OTHER"
+
+INVOCATION_STATUS_UNSPECIFIED = "TYPE_UNSPECIFIED"
+INVOCATION_STATUS_SUCCESS = "SUCCESS"
+INVOCATION_STATUS_HANDLED_ERROR = "HANDLED_ERROR"
+INVOCATION_STATUS_INTERRUPTED = "INTERRUPTED"
+INVOCATION_STATUS_INTERNAL_ERROR = "INTERNAL_ERROR"
+
+TERMINATION_REASON_UNSPECIFIED = "TYPE_UNSPECIFIED"
+TERMINATION_REASON_NORMAL = "NORMAL"
+TERMINATION_REASON_FAIL_FAST = "FAIL_FAST"
+TERMINATION_REASON_INTERRUPTED = "INTERRUPTED"
+TERMINATION_REASON_TASK_ERROR = "TASK_ERROR"
+TERMINATION_REASON_INTERNAL_ERROR = "INTERNAL_ERROR"
 
 
 @dataclass
@@ -100,11 +122,59 @@ class PostParsePayload:
 
 
 @dataclass
+class NodeStatusCounts:
+    """Node counts by dbt terminal status; total equals the sum of the buckets."""
+
+    total: int = 0
+    success: int = 0
+    error: int = 0
+    fail: int = 0
+    warn: int = 0
+    skipped: int = 0
+    partial_success: int = 0
+    pass_: int = 0  # proto field: pass
+    runtime_error: int = 0
+    no_op: int = 0
+    reused: int = 0
+
+
+@dataclass
+class ResourceOutcomeStats:
+    """Status counts for one resource type."""
+
+    resource_type: str = RESOURCE_TYPE_UNSPECIFIED
+    status_counts: NodeStatusCounts = field(default_factory=NodeStatusCounts)
+
+
+@dataclass
+class RunOutcome:
+    invocation_status: str = INVOCATION_STATUS_UNSPECIFIED
+    termination_reason: str = TERMINATION_REASON_UNSPECIFIED
+    invocation_duration_ms: int = 0
+    result_aggregates_available: bool = False
+    expected_result_coverage_complete: bool = False
+
+
+@dataclass
+class PostRunPayload:
+    """The ``DbtPostRun`` payload."""
+
+    run_outcome: RunOutcome = field(default_factory=RunOutcome)
+    selected_resources: int = 0
+    expected_result_resources: int = 0
+    result_counts: NodeStatusCounts = field(default_factory=NodeStatusCounts)
+    results_by_resource_type: list[ResourceOutcomeStats] = field(default_factory=list)
+    auxiliary_hook_results: NodeStatusCounts = field(default_factory=NodeStatusCounts)
+    unknown_resource_type_results: int = 0
+
+
+@dataclass
 class TelemetryLog:
-    """A POST_PARSE ``DbtDatabricksTelemetryLog`` event."""
+    """A ``DbtDatabricksTelemetryLog`` event; one phase payload is populated."""
 
     invocation_id: str
     adapter_version: str
     dbt_core_version: str
-    post_parse: PostParsePayload
     event_type: str = EVENT_TYPE_POST_PARSE
+    post_parse: Optional[PostParsePayload] = None
+    post_run: Optional[PostRunPayload] = None

--- a/dbt/adapters/databricks/telemetry/models.py
+++ b/dbt/adapters/databricks/telemetry/models.py
@@ -1,0 +1,14 @@
+"""Event model for the dbt-databricks initial connection telemetry log."""
+
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class ConnectionLog:
+    dbt_databricks_version: str
+    dbt_core_version: str
+    databricks_sql_connector_version: str
+    session_id: Optional[str] = None
+    http_path: Optional[str] = None
+    compute_type: Optional[str] = None  # "cluster" | "sql_warehouse"

--- a/dbt/adapters/databricks/telemetry/models.py
+++ b/dbt/adapters/databricks/telemetry/models.py
@@ -1,14 +1,110 @@
-"""Event model for the dbt-databricks initial connection telemetry log."""
+"""Sanitized POST_PARSE payload models, mirroring the DbtDatabricksTelemetryLog
+proto. Fixed scalars and closed-enum value names only; no raw credentials,
+paths, names, SQL, or open maps.
+"""
 
-from dataclasses import dataclass
-from typing import Optional
+from dataclasses import dataclass, field
+
+# Closed-enum value names; must match the proto enum members.
+EVENT_TYPE_POST_PARSE = "POST_PARSE"
+
+COMPUTE_TYPE_UNSPECIFIED = "TYPE_UNSPECIFIED"
+COMPUTE_TYPE_SQL_WAREHOUSE = "SQL_WAREHOUSE"
+COMPUTE_TYPE_ALL_PURPOSE_CLUSTER = "ALL_PURPOSE_CLUSTER"
+COMPUTE_TYPE_OTHER = "OTHER"
+
+AUTH_FAMILY_UNSPECIFIED = "TYPE_UNSPECIFIED"
+AUTH_FAMILY_PAT = "PAT"
+AUTH_FAMILY_OAUTH_U2M = "OAUTH_U2M"
+AUTH_FAMILY_OAUTH_M2M = "OAUTH_M2M"
+AUTH_FAMILY_AZURE_SERVICE_PRINCIPAL = "AZURE_SERVICE_PRINCIPAL"
+AUTH_FAMILY_LEGACY_CLIENT_SECRET_AMBIGUOUS = "LEGACY_CLIENT_SECRET_AMBIGUOUS"
+AUTH_FAMILY_OTHER = "OTHER"
+
+COMMAND_UNSPECIFIED = "TYPE_UNSPECIFIED"
+COMMAND_OTHER = "OTHER"
+
+WARN_ERROR_DISABLED = "WARN_ERROR_DISABLED"
+WARN_ERROR_ALL = "WARN_ERROR_ALL"
+WARN_ERROR_CUSTOM_POLICY = "WARN_ERROR_CUSTOM_POLICY"
 
 
 @dataclass
-class ConnectionLog:
-    dbt_databricks_version: str
+class ResourceCounts:
+    """Per-type enabled-resource counts; reused for whole-manifest totals."""
+
+    model_count: int = 0
+    data_test_count: int = 0
+    generic_data_test_count: int = 0
+    seed_count: int = 0
+    snapshot_count: int = 0
+    source_count: int = 0
+    function_count: int = 0
+    exposure_count: int = 0
+    saved_query_count: int = 0
+    other_count: int = 0
+
+
+@dataclass
+class ManifestStats:
+    """Enabled resources in the parsed manifest, split by origin."""
+
+    enabled_total: ResourceCounts = field(default_factory=ResourceCounts)
+    enabled_root_project: ResourceCounts = field(default_factory=ResourceCounts)
+    enabled_installed_packages: ResourceCounts = field(default_factory=ResourceCounts)
+
+
+@dataclass
+class InvocationConfig:
+    """Invocation CLI flags; no customer-defined values."""
+
+    thread_count: int = 0
+    dbt_command: str = COMMAND_UNSPECIFIED
+    full_refresh: bool = False
+    empty: bool = False
+    fail_fast: bool = False
+    warn_error_policy: str = WARN_ERROR_DISABLED
+
+
+@dataclass
+class ConnectionConfig:
+    """Connection classification derived from the profile; no http_path."""
+
+    default_compute_type: str = COMPUTE_TYPE_UNSPECIFIED
+    configured_auth_family: str = AUTH_FAMILY_UNSPECIFIED
+    named_compute_count: int = 0
+    uses_spog_routing: bool = False
+    use_kernel: bool = False
+
+
+@dataclass
+class ProjectConfig:
+    """dbt-databricks behavior flags in effect for the invocation."""
+
+    use_user_folder_for_python: bool = False
+    use_materialization_v2: bool = False
+    use_replace_on_for_insert_overwrite: bool = False
+    use_managed_iceberg: bool = False
+    use_concurrent_microbatch: bool = False
+    use_describe_as_json_for_relation_metadata: bool = False
+
+
+@dataclass
+class PostParsePayload:
+    """The ``DbtPostParse`` payload."""
+
+    invocation_config: InvocationConfig
+    manifest_stats: ManifestStats
+    connection_config: ConnectionConfig
+    project_config: ProjectConfig
+
+
+@dataclass
+class TelemetryLog:
+    """A POST_PARSE ``DbtDatabricksTelemetryLog`` event."""
+
+    invocation_id: str
+    adapter_version: str
     dbt_core_version: str
-    databricks_sql_connector_version: str
-    session_id: Optional[str] = None
-    http_path: Optional[str] = None
-    compute_type: Optional[str] = None  # "cluster" | "sql_warehouse"
+    post_parse: PostParsePayload
+    event_type: str = EVENT_TYPE_POST_PARSE

--- a/dbt/adapters/databricks/telemetry/models.py
+++ b/dbt/adapters/databricks/telemetry/models.py
@@ -3,7 +3,6 @@ from enum import Enum
 from typing import Optional
 
 
-# Closed enums; values are the proto enum member names.
 class EventType(Enum):
     TYPE_UNSPECIFIED = "TYPE_UNSPECIFIED"
     POST_PARSE = "POST_PARSE"
@@ -85,8 +84,6 @@ class TerminationReason(Enum):
 
 @dataclass
 class ResourceCounts:
-    """Per-type enabled-resource counts; reused for whole-manifest totals."""
-
     model_count: int = 0
     data_test_count: int = 0
     generic_data_test_count: int = 0
@@ -102,8 +99,6 @@ class ResourceCounts:
 
 @dataclass
 class ManifestStats:
-    """Enabled resources in the parsed manifest, split by origin."""
-
     enabled_total: ResourceCounts = field(default_factory=ResourceCounts)
     enabled_root_project: ResourceCounts = field(default_factory=ResourceCounts)
     enabled_installed_packages: ResourceCounts = field(default_factory=ResourceCounts)
@@ -111,8 +106,6 @@ class ManifestStats:
 
 @dataclass
 class InvocationConfig:
-    """Invocation CLI flags; no customer-defined values."""
-
     thread_count: int = 0
     dbt_command: DbtCommand = DbtCommand.TYPE_UNSPECIFIED
     full_refresh: bool = False
@@ -123,8 +116,6 @@ class InvocationConfig:
 
 @dataclass
 class ConnectionConfig:
-    """Connection classification derived from the profile; no http_path."""
-
     default_compute_type: ComputeType = ComputeType.TYPE_UNSPECIFIED
     configured_auth_family: AuthFamily = AuthFamily.TYPE_UNSPECIFIED
     named_compute_count: int = 0
@@ -134,8 +125,6 @@ class ConnectionConfig:
 
 @dataclass
 class ProjectConfig:
-    """dbt-databricks behavior flags in effect for the invocation."""
-
     use_user_folder_for_python: bool = False
     use_materialization_v2: bool = False
     use_replace_on_for_insert_overwrite: bool = False
@@ -146,8 +135,6 @@ class ProjectConfig:
 
 @dataclass
 class PostParsePayload:
-    """The ``DbtPostParse`` payload."""
-
     invocation_config: InvocationConfig
     manifest_stats: ManifestStats
     connection_config: ConnectionConfig
@@ -156,8 +143,6 @@ class PostParsePayload:
 
 @dataclass
 class NodeStatusCounts:
-    """Node counts by dbt terminal status; total equals the sum of the buckets."""
-
     total: int = 0
     success: int = 0
     error: int = 0
@@ -173,8 +158,6 @@ class NodeStatusCounts:
 
 @dataclass
 class ResourceOutcomeStats:
-    """Status counts for one resource type."""
-
     resource_type: ResourceType = ResourceType.TYPE_UNSPECIFIED
     status_counts: NodeStatusCounts = field(default_factory=NodeStatusCounts)
 
@@ -190,8 +173,6 @@ class RunOutcome:
 
 @dataclass
 class PostRunPayload:
-    """The ``DbtPostRun`` payload."""
-
     run_outcome: RunOutcome = field(default_factory=RunOutcome)
     selected_resources: Optional[int] = None
     expected_result_resources: int = 0
@@ -203,8 +184,6 @@ class PostRunPayload:
 
 @dataclass
 class TelemetryLog:
-    """A ``DbtDatabricksTelemetryLog`` event; one phase payload is populated."""
-
     invocation_id: str
     adapter_version: str
     dbt_core_version: str

--- a/tests/unit/telemetry/test_builder.py
+++ b/tests/unit/telemetry/test_builder.py
@@ -1,0 +1,203 @@
+from types import SimpleNamespace
+
+from dbt.adapters.databricks.telemetry import builder, models
+
+
+def _creds(**kw):
+    base = dict(
+        token=None,
+        client_id=None,
+        client_secret=None,
+        azure_client_id=None,
+        azure_client_secret=None,
+        auth_type=None,
+        http_path="/sql/1.0/warehouses/x",
+        compute=None,
+        connection_parameters=None,
+    )
+    base.update(kw)
+    return SimpleNamespace(**base)
+
+
+def _node(resource_type, package_name="root", test_metadata=None):
+    return SimpleNamespace(
+        resource_type=resource_type, package_name=package_name, test_metadata=test_metadata
+    )
+
+
+class TestClassifyComputeType:
+    def test_sql_warehouse(self):
+        assert builder.classify_compute_type("/sql/1.0/warehouses/a") == (
+            models.COMPUTE_TYPE_SQL_WAREHOUSE
+        )
+
+    def test_endpoints_form_is_warehouse(self):
+        assert builder.classify_compute_type("/sql/1.0/endpoints/a") == (
+            models.COMPUTE_TYPE_SQL_WAREHOUSE
+        )
+
+    def test_all_purpose_cluster(self):
+        assert builder.classify_compute_type("/sql/protocolv1/o/1/2") == (
+            models.COMPUTE_TYPE_ALL_PURPOSE_CLUSTER
+        )
+
+    def test_query_string_ignored(self):
+        assert builder.classify_compute_type("/sql/1.0/warehouses/a?o=9") == (
+            models.COMPUTE_TYPE_SQL_WAREHOUSE
+        )
+
+    def test_unknown_form_is_other(self):
+        assert builder.classify_compute_type("/unknown") == models.COMPUTE_TYPE_OTHER
+
+    def test_missing_is_unspecified(self):
+        assert builder.classify_compute_type(None) == models.COMPUTE_TYPE_UNSPECIFIED
+
+
+class TestClassifyAuthFamily:
+    def test_token_is_pat(self):
+        assert builder.classify_auth_family(_creds(token="dapi")) == models.AUTH_FAMILY_PAT
+
+    def test_azure_service_principal(self):
+        assert (
+            builder.classify_auth_family(_creds(azure_client_id="a", azure_client_secret="b"))
+            == models.AUTH_FAMILY_AZURE_SERVICE_PRINCIPAL
+        )
+
+    def test_no_secret_is_u2m(self):
+        assert builder.classify_auth_family(_creds(auth_type="oauth")) == (
+            models.AUTH_FAMILY_OAUTH_U2M
+        )
+
+    def test_client_secret_is_ambiguous(self):
+        assert builder.classify_auth_family(_creds(client_id="c", client_secret="s")) == (
+            models.AUTH_FAMILY_LEGACY_CLIENT_SECRET_AMBIGUOUS
+        )
+
+
+class TestClassifyCommand:
+    def test_known(self):
+        assert builder.classify_command("run") == "RUN"
+        assert builder.classify_command("build") == "BUILD"
+
+    def test_normalized_forms(self):
+        assert builder.classify_command("run-operation") == "RUN_OPERATION"
+        assert builder.classify_command("source freshness") == "SOURCE"
+        assert builder.classify_command("docs generate") == "DOCS"
+
+    def test_unknown_is_other(self):
+        assert builder.classify_command("parse") == models.COMMAND_OTHER
+
+    def test_missing_is_unspecified(self):
+        assert builder.classify_command(None) == models.COMMAND_UNSPECIFIED
+
+
+class TestClassifyWarnErrorPolicy:
+    def test_disabled(self):
+        assert builder.classify_warn_error_policy(None, None) == models.WARN_ERROR_DISABLED
+
+    def test_all(self):
+        assert builder.classify_warn_error_policy(True, None) == models.WARN_ERROR_ALL
+
+    def test_custom_policy(self):
+        assert builder.classify_warn_error_policy(False, {"include": ["X"]}) == (
+            models.WARN_ERROR_CUSTOM_POLICY
+        )
+
+
+class TestBuildConnectionConfig:
+    def test_derives_all_fields(self):
+        cc = builder.build_connection_config(
+            _creds(
+                client_id="c",
+                client_secret="s",
+                http_path="/sql/protocolv1/o/1/2?o=42",
+                compute={"a": {}, "b": {}},
+                connection_parameters={"use_kernel": True},
+            )
+        )
+        assert cc.default_compute_type == models.COMPUTE_TYPE_ALL_PURPOSE_CLUSTER
+        assert cc.configured_auth_family == models.AUTH_FAMILY_LEGACY_CLIENT_SECRET_AMBIGUOUS
+        assert cc.named_compute_count == 2
+        assert cc.uses_spog_routing is True
+        assert cc.use_kernel is True
+
+    def test_defaults_when_bare(self):
+        cc = builder.build_connection_config(_creds(token="dapi"))
+        assert cc.named_compute_count == 0
+        assert cc.uses_spog_routing is False
+        assert cc.use_kernel is False
+
+
+class TestBuildProjectConfig:
+    def test_reads_behavior_flags(self):
+        on = {"use_materialization_v2", "use_managed_iceberg"}
+        pc = builder.build_project_config(lambda name: name in on)
+        assert pc.use_materialization_v2 is True
+        assert pc.use_managed_iceberg is True
+        assert pc.use_user_folder_for_python is False
+
+
+class TestAggregateManifest:
+    def _manifest(self):
+        return SimpleNamespace(
+            metadata=SimpleNamespace(project_name="root", invocation_id="inv-1"),
+            nodes={
+                "m1": _node("model", "root"),
+                "m2": _node("model", "dep_pkg"),
+                "t_generic": _node("test", "root", test_metadata={"name": "not_null"}),
+                "t_singular": _node("test", "root"),
+                "sd": _node("seed", "root"),
+                "sn": _node("snapshot", "root"),
+                "op": _node("operation", "root"),
+                "ut": _node("unit_test", "root"),
+            },
+            sources={"s1": _node("source", "root")},
+            exposures={"e1": _node("exposure", "root")},
+            metrics={"me1": _node("metric", "root")},
+            saved_queries={"sq1": _node("saved_query", "root")},
+            functions={},
+        )
+
+    def test_total_counts(self):
+        ms = builder.aggregate_manifest(self._manifest())
+        assert ms.enabled_total.model_count == 2
+        assert ms.enabled_total.data_test_count == 2
+        assert ms.enabled_total.generic_data_test_count == 1
+        assert ms.enabled_total.seed_count == 1
+        assert ms.enabled_total.snapshot_count == 1
+        assert ms.enabled_total.source_count == 1
+        assert ms.enabled_total.exposure_count == 1
+        assert ms.enabled_total.saved_query_count == 1
+        # operation + metric counted; unit_test is skipped.
+        assert ms.enabled_total.other_count == 2
+
+    def test_root_vs_installed_split(self):
+        ms = builder.aggregate_manifest(self._manifest())
+        assert ms.enabled_root_project.model_count == 1
+        assert ms.enabled_installed_packages.model_count == 1
+
+    def test_empty_manifest(self):
+        empty = SimpleNamespace(metadata=SimpleNamespace(project_name="root"))
+        ms = builder.aggregate_manifest(empty)
+        assert ms.enabled_total.model_count == 0
+
+
+class TestBuildPostParseLog:
+    def test_assembles_event(self):
+        manifest = SimpleNamespace(
+            metadata=SimpleNamespace(project_name="root", invocation_id="inv-9"),
+            nodes={"m1": _node("model", "root")},
+        )
+        log = builder.build_post_parse_log(
+            manifest=manifest,
+            config=SimpleNamespace(threads=8),
+            creds=_creds(token="dapi", http_path="/sql/1.0/warehouses/w"),
+            behavior_flag=lambda name: False,
+        )
+        # Live get_invocation_id() when available, else manifest metadata.
+        assert isinstance(log.invocation_id, str) and log.invocation_id
+        assert log.event_type == models.EVENT_TYPE_POST_PARSE
+        assert log.post_parse.invocation_config.thread_count == 8
+        assert log.post_parse.connection_config.default_compute_type == (
+            models.COMPUTE_TYPE_SQL_WAREHOUSE
+        )

--- a/tests/unit/telemetry/test_builder.py
+++ b/tests/unit/telemetry/test_builder.py
@@ -143,12 +143,6 @@ class TestBuildConnectionConfig:
         assert cc.spog_routing_configured is True
         assert cc.use_kernel is True
 
-    def test_defaults_when_bare(self):
-        cc = builder.build_connection_config(_creds(token="dapi"))
-        assert cc.named_compute_count == 0
-        assert cc.spog_routing_configured is False
-        assert cc.use_kernel is False
-
     def test_spog_parameter_is_parsed_not_substring_matched(self):
         cc = builder.build_connection_config(
             _creds(token="dapi", http_path="/sql/1.0/warehouses/w?foo=x&o=42")
@@ -159,15 +153,6 @@ class TestBuildConnectionConfig:
             _creds(token="dapi", http_path="/sql/1.0/warehouses/w?foo=?o=42")
         )
         assert cc.spog_routing_configured is False
-
-
-class TestBuildProjectConfig:
-    def test_reads_behavior_flags(self):
-        on = {"use_materialization_v2", "use_managed_iceberg"}
-        pc = builder.build_project_config(lambda name: name in on)
-        assert pc.use_materialization_v2 is True
-        assert pc.use_managed_iceberg is True
-        assert pc.use_user_folder_for_python is False
 
 
 class TestAggregateManifest:
@@ -202,7 +187,6 @@ class TestAggregateManifest:
         assert ms.enabled_total.source_count == 1
         assert ms.enabled_total.exposure_count == 1
         assert ms.enabled_total.saved_query_count == 1
-        # operation + metric + semantic model; unit tests have their own bucket.
         assert ms.enabled_total.other_count == 3
         assert ms.enabled_total.unit_test_count == 1
 
@@ -210,32 +194,6 @@ class TestAggregateManifest:
         ms = builder.aggregate_manifest(self._manifest())
         assert ms.enabled_root_project.model_count == 1
         assert ms.enabled_installed_packages.model_count == 1
-
-    def test_empty_manifest(self):
-        empty = SimpleNamespace(metadata=SimpleNamespace(project_name="root"))
-        ms = builder.aggregate_manifest(empty)
-        assert ms.enabled_total.model_count == 0
-
-
-class TestBuildPostParseLog:
-    def test_assembles_event(self):
-        manifest = SimpleNamespace(
-            metadata=SimpleNamespace(project_name="root", invocation_id="inv-9"),
-            nodes={"m1": _node("model", "root")},
-        )
-        log = builder.build_post_parse_log(
-            manifest=manifest,
-            config=SimpleNamespace(threads=8),
-            creds=_creds(token="dapi", http_path="/sql/1.0/warehouses/w"),
-            behavior_flag=lambda name: False,
-        )
-        # Live get_invocation_id() when available, else manifest metadata.
-        assert isinstance(log.invocation_id, str) and log.invocation_id
-        assert log.event_type == models.EventType.POST_PARSE
-        assert log.post_parse.invocation_config.thread_count == 8
-        assert log.post_parse.connection_config.default_compute_type == (
-            models.ComputeType.SQL_WAREHOUSE
-        )
 
 
 class TestBuildPostRunLog:
@@ -278,13 +236,6 @@ class TestBuildPostRunLog:
         assert outcome.invocation_status == models.InvocationStatus.INTERRUPTED
         assert outcome.termination_reason == models.TerminationReason.INTERRUPTED
 
-    def test_system_exit(self):
-        outcome = builder.build_post_run_log(
-            "inv", 1, SystemExit, [], 0, False, False
-        ).post_run.run_outcome
-        assert outcome.invocation_status == models.InvocationStatus.INTERRUPTED
-        assert outcome.termination_reason == models.TerminationReason.INTERRUPTED
-
     def test_authoritative_task_failure_includes_auxiliary_failures(self):
         outcome = builder.build_post_run_log(
             "inv",
@@ -314,21 +265,6 @@ class TestBuildPostRunLog:
         assert post_run.results_by_resource_type is None
         assert post_run.auxiliary_hook_results is None
         assert post_run.unknown_resource_type_results is None
-
-    def test_counts_and_expected_populated(self):
-        results = [("model.p.m1", "success"), ("test.p.t", "pass"), ("seed.p.s", "success")]
-        pr = builder.build_post_run_log("inv", 1, None, results, 3, True, True).post_run
-        assert pr.result_counts.total == 3
-        assert pr.result_counts.success == 2
-        assert pr.result_counts.pass_ == 1
-        assert pr.expected_result_resources == 3
-        assert pr.run_outcome.expected_result_coverage_complete is True
-
-    def test_selected_resources_populated(self):
-        pr = builder.build_post_run_log(
-            "inv", 1, None, [], 2, True, True, selected_resources=3
-        ).post_run
-        assert pr.selected_resources == 3
 
 
 class TestAggregateNodeResults:

--- a/tests/unit/telemetry/test_builder.py
+++ b/tests/unit/telemetry/test_builder.py
@@ -28,79 +28,83 @@ def _node(resource_type, package_name="root", test_metadata=None):
 class TestClassifyComputeType:
     def test_sql_warehouse(self):
         assert builder.classify_compute_type("/sql/1.0/warehouses/a") == (
-            models.COMPUTE_TYPE_SQL_WAREHOUSE
+            models.ComputeType.SQL_WAREHOUSE
         )
 
     def test_endpoints_form_is_warehouse(self):
         assert builder.classify_compute_type("/sql/1.0/endpoints/a") == (
-            models.COMPUTE_TYPE_SQL_WAREHOUSE
+            models.ComputeType.SQL_WAREHOUSE
         )
 
     def test_all_purpose_cluster(self):
         assert builder.classify_compute_type("/sql/protocolv1/o/1/2") == (
-            models.COMPUTE_TYPE_ALL_PURPOSE_CLUSTER
+            models.ComputeType.ALL_PURPOSE_CLUSTER
         )
 
     def test_query_string_ignored(self):
         assert builder.classify_compute_type("/sql/1.0/warehouses/a?o=9") == (
-            models.COMPUTE_TYPE_SQL_WAREHOUSE
+            models.ComputeType.SQL_WAREHOUSE
         )
 
     def test_unknown_form_is_other(self):
-        assert builder.classify_compute_type("/unknown") == models.COMPUTE_TYPE_OTHER
+        assert builder.classify_compute_type("/unknown") == models.ComputeType.OTHER
 
     def test_missing_is_unspecified(self):
-        assert builder.classify_compute_type(None) == models.COMPUTE_TYPE_UNSPECIFIED
+        assert builder.classify_compute_type(None) == models.ComputeType.TYPE_UNSPECIFIED
 
 
 class TestClassifyAuthFamily:
     def test_token_is_pat(self):
-        assert builder.classify_auth_family(_creds(token="dapi")) == models.AUTH_FAMILY_PAT
+        assert builder.classify_auth_family(_creds(token="dapi")) == models.AuthFamily.PAT
 
     def test_azure_service_principal(self):
         assert (
             builder.classify_auth_family(_creds(azure_client_id="a", azure_client_secret="b"))
-            == models.AUTH_FAMILY_AZURE_SERVICE_PRINCIPAL
+            == models.AuthFamily.AZURE_SERVICE_PRINCIPAL
         )
 
     def test_no_secret_is_u2m(self):
         assert builder.classify_auth_family(_creds(auth_type="oauth")) == (
-            models.AUTH_FAMILY_OAUTH_U2M
+            models.AuthFamily.OAUTH_U2M
         )
 
     def test_client_secret_is_ambiguous(self):
         assert builder.classify_auth_family(_creds(client_id="c", client_secret="s")) == (
-            models.AUTH_FAMILY_LEGACY_CLIENT_SECRET_AMBIGUOUS
+            models.AuthFamily.LEGACY_CLIENT_SECRET_AMBIGUOUS
         )
 
 
 class TestClassifyCommand:
     def test_known(self):
-        assert builder.classify_command("run") == "RUN"
-        assert builder.classify_command("build") == "BUILD"
+        assert builder.classify_command("run") == models.DbtCommand.RUN
+        assert builder.classify_command("build") == models.DbtCommand.BUILD
 
     def test_normalized_forms(self):
-        assert builder.classify_command("run-operation") == "RUN_OPERATION"
-        assert builder.classify_command("source freshness") == "SOURCE"
-        assert builder.classify_command("docs generate") == "DOCS"
+        assert builder.classify_command("run-operation") == models.DbtCommand.RUN_OPERATION
+        assert builder.classify_command("source freshness") == models.DbtCommand.SOURCE
+        assert builder.classify_command("docs generate") == models.DbtCommand.DOCS
 
     def test_unknown_is_other(self):
-        assert builder.classify_command("parse") == models.COMMAND_OTHER
+        assert builder.classify_command("parse") == models.DbtCommand.OTHER
 
     def test_missing_is_unspecified(self):
-        assert builder.classify_command(None) == models.COMMAND_UNSPECIFIED
+        assert builder.classify_command(None) == models.DbtCommand.TYPE_UNSPECIFIED
 
 
 class TestClassifyWarnErrorPolicy:
     def test_disabled(self):
-        assert builder.classify_warn_error_policy(None, None) == models.WARN_ERROR_DISABLED
+        assert builder.classify_warn_error_policy(None, None) == (
+            models.WarnErrorPolicy.WARN_ERROR_DISABLED
+        )
 
     def test_all(self):
-        assert builder.classify_warn_error_policy(True, None) == models.WARN_ERROR_ALL
+        assert builder.classify_warn_error_policy(True, None) == (
+            models.WarnErrorPolicy.WARN_ERROR_ALL
+        )
 
     def test_custom_policy(self):
         assert builder.classify_warn_error_policy(False, {"include": ["X"]}) == (
-            models.WARN_ERROR_CUSTOM_POLICY
+            models.WarnErrorPolicy.WARN_ERROR_CUSTOM_POLICY
         )
 
 
@@ -115,8 +119,8 @@ class TestBuildConnectionConfig:
                 connection_parameters={"use_kernel": True},
             )
         )
-        assert cc.default_compute_type == models.COMPUTE_TYPE_ALL_PURPOSE_CLUSTER
-        assert cc.configured_auth_family == models.AUTH_FAMILY_LEGACY_CLIENT_SECRET_AMBIGUOUS
+        assert cc.default_compute_type == models.ComputeType.ALL_PURPOSE_CLUSTER
+        assert cc.configured_auth_family == models.AuthFamily.LEGACY_CLIENT_SECRET_AMBIGUOUS
         assert cc.named_compute_count == 2
         assert cc.uses_spog_routing is True
         assert cc.use_kernel is True
@@ -196,8 +200,8 @@ class TestBuildPostParseLog:
         )
         # Live get_invocation_id() when available, else manifest metadata.
         assert isinstance(log.invocation_id, str) and log.invocation_id
-        assert log.event_type == models.EVENT_TYPE_POST_PARSE
+        assert log.event_type == models.EventType.POST_PARSE
         assert log.post_parse.invocation_config.thread_count == 8
         assert log.post_parse.connection_config.default_compute_type == (
-            models.COMPUTE_TYPE_SQL_WAREHOUSE
+            models.ComputeType.SQL_WAREHOUSE
         )

--- a/tests/unit/telemetry/test_builder.py
+++ b/tests/unit/telemetry/test_builder.py
@@ -102,6 +102,24 @@ class TestClassifyWarnErrorPolicy:
             models.WarnErrorPolicy.WARN_ERROR_ALL
         )
 
+    def test_error_all_without_overrides_is_all(self):
+        options = SimpleNamespace(error="all", warn=[], silence=[])
+        assert builder.classify_warn_error_policy(False, options) == (
+            models.WarnErrorPolicy.WARN_ERROR_ALL
+        )
+
+    def test_error_all_with_named_override_is_custom(self):
+        options = SimpleNamespace(error="all", warn=["SomeWarning"], silence=[])
+        assert builder.classify_warn_error_policy(False, options) == (
+            models.WarnErrorPolicy.WARN_ERROR_CUSTOM_POLICY
+        )
+
+    def test_legacy_warn_error_takes_precedence(self):
+        options = SimpleNamespace(error=[], warn=[], silence=["SomeWarning"])
+        assert builder.classify_warn_error_policy(True, options) == (
+            models.WarnErrorPolicy.WARN_ERROR_ALL
+        )
+
     def test_custom_policy(self):
         assert builder.classify_warn_error_policy(False, {"include": ["X"]}) == (
             models.WarnErrorPolicy.WARN_ERROR_CUSTOM_POLICY
@@ -131,6 +149,17 @@ class TestBuildConnectionConfig:
         assert cc.spog_routing_configured is False
         assert cc.use_kernel is False
 
+    def test_spog_parameter_is_parsed_not_substring_matched(self):
+        cc = builder.build_connection_config(
+            _creds(token="dapi", http_path="/sql/1.0/warehouses/w?foo=x&o=42")
+        )
+        assert cc.spog_routing_configured is True
+
+        cc = builder.build_connection_config(
+            _creds(token="dapi", http_path="/sql/1.0/warehouses/w?foo=?o=42")
+        )
+        assert cc.spog_routing_configured is False
+
 
 class TestBuildProjectConfig:
     def test_reads_behavior_flags(self):
@@ -153,13 +182,14 @@ class TestAggregateManifest:
                 "sd": _node("seed", "root"),
                 "sn": _node("snapshot", "root"),
                 "op": _node("operation", "root"),
-                "ut": _node("unit_test", "root"),
             },
             sources={"s1": _node("source", "root")},
             exposures={"e1": _node("exposure", "root")},
             metrics={"me1": _node("metric", "root")},
             saved_queries={"sq1": _node("saved_query", "root")},
             functions={},
+            semantic_models={"sem1": _node("semantic_model", "root")},
+            unit_tests={"ut2": _node("unit_test", "root")},
         )
 
     def test_total_counts(self):
@@ -172,8 +202,8 @@ class TestAggregateManifest:
         assert ms.enabled_total.source_count == 1
         assert ms.enabled_total.exposure_count == 1
         assert ms.enabled_total.saved_query_count == 1
-        # operation + metric only; unit tests have their own bucket.
-        assert ms.enabled_total.other_count == 2
+        # operation + metric + semantic model; unit tests have their own bucket.
+        assert ms.enabled_total.other_count == 3
         assert ms.enabled_total.unit_test_count == 1
 
     def test_root_vs_installed_split(self):
@@ -210,7 +240,7 @@ class TestBuildPostParseLog:
 
 class TestBuildPostRunLog:
     def test_success_when_no_exception(self):
-        log = builder.build_post_run_log("inv", 250, None, [], True)
+        log = builder.build_post_run_log("inv", 250, None, [], 0, True, True)
         assert log.event_type == models.EventType.POST_RUN
         outcome = log.post_run.run_outcome
         assert outcome.invocation_status == models.InvocationStatus.SUCCESS
@@ -220,39 +250,91 @@ class TestBuildPostRunLog:
 
     def test_handled_error_when_failures(self):
         outcome = builder.build_post_run_log(
-            "inv", 1, None, [("model", "error")], True
+            "inv", 1, None, [("model.p.m1", "error")], 1, True, True
         ).post_run.run_outcome
         assert outcome.invocation_status == models.InvocationStatus.HANDLED_ERROR
         assert outcome.termination_reason == models.TerminationReason.NORMAL
 
+    def test_fail_fast_termination_when_observed(self):
+        outcome = builder.build_post_run_log(
+            "inv",
+            1,
+            None,
+            [("model.p.m1", "error"), ("model.p.m2", "skipped")],
+            2,
+            True,
+            True,
+            selected_resources=2,
+            fail_fast_triggered=True,
+            task_success=False,
+        ).post_run.run_outcome
+        assert outcome.invocation_status == models.InvocationStatus.HANDLED_ERROR
+        assert outcome.termination_reason == models.TerminationReason.FAIL_FAST
+
     def test_keyboard_interrupt(self):
         outcome = builder.build_post_run_log(
-            "inv", 1, KeyboardInterrupt, [], True
+            "inv", 1, KeyboardInterrupt, [], 0, False, True
         ).post_run.run_outcome
         assert outcome.invocation_status == models.InvocationStatus.INTERRUPTED
         assert outcome.termination_reason == models.TerminationReason.INTERRUPTED
 
+    def test_system_exit(self):
+        outcome = builder.build_post_run_log(
+            "inv", 1, SystemExit, [], 0, False, False
+        ).post_run.run_outcome
+        assert outcome.invocation_status == models.InvocationStatus.INTERRUPTED
+        assert outcome.termination_reason == models.TerminationReason.INTERRUPTED
+
+    def test_authoritative_task_failure_includes_auxiliary_failures(self):
+        outcome = builder.build_post_run_log(
+            "inv",
+            1,
+            None,
+            [("operation.p.h", "error"), ("model.p.m", "skipped")],
+            1,
+            True,
+            True,
+            task_success=False,
+        ).post_run.run_outcome
+        assert outcome.invocation_status == models.InvocationStatus.HANDLED_ERROR
+
     def test_other_exception_is_internal_error(self):
-        outcome = builder.build_post_run_log("inv", 1, RuntimeError, [], True).post_run.run_outcome
+        outcome = builder.build_post_run_log(
+            "inv", 1, RuntimeError, [], 0, False, True
+        ).post_run.run_outcome
         assert outcome.invocation_status == models.InvocationStatus.INTERNAL_ERROR
         assert outcome.termination_reason == models.TerminationReason.INTERNAL_ERROR
 
     def test_aggregates_unavailable_when_not_captured(self):
-        outcome = builder.build_post_run_log("inv", 1, None, [], False).post_run.run_outcome
+        post_run = builder.build_post_run_log("inv", 1, None, [], 0, False, False).post_run
+        outcome = post_run.run_outcome
         assert outcome.result_aggregates_available is False
+        assert outcome.expected_result_coverage_complete is None
+        assert post_run.result_counts is None
+        assert post_run.results_by_resource_type is None
+        assert post_run.auxiliary_hook_results is None
+        assert post_run.unknown_resource_type_results is None
 
-    def test_counts_populated_from_results(self):
-        node_results = [("model", "success"), ("test", "pass"), ("seed", "success")]
-        pr = builder.build_post_run_log("inv", 1, None, node_results, True).post_run
+    def test_counts_and_expected_populated(self):
+        results = [("model.p.m1", "success"), ("test.p.t", "pass"), ("seed.p.s", "success")]
+        pr = builder.build_post_run_log("inv", 1, None, results, 3, True, True).post_run
         assert pr.result_counts.total == 3
         assert pr.result_counts.success == 2
         assert pr.result_counts.pass_ == 1
+        assert pr.expected_result_resources == 3
+        assert pr.run_outcome.expected_result_coverage_complete is True
+
+    def test_selected_resources_populated(self):
+        pr = builder.build_post_run_log(
+            "inv", 1, None, [], 2, True, True, selected_resources=3
+        ).post_run
+        assert pr.selected_resources == 3
 
 
 class TestAggregateNodeResults:
     def test_result_counts_and_total(self):
         rc, _, _, unknown = builder.aggregate_node_results(
-            [("model", "success"), ("model", "error"), ("test", "pass")]
+            [("model.p.a", "success"), ("model.p.b", "error"), ("test.p.t", "pass")]
         )
         assert rc.total == 3
         assert rc.success == 1 and rc.error == 1 and rc.pass_ == 1
@@ -260,7 +342,7 @@ class TestAggregateNodeResults:
 
     def test_results_by_resource_type(self):
         _, by_type, _, _ = builder.aggregate_node_results(
-            [("model", "success"), ("model", "success"), ("test", "pass")]
+            [("model.p.a", "success"), ("model.p.b", "success"), ("test.p.t", "pass")]
         )
         by = {r.resource_type: r.status_counts for r in by_type}
         assert by[models.ResourceType.MODEL].success == 2
@@ -269,7 +351,7 @@ class TestAggregateNodeResults:
 
     def test_operations_are_auxiliary(self):
         rc, by_type, aux, _ = builder.aggregate_node_results(
-            [("operation", "success"), ("model", "success")]
+            [("operation.p.hook", "success"), ("model.p.a", "success")]
         )
         assert aux.total == 1 and aux.success == 1
         assert rc.total == 1
@@ -277,7 +359,7 @@ class TestAggregateNodeResults:
 
     def test_unknown_resource_type(self):
         rc, by_type, _, unknown = builder.aggregate_node_results(
-            [("analysis", "success"), ("model", "success")]
+            [("analysis.p.a", "success"), ("model.p.m", "success")]
         )
         assert unknown == 1
         assert rc.total == 2
@@ -285,7 +367,12 @@ class TestAggregateNodeResults:
 
     def test_invariant_known_plus_unknown_equals_total(self):
         rc, by_type, _, unknown = builder.aggregate_node_results(
-            [("model", "success"), ("test", "pass"), ("analysis", "fail"), ("operation", "success")]
+            [
+                ("model.p.m", "success"),
+                ("test.p.t", "pass"),
+                ("analysis.p.a", "fail"),
+                ("operation.p.h", "success"),
+            ]
         )
         known_total = sum(r.status_counts.total for r in by_type)
         assert known_total + unknown == rc.total

--- a/tests/unit/telemetry/test_builder.py
+++ b/tests/unit/telemetry/test_builder.py
@@ -122,13 +122,13 @@ class TestBuildConnectionConfig:
         assert cc.default_compute_type == models.ComputeType.ALL_PURPOSE_CLUSTER
         assert cc.configured_auth_family == models.AuthFamily.LEGACY_CLIENT_SECRET_AMBIGUOUS
         assert cc.named_compute_count == 2
-        assert cc.uses_spog_routing is True
+        assert cc.spog_routing_configured is True
         assert cc.use_kernel is True
 
     def test_defaults_when_bare(self):
         cc = builder.build_connection_config(_creds(token="dapi"))
         assert cc.named_compute_count == 0
-        assert cc.uses_spog_routing is False
+        assert cc.spog_routing_configured is False
         assert cc.use_kernel is False
 
 
@@ -172,8 +172,9 @@ class TestAggregateManifest:
         assert ms.enabled_total.source_count == 1
         assert ms.enabled_total.exposure_count == 1
         assert ms.enabled_total.saved_query_count == 1
-        # operation + metric counted; unit_test is skipped.
+        # operation + metric only; unit tests have their own bucket.
         assert ms.enabled_total.other_count == 2
+        assert ms.enabled_total.unit_test_count == 1
 
     def test_root_vs_installed_split(self):
         ms = builder.aggregate_manifest(self._manifest())
@@ -205,3 +206,86 @@ class TestBuildPostParseLog:
         assert log.post_parse.connection_config.default_compute_type == (
             models.ComputeType.SQL_WAREHOUSE
         )
+
+
+class TestBuildPostRunLog:
+    def test_success_when_no_exception(self):
+        log = builder.build_post_run_log("inv", 250, None, [], True)
+        assert log.event_type == models.EventType.POST_RUN
+        outcome = log.post_run.run_outcome
+        assert outcome.invocation_status == models.InvocationStatus.SUCCESS
+        assert outcome.termination_reason == models.TerminationReason.NORMAL
+        assert outcome.invocation_duration_ms == 250
+        assert outcome.result_aggregates_available is True
+
+    def test_handled_error_when_failures(self):
+        outcome = builder.build_post_run_log(
+            "inv", 1, None, [("model", "error")], True
+        ).post_run.run_outcome
+        assert outcome.invocation_status == models.InvocationStatus.HANDLED_ERROR
+        assert outcome.termination_reason == models.TerminationReason.NORMAL
+
+    def test_keyboard_interrupt(self):
+        outcome = builder.build_post_run_log(
+            "inv", 1, KeyboardInterrupt, [], True
+        ).post_run.run_outcome
+        assert outcome.invocation_status == models.InvocationStatus.INTERRUPTED
+        assert outcome.termination_reason == models.TerminationReason.INTERRUPTED
+
+    def test_other_exception_is_internal_error(self):
+        outcome = builder.build_post_run_log("inv", 1, RuntimeError, [], True).post_run.run_outcome
+        assert outcome.invocation_status == models.InvocationStatus.INTERNAL_ERROR
+        assert outcome.termination_reason == models.TerminationReason.INTERNAL_ERROR
+
+    def test_aggregates_unavailable_when_not_captured(self):
+        outcome = builder.build_post_run_log("inv", 1, None, [], False).post_run.run_outcome
+        assert outcome.result_aggregates_available is False
+
+    def test_counts_populated_from_results(self):
+        node_results = [("model", "success"), ("test", "pass"), ("seed", "success")]
+        pr = builder.build_post_run_log("inv", 1, None, node_results, True).post_run
+        assert pr.result_counts.total == 3
+        assert pr.result_counts.success == 2
+        assert pr.result_counts.pass_ == 1
+
+
+class TestAggregateNodeResults:
+    def test_result_counts_and_total(self):
+        rc, _, _, unknown = builder.aggregate_node_results(
+            [("model", "success"), ("model", "error"), ("test", "pass")]
+        )
+        assert rc.total == 3
+        assert rc.success == 1 and rc.error == 1 and rc.pass_ == 1
+        assert unknown == 0
+
+    def test_results_by_resource_type(self):
+        _, by_type, _, _ = builder.aggregate_node_results(
+            [("model", "success"), ("model", "success"), ("test", "pass")]
+        )
+        by = {r.resource_type: r.status_counts for r in by_type}
+        assert by[models.ResourceType.MODEL].success == 2
+        assert by[models.ResourceType.MODEL].total == 2
+        assert by[models.ResourceType.DATA_TEST].pass_ == 1
+
+    def test_operations_are_auxiliary(self):
+        rc, by_type, aux, _ = builder.aggregate_node_results(
+            [("operation", "success"), ("model", "success")]
+        )
+        assert aux.total == 1 and aux.success == 1
+        assert rc.total == 1
+        assert [r.resource_type for r in by_type] == [models.ResourceType.MODEL]
+
+    def test_unknown_resource_type(self):
+        rc, by_type, _, unknown = builder.aggregate_node_results(
+            [("analysis", "success"), ("model", "success")]
+        )
+        assert unknown == 1
+        assert rc.total == 2
+        assert [r.resource_type for r in by_type] == [models.ResourceType.MODEL]
+
+    def test_invariant_known_plus_unknown_equals_total(self):
+        rc, by_type, _, unknown = builder.aggregate_node_results(
+            [("model", "success"), ("test", "pass"), ("analysis", "fail"), ("operation", "success")]
+        )
+        known_total = sum(r.status_counts.total for r in by_type)
+        assert known_total + unknown == rc.total

--- a/tests/unit/telemetry/test_builder.py
+++ b/tests/unit/telemetry/test_builder.py
@@ -301,10 +301,10 @@ class TestAggregateNodeResults:
         assert rc.total == 2
         assert [r.resource_type for r in by_type] == [models.ResourceType.MODEL]
 
-    def test_unavailable_resource_type_is_not_unknown(self):
+    def test_unavailable_resource_type_is_unknown(self):
         rc, _, _, unknown = builder.aggregate_node_results([(None, "skipped")])
         assert rc.total == 1
-        assert unknown == 0
+        assert unknown == 1
 
     def test_invariant_known_plus_unknown_equals_total(self):
         rc, by_type, _, unknown = builder.aggregate_node_results(

--- a/tests/unit/telemetry/test_builder.py
+++ b/tests/unit/telemetry/test_builder.py
@@ -301,6 +301,11 @@ class TestAggregateNodeResults:
         assert rc.total == 2
         assert [r.resource_type for r in by_type] == [models.ResourceType.MODEL]
 
+    def test_unavailable_resource_type_is_not_unknown(self):
+        rc, _, _, unknown = builder.aggregate_node_results([(None, "skipped")])
+        assert rc.total == 1
+        assert unknown == 0
+
     def test_invariant_known_plus_unknown_equals_total(self):
         rc, by_type, _, unknown = builder.aggregate_node_results(
             [

--- a/tests/unit/telemetry/test_config.py
+++ b/tests/unit/telemetry/test_config.py
@@ -4,7 +4,13 @@ from dbt.adapters.databricks.telemetry import config
 
 
 def _creds(connection_parameters):
-    return SimpleNamespace(connection_parameters=connection_parameters)
+    return SimpleNamespace(
+        connection_parameters=connection_parameters,
+        auth_type=None,
+        token=None,
+        client_secret=None,
+        azure_client_secret=None,
+    )
 
 
 class TestOptIn:
@@ -20,3 +26,34 @@ class TestOptIn:
 
     def test_falsey_value_off(self):
         assert config.is_enabled(_creds({"enable_dbt_telemetry": False})) is False
+
+
+class TestCommandEligibility:
+    def test_warehouse_graph_commands_are_eligible(self, monkeypatch):
+        from dbt import flags
+
+        monkeypatch.setattr(flags, "get_flags", lambda: SimpleNamespace(WHICH="build"))
+        assert config.is_eligible_command() is True
+
+    def test_parse_only_and_unwired_task_shapes_are_ineligible(self, monkeypatch):
+        from dbt import flags
+
+        for command in ("compile", "source freshness", "run-operation"):
+            monkeypatch.setattr(
+                flags,
+                "get_flags",
+                lambda command=command: SimpleNamespace(WHICH=command),
+            )
+            assert config.is_eligible_command() is False
+
+
+class TestTransportEligibility:
+    def test_kernel_u2m_is_ineligible(self):
+        creds = _creds({"use_kernel": True})
+        creds.auth_type = "oauth"
+        assert config.has_reusable_transport(creds) is False
+
+    def test_kernel_pat_is_eligible(self):
+        creds = _creds({"use_kernel": True})
+        creds.token = "token"
+        assert config.has_reusable_transport(creds) is True

--- a/tests/unit/telemetry/test_config.py
+++ b/tests/unit/telemetry/test_config.py
@@ -18,14 +18,8 @@ class TestOptIn:
         assert config.is_enabled(_creds({})) is False
         assert config.is_enabled(_creds(None)) is False
 
-    def test_none_credentials_off(self):
-        assert config.is_enabled(None) is False
-
     def test_explicit_opt_in(self):
         assert config.is_enabled(_creds({"enable_dbt_telemetry": True})) is True
-
-    def test_falsey_value_off(self):
-        assert config.is_enabled(_creds({"enable_dbt_telemetry": False})) is False
 
 
 class TestCommandEligibility:

--- a/tests/unit/telemetry/test_config.py
+++ b/tests/unit/telemetry/test_config.py
@@ -1,0 +1,22 @@
+from types import SimpleNamespace
+
+from dbt.adapters.databricks.telemetry import config
+
+
+def _creds(connection_parameters):
+    return SimpleNamespace(connection_parameters=connection_parameters)
+
+
+class TestOptIn:
+    def test_defaults_off(self):
+        assert config.is_enabled(_creds({})) is False
+        assert config.is_enabled(_creds(None)) is False
+
+    def test_none_credentials_off(self):
+        assert config.is_enabled(None) is False
+
+    def test_explicit_opt_in(self):
+        assert config.is_enabled(_creds({"enable_dbt_telemetry": True})) is True
+
+    def test_falsey_value_off(self):
+        assert config.is_enabled(_creds({"enable_dbt_telemetry": False})) is False

--- a/tests/unit/telemetry/test_coordinator.py
+++ b/tests/unit/telemetry/test_coordinator.py
@@ -107,7 +107,6 @@ class TestSendOrdering:
         monkeypatch.setattr(coord_mod.client, "send", slow_send)
         c = coord_mod.Coordinator()
         c.set_post_parse("inv-1", _log())
-        # The connection-open path must return without waiting for the send.
         c.set_transport("inv-1", _transport())
         assert in_send.wait(timeout=2)
         release.set()
@@ -189,14 +188,6 @@ class TestPostRun:
             json.loads(call[1]["protoLogs"][0])["frontend_log_event_id"] for call in capture.calls
         }
         assert len(ids) == 2
-
-    def test_elapsed_ms_is_wall_clock(self, monkeypatch):
-        ticks = iter([0.0, 8.5])
-        monkeypatch.setattr(coord_mod.time, "monotonic", lambda: next(ticks))
-        c = coord_mod.Coordinator()
-        c.mark_start("inv-1")
-
-        assert c.elapsed_ms("inv-1") == 8500
 
 
 class TestResultCapture:

--- a/tests/unit/telemetry/test_coordinator.py
+++ b/tests/unit/telemetry/test_coordinator.py
@@ -150,7 +150,7 @@ class TestPostRun:
         assert self._entry(capture.calls[0])["event_type"] == "POST_PARSE"
         assert self._entry(capture.calls[1])["event_type"] == "POST_RUN"
 
-    def test_post_run_waits_for_in_flight_post_parse(self, monkeypatch):
+    def test_close_waits_for_post_run_behind_slow_post_parse(self, monkeypatch):
         started = threading.Event()
         release = threading.Event()
         phases = []
@@ -164,15 +164,18 @@ class TestPostRun:
             return True
 
         monkeypatch.setattr(coord_mod.client, "send", blocking_send)
+        monkeypatch.setattr(coord_mod.client, "_TIMEOUT_SECONDS", 0.25)
         c = coord_mod.Coordinator()
         c.set_post_parse("inv-1", _log())
         c.set_transport("inv-1", _transport())
         assert started.wait(timeout=2)
-
         c.set_post_run("inv-1", _run_log())
-        assert phases == ["POST_PARSE"]
-        release.set()
-        c.flush(timeout=2)
+
+        timer = threading.Timer(0.35, release.set)
+        timer.start()
+        c.flush()
+        c.close("inv-1")
+        timer.join()
 
         assert phases == ["POST_PARSE", "POST_RUN"]
 

--- a/tests/unit/telemetry/test_coordinator.py
+++ b/tests/unit/telemetry/test_coordinator.py
@@ -51,9 +51,8 @@ class TestTransportOpacity:
         assert "Bearer" not in repr(t)
 
     def test_not_a_dataclass_and_no_dict(self):
-        # Opaque handle must not offer easy serialization.
         t = _transport()
-        assert not hasattr(t, "__dict__")  # __slots__ only
+        assert not hasattr(t, "__dict__")
 
 
 class TestSendOrdering:
@@ -92,16 +91,6 @@ class TestSendOrdering:
         c.set_transport("inv-1", _transport(header_factory=None))
         assert capture.calls == []
 
-    def test_stable_event_id_in_payload(self, monkeypatch):
-        capture = _Capture()
-        monkeypatch.setattr(coord_mod.client, "send", capture)
-        c = coord_mod.Coordinator()
-        c.set_post_parse("inv-1", _log())
-        c.set_transport("inv-1", _transport())
-        _, body, _, _ = capture.calls[0]
-        fe = json.loads(body["protoLogs"][0])
-        assert fe["frontend_log_event_id"]  # a stable UUID was assigned
-
 
 class TestIsolationAndClose:
     def test_distinct_invocations_do_not_cross_pair(self, monkeypatch):
@@ -110,7 +99,6 @@ class TestIsolationAndClose:
         c = coord_mod.Coordinator()
         c.set_post_parse("inv-A", _log("inv-A"))
         c.set_transport("inv-B", _transport())
-        # A has no transport, B has no payload -> nothing sends.
         assert capture.calls == []
 
     def test_closed_invocation_rejects_late_callbacks(self, monkeypatch):
@@ -126,15 +114,6 @@ class TestIsolationAndClose:
 class TestPostRun:
     def _entry(self, call):
         return json.loads(call[1]["protoLogs"][0])["entry"]["dbt_databricks_telemetry_log"]
-
-    def test_post_run_sends_after_transport(self, monkeypatch):
-        capture = _Capture()
-        monkeypatch.setattr(coord_mod.client, "send", capture)
-        c = coord_mod.Coordinator()
-        c.set_post_run("inv-1", _run_log())
-        assert capture.calls == []
-        c.set_transport("inv-1", _transport())
-        assert len(capture.calls) == 1
 
     def test_both_phases_send_post_parse_first(self, monkeypatch):
         capture = _Capture()
@@ -187,17 +166,6 @@ class TestPostRun:
         }
         assert len(ids) == 2
 
-    def test_elapsed_ms(self):
-        c = coord_mod.Coordinator()
-        c.set_post_parse("inv-1", _log())
-        assert c.elapsed_ms("inv-1") >= 0
-        assert c.elapsed_ms("missing") == 0
-
-    def test_mark_start_enables_timer(self):
-        c = coord_mod.Coordinator()
-        c.mark_start("inv-1")
-        assert c.elapsed_ms("inv-1") >= 0
-
     def test_elapsed_ms_excludes_synchronous_telemetry_delivery(self, monkeypatch):
         ticks = iter([0.0, 2.0, 3.5, 10.0])
         monkeypatch.setattr(coord_mod.time, "monotonic", lambda: next(ticks))
@@ -221,7 +189,6 @@ class TestResultCapture:
         assert captured is False
         assert selected == 2
         assert expected == 2
-        # No EndRunResult -> this is the partial interrupt fallback.
         assert coverage_complete is False
         assert results == [("model.p.m1", "success"), ("test.p.t", "pass")]
 
@@ -241,7 +208,7 @@ class TestResultCapture:
         c = coord_mod.Coordinator()
         c.mark_start("inv-1")
         c.record_expected_count("inv-1", 2)
-        c.record_node_result("inv-1", "model.p.m1", "success")  # partial
+        c.record_node_result("inv-1", "model.p.m1", "success")
         c.record_end_run("inv-1", ["success", "skipped"])
         results, _, _, coverage_complete, _ = c.result_snapshot("inv-1")
         assert coverage_complete is True
@@ -267,8 +234,6 @@ class TestResultCapture:
         c.record_expected_count("inv-1", 2)
         c.record_ephemeral_ids("inv-1", {"model.p.ephemeral"})
         c.record_node_result("inv-1", "model.p.m1", "error")
-        # EndRunResult has no IDs: one expected skip plus one synthetic
-        # ephemeral skip remain after matching the observed error.
         c.record_end_run("inv-1", ["error", "skipped", "skipped"])
 
         results, selected, expected, coverage_complete, _ = c.result_snapshot("inv-1")
@@ -277,10 +242,6 @@ class TestResultCapture:
         assert selected == 3
         assert expected == 2
         assert coverage_complete is True
-
-    def test_snapshot_missing_invocation(self):
-        c = coord_mod.Coordinator()
-        assert c.result_snapshot("nope") == ([], 0, 0, False, False)
 
     def test_record_after_close_ignored(self):
         c = coord_mod.Coordinator()
@@ -303,11 +264,3 @@ class TestResultCapture:
         assert expected == 1
         assert coverage_complete is False
         assert captured is False
-
-    def test_authoritative_outcome_and_fail_fast_signal(self):
-        c = coord_mod.Coordinator()
-        c.mark_start("inv-1")
-        c.mark_fail_fast_triggered("inv-1")
-        c.record_end_run("inv-1", ["error"], success=False)
-
-        assert c.outcome_snapshot("inv-1") == (False, True)

--- a/tests/unit/telemetry/test_coordinator.py
+++ b/tests/unit/telemetry/test_coordinator.py
@@ -63,6 +63,7 @@ class TestSendOrdering:
         c.set_post_parse("inv-1", _log())
         assert capture.calls == []
         c.set_transport("inv-1", _transport())
+        c.flush()
         assert len(capture.calls) == 1
 
     def test_transport_then_parse_sends_once(self, monkeypatch):
@@ -72,6 +73,7 @@ class TestSendOrdering:
         c.set_transport("inv-1", _transport())
         assert capture.calls == []
         c.set_post_parse("inv-1", _log())
+        c.flush()
         assert len(capture.calls) == 1
 
     def test_repeated_parse_is_idempotent(self, monkeypatch):
@@ -81,6 +83,7 @@ class TestSendOrdering:
         c.set_transport("inv-1", _transport())
         c.set_post_parse("inv-1", _log())
         c.set_post_parse("inv-1", _log())
+        c.flush()
         assert len(capture.calls) == 1
 
     def test_transport_without_auth_headers_does_not_send(self, monkeypatch):
@@ -89,7 +92,26 @@ class TestSendOrdering:
         c = coord_mod.Coordinator()
         c.set_post_parse("inv-1", _log())
         c.set_transport("inv-1", _transport(header_factory=None))
+        c.flush()
         assert capture.calls == []
+
+    def test_transport_does_not_block_on_slow_send(self, monkeypatch):
+        in_send = threading.Event()
+        release = threading.Event()
+
+        def slow_send(host, body, header_factory=None, workspace_id=None):
+            in_send.set()
+            assert release.wait(timeout=2)
+            return True
+
+        monkeypatch.setattr(coord_mod.client, "send", slow_send)
+        c = coord_mod.Coordinator()
+        c.set_post_parse("inv-1", _log())
+        # The connection-open path must return without waiting for the send.
+        c.set_transport("inv-1", _transport())
+        assert in_send.wait(timeout=2)
+        release.set()
+        c.flush(timeout=2)
 
 
 class TestIsolationAndClose:
@@ -99,6 +121,7 @@ class TestIsolationAndClose:
         c = coord_mod.Coordinator()
         c.set_post_parse("inv-A", _log("inv-A"))
         c.set_transport("inv-B", _transport())
+        c.flush()
         assert capture.calls == []
 
     def test_closed_invocation_rejects_late_callbacks(self, monkeypatch):
@@ -108,6 +131,7 @@ class TestIsolationAndClose:
         c.close("inv-1")
         c.set_post_parse("inv-1", _log())
         c.set_transport("inv-1", _transport())
+        c.flush()
         assert capture.calls == []
 
 
@@ -122,6 +146,7 @@ class TestPostRun:
         c.set_post_parse("inv-1", _log())
         c.set_post_run("inv-1", _run_log())
         c.set_transport("inv-1", _transport())
+        c.flush()
         assert len(capture.calls) == 2
         assert self._entry(capture.calls[0])["event_type"] == "POST_PARSE"
         assert self._entry(capture.calls[1])["event_type"] == "POST_RUN"
@@ -142,16 +167,14 @@ class TestPostRun:
         monkeypatch.setattr(coord_mod.client, "send", blocking_send)
         c = coord_mod.Coordinator()
         c.set_post_parse("inv-1", _log())
-        sender = threading.Thread(target=lambda: c.set_transport("inv-1", _transport()))
-        sender.start()
+        c.set_transport("inv-1", _transport())
         assert started.wait(timeout=2)
 
         c.set_post_run("inv-1", _run_log())
         assert phases == ["POST_PARSE"]
         release.set()
-        sender.join(timeout=2)
+        c.flush(timeout=2)
 
-        assert not sender.is_alive()
         assert phases == ["POST_PARSE", "POST_RUN"]
 
     def test_phases_use_distinct_event_ids(self, monkeypatch):
@@ -161,19 +184,17 @@ class TestPostRun:
         c.set_transport("inv-1", _transport())
         c.set_post_parse("inv-1", _log())
         c.set_post_run("inv-1", _run_log())
+        c.flush()
         ids = {
             json.loads(call[1]["protoLogs"][0])["frontend_log_event_id"] for call in capture.calls
         }
         assert len(ids) == 2
 
-    def test_elapsed_ms_excludes_synchronous_telemetry_delivery(self, monkeypatch):
-        ticks = iter([0.0, 2.0, 3.5, 10.0])
+    def test_elapsed_ms_is_wall_clock(self, monkeypatch):
+        ticks = iter([0.0, 8.5])
         monkeypatch.setattr(coord_mod.time, "monotonic", lambda: next(ticks))
-        monkeypatch.setattr(coord_mod.client, "send", lambda *args, **kwargs: True)
         c = coord_mod.Coordinator()
         c.mark_start("inv-1")
-        c.set_post_parse("inv-1", _log())
-        c.set_transport("inv-1", _transport())
 
         assert c.elapsed_ms("inv-1") == 8500
 

--- a/tests/unit/telemetry/test_coordinator.py
+++ b/tests/unit/telemetry/test_coordinator.py
@@ -1,4 +1,5 @@
 import json
+import threading
 
 from dbt.adapters.databricks.telemetry import coordinator as coord_mod
 from dbt.adapters.databricks.telemetry import models
@@ -146,6 +147,34 @@ class TestPostRun:
         assert self._entry(capture.calls[0])["event_type"] == "POST_PARSE"
         assert self._entry(capture.calls[1])["event_type"] == "POST_RUN"
 
+    def test_post_run_waits_for_in_flight_post_parse(self, monkeypatch):
+        started = threading.Event()
+        release = threading.Event()
+        phases = []
+
+        def blocking_send(host, body, header_factory=None, workspace_id=None):
+            entry = json.loads(body["protoLogs"][0])["entry"]["dbt_databricks_telemetry_log"]
+            phases.append(entry["event_type"])
+            if entry["event_type"] == "POST_PARSE":
+                started.set()
+                assert release.wait(timeout=2)
+            return True
+
+        monkeypatch.setattr(coord_mod.client, "send", blocking_send)
+        c = coord_mod.Coordinator()
+        c.set_post_parse("inv-1", _log())
+        sender = threading.Thread(target=lambda: c.set_transport("inv-1", _transport()))
+        sender.start()
+        assert started.wait(timeout=2)
+
+        c.set_post_run("inv-1", _run_log())
+        assert phases == ["POST_PARSE"]
+        release.set()
+        sender.join(timeout=2)
+
+        assert not sender.is_alive()
+        assert phases == ["POST_PARSE", "POST_RUN"]
+
     def test_phases_use_distinct_event_ids(self, monkeypatch):
         capture = _Capture()
         monkeypatch.setattr(coord_mod.client, "send", capture)
@@ -169,26 +198,116 @@ class TestPostRun:
         c.mark_start("inv-1")
         assert c.elapsed_ms("inv-1") >= 0
 
-
-class TestResultCapture:
-    def test_record_and_snapshot(self):
+    def test_elapsed_ms_excludes_synchronous_telemetry_delivery(self, monkeypatch):
+        ticks = iter([0.0, 2.0, 3.5, 10.0])
+        monkeypatch.setattr(coord_mod.time, "monotonic", lambda: next(ticks))
+        monkeypatch.setattr(coord_mod.client, "send", lambda *args, **kwargs: True)
         c = coord_mod.Coordinator()
         c.mark_start("inv-1")
-        c.begin_result_capture("inv-1")
-        c.record_node_result("inv-1", "model", "success")
-        c.record_node_result("inv-1", "test", "pass")
-        node_results, captured = c.result_snapshot("inv-1")
-        assert captured is True
-        assert node_results == [("model", "success"), ("test", "pass")]
+        c.set_post_parse("inv-1", _log())
+        c.set_transport("inv-1", _transport())
+
+        assert c.elapsed_ms("inv-1") == 8500
+
+
+class TestResultCapture:
+    def test_node_results_fallback_snapshot(self):
+        c = coord_mod.Coordinator()
+        c.mark_start("inv-1")
+        c.record_expected_count("inv-1", 2)
+        c.record_node_result("inv-1", "model.p.m1", "success")
+        c.record_node_result("inv-1", "test.p.t", "pass")
+        results, selected, expected, coverage_complete, captured = c.result_snapshot("inv-1")
+        assert captured is False
+        assert selected == 2
+        assert expected == 2
+        # No EndRunResult -> this is the partial interrupt fallback.
+        assert coverage_complete is False
+        assert results == [("model.p.m1", "success"), ("test.p.t", "pass")]
+
+    def test_partial_snapshot_omits_unprovable_selected_ephemeral_count(self):
+        c = coord_mod.Coordinator()
+        c.mark_start("inv-1")
+        c.record_expected_count("inv-1", 1)
+        c.record_ephemeral_ids("inv-1", {"model.p.ephemeral1", "model.p.ephemeral2"})
+        c.record_node_result("inv-1", "model.p.ephemeral1", "success")
+
+        _, selected, _, _, captured = c.result_snapshot("inv-1")
+
+        assert selected is None
+        assert captured is False
+
+    def test_end_run_is_authoritative_and_complete(self):
+        c = coord_mod.Coordinator()
+        c.mark_start("inv-1")
+        c.record_expected_count("inv-1", 2)
+        c.record_node_result("inv-1", "model.p.m1", "success")  # partial
+        c.record_end_run("inv-1", ["success", "skipped"])
+        results, _, _, coverage_complete, _ = c.result_snapshot("inv-1")
+        assert coverage_complete is True
+        assert results == [("model.p.m1", "success"), (None, "skipped")]
+
+    def test_hooks_are_auxiliary_and_subtracted_from_end_statuses(self):
+        c = coord_mod.Coordinator()
+        c.mark_start("inv-1")
+        c.record_expected_count("inv-1", 1)
+        c.record_node_result("inv-1", "model.p.m1", "success")
+        c.record_hook_result("inv-1", "success")
+        c.record_end_run("inv-1", ["success", "success"])
+
+        results, selected, expected, coverage_complete, _ = c.result_snapshot("inv-1")
+
+        assert results == [("model.p.m1", "success"), ("operation", "success")]
+        assert selected == expected == 1
+        assert coverage_complete is True
+
+    def test_fail_fast_synthetic_ephemeral_counts_as_selected_not_result(self):
+        c = coord_mod.Coordinator()
+        c.mark_start("inv-1")
+        c.record_expected_count("inv-1", 2)
+        c.record_ephemeral_ids("inv-1", {"model.p.ephemeral"})
+        c.record_node_result("inv-1", "model.p.m1", "error")
+        # EndRunResult has no IDs: one expected skip plus one synthetic
+        # ephemeral skip remain after matching the observed error.
+        c.record_end_run("inv-1", ["error", "skipped", "skipped"])
+
+        results, selected, expected, coverage_complete, _ = c.result_snapshot("inv-1")
+
+        assert results == [("model.p.m1", "error"), (None, "skipped")]
+        assert selected == 3
+        assert expected == 2
+        assert coverage_complete is True
 
     def test_snapshot_missing_invocation(self):
         c = coord_mod.Coordinator()
-        assert c.result_snapshot("nope") == ([], False)
+        assert c.result_snapshot("nope") == ([], 0, 0, False, False)
 
     def test_record_after_close_ignored(self):
         c = coord_mod.Coordinator()
         c.mark_start("inv-1")
         c.close("inv-1")
-        c.record_node_result("inv-1", "model", "success")
-        node_results, _ = c.result_snapshot("inv-1")
-        assert node_results == []
+        c.record_node_result("inv-1", "model.p.m1", "success")
+        results, _, _, _, _ = c.result_snapshot("inv-1")
+        assert results == []
+
+    def test_ephemeral_is_selected_but_not_a_top_level_result(self):
+        c = coord_mod.Coordinator()
+        c.mark_start("inv-1")
+        c.record_expected_count("inv-1", 1)
+        c.record_ephemeral_ids("inv-1", {"model.p.ephemeral"})
+        c.record_node_result("inv-1", "model.p.ephemeral", "success")
+        c.record_node_result("inv-1", "model.p.table", "success")
+        results, selected, expected, coverage_complete, captured = c.result_snapshot("inv-1")
+        assert results == [("model.p.table", "success")]
+        assert selected == 2
+        assert expected == 1
+        assert coverage_complete is False
+        assert captured is False
+
+    def test_authoritative_outcome_and_fail_fast_signal(self):
+        c = coord_mod.Coordinator()
+        c.mark_start("inv-1")
+        c.mark_fail_fast_triggered("inv-1")
+        c.record_end_run("inv-1", ["error"], success=False)
+
+        assert c.outcome_snapshot("inv-1") == (False, True)

--- a/tests/unit/telemetry/test_coordinator.py
+++ b/tests/unit/telemetry/test_coordinator.py
@@ -1,0 +1,112 @@
+import json
+
+from dbt.adapters.databricks.telemetry import coordinator as coord_mod
+from dbt.adapters.databricks.telemetry import models
+
+
+def _log(invocation_id="inv-1"):
+    return models.TelemetryLog(
+        invocation_id=invocation_id,
+        adapter_version="1.2.3",
+        dbt_core_version="1.12.0",
+        post_parse=models.PostParsePayload(
+            invocation_config=models.InvocationConfig(),
+            manifest_stats=models.ManifestStats(),
+            connection_config=models.ConnectionConfig(),
+            project_config=models.ProjectConfig(),
+        ),
+    )
+
+
+def _transport(header_factory=lambda: {"Authorization": "Bearer x"}, workspace_id="42"):
+    return coord_mod.Transport(
+        host="https://h", header_factory=header_factory, workspace_id=workspace_id
+    )
+
+
+class _Capture:
+    def __init__(self):
+        self.calls = []
+
+    def __call__(self, host, body, header_factory=None, workspace_id=None):
+        self.calls.append((host, body, header_factory, workspace_id))
+        return True
+
+
+class TestTransportOpacity:
+    def test_repr_is_redacted(self):
+        t = _transport()
+        assert "redacted" in repr(t)
+        assert "Bearer" not in repr(t)
+
+    def test_not_a_dataclass_and_no_dict(self):
+        # Opaque handle must not offer easy serialization.
+        t = _transport()
+        assert not hasattr(t, "__dict__")  # __slots__ only
+
+
+class TestSendOrdering:
+    def test_parse_then_transport_sends_once(self, monkeypatch):
+        capture = _Capture()
+        monkeypatch.setattr(coord_mod.client, "send", capture)
+        c = coord_mod.Coordinator()
+        c.set_post_parse("inv-1", _log())
+        assert capture.calls == []
+        c.set_transport("inv-1", _transport())
+        assert len(capture.calls) == 1
+
+    def test_transport_then_parse_sends_once(self, monkeypatch):
+        capture = _Capture()
+        monkeypatch.setattr(coord_mod.client, "send", capture)
+        c = coord_mod.Coordinator()
+        c.set_transport("inv-1", _transport())
+        assert capture.calls == []
+        c.set_post_parse("inv-1", _log())
+        assert len(capture.calls) == 1
+
+    def test_repeated_parse_is_idempotent(self, monkeypatch):
+        capture = _Capture()
+        monkeypatch.setattr(coord_mod.client, "send", capture)
+        c = coord_mod.Coordinator()
+        c.set_transport("inv-1", _transport())
+        c.set_post_parse("inv-1", _log())
+        c.set_post_parse("inv-1", _log())
+        assert len(capture.calls) == 1
+
+    def test_transport_without_auth_headers_does_not_send(self, monkeypatch):
+        capture = _Capture()
+        monkeypatch.setattr(coord_mod.client, "send", capture)
+        c = coord_mod.Coordinator()
+        c.set_post_parse("inv-1", _log())
+        c.set_transport("inv-1", _transport(header_factory=None))
+        assert capture.calls == []
+
+    def test_stable_event_id_in_payload(self, monkeypatch):
+        capture = _Capture()
+        monkeypatch.setattr(coord_mod.client, "send", capture)
+        c = coord_mod.Coordinator()
+        c.set_post_parse("inv-1", _log())
+        c.set_transport("inv-1", _transport())
+        _, body, _, _ = capture.calls[0]
+        fe = json.loads(body["protoLogs"][0])
+        assert fe["frontend_log_event_id"]  # a stable UUID was assigned
+
+
+class TestIsolationAndClose:
+    def test_distinct_invocations_do_not_cross_pair(self, monkeypatch):
+        capture = _Capture()
+        monkeypatch.setattr(coord_mod.client, "send", capture)
+        c = coord_mod.Coordinator()
+        c.set_post_parse("inv-A", _log("inv-A"))
+        c.set_transport("inv-B", _transport())
+        # A has no transport, B has no payload -> nothing sends.
+        assert capture.calls == []
+
+    def test_closed_invocation_rejects_late_callbacks(self, monkeypatch):
+        capture = _Capture()
+        monkeypatch.setattr(coord_mod.client, "send", capture)
+        c = coord_mod.Coordinator()
+        c.close("inv-1")
+        c.set_post_parse("inv-1", _log())
+        c.set_transport("inv-1", _transport())
+        assert capture.calls == []

--- a/tests/unit/telemetry/test_coordinator.py
+++ b/tests/unit/telemetry/test_coordinator.py
@@ -18,6 +18,16 @@ def _log(invocation_id="inv-1"):
     )
 
 
+def _run_log(invocation_id="inv-1"):
+    return models.TelemetryLog(
+        invocation_id=invocation_id,
+        adapter_version="1.2.3",
+        dbt_core_version="1.12.0",
+        event_type=models.EventType.POST_RUN,
+        post_run=models.PostRunPayload(),
+    )
+
+
 def _transport(header_factory=lambda: {"Authorization": "Bearer x"}, workspace_id="42"):
     return coord_mod.Transport(
         host="https://h", header_factory=header_factory, workspace_id=workspace_id
@@ -110,3 +120,75 @@ class TestIsolationAndClose:
         c.set_post_parse("inv-1", _log())
         c.set_transport("inv-1", _transport())
         assert capture.calls == []
+
+
+class TestPostRun:
+    def _entry(self, call):
+        return json.loads(call[1]["protoLogs"][0])["entry"]["dbt_databricks_telemetry_log"]
+
+    def test_post_run_sends_after_transport(self, monkeypatch):
+        capture = _Capture()
+        monkeypatch.setattr(coord_mod.client, "send", capture)
+        c = coord_mod.Coordinator()
+        c.set_post_run("inv-1", _run_log())
+        assert capture.calls == []
+        c.set_transport("inv-1", _transport())
+        assert len(capture.calls) == 1
+
+    def test_both_phases_send_post_parse_first(self, monkeypatch):
+        capture = _Capture()
+        monkeypatch.setattr(coord_mod.client, "send", capture)
+        c = coord_mod.Coordinator()
+        c.set_post_parse("inv-1", _log())
+        c.set_post_run("inv-1", _run_log())
+        c.set_transport("inv-1", _transport())
+        assert len(capture.calls) == 2
+        assert self._entry(capture.calls[0])["event_type"] == "POST_PARSE"
+        assert self._entry(capture.calls[1])["event_type"] == "POST_RUN"
+
+    def test_phases_use_distinct_event_ids(self, monkeypatch):
+        capture = _Capture()
+        monkeypatch.setattr(coord_mod.client, "send", capture)
+        c = coord_mod.Coordinator()
+        c.set_transport("inv-1", _transport())
+        c.set_post_parse("inv-1", _log())
+        c.set_post_run("inv-1", _run_log())
+        ids = {
+            json.loads(call[1]["protoLogs"][0])["frontend_log_event_id"] for call in capture.calls
+        }
+        assert len(ids) == 2
+
+    def test_elapsed_ms(self):
+        c = coord_mod.Coordinator()
+        c.set_post_parse("inv-1", _log())
+        assert c.elapsed_ms("inv-1") >= 0
+        assert c.elapsed_ms("missing") == 0
+
+    def test_mark_start_enables_timer(self):
+        c = coord_mod.Coordinator()
+        c.mark_start("inv-1")
+        assert c.elapsed_ms("inv-1") >= 0
+
+
+class TestResultCapture:
+    def test_record_and_snapshot(self):
+        c = coord_mod.Coordinator()
+        c.mark_start("inv-1")
+        c.begin_result_capture("inv-1")
+        c.record_node_result("inv-1", "model", "success")
+        c.record_node_result("inv-1", "test", "pass")
+        node_results, captured = c.result_snapshot("inv-1")
+        assert captured is True
+        assert node_results == [("model", "success"), ("test", "pass")]
+
+    def test_snapshot_missing_invocation(self):
+        c = coord_mod.Coordinator()
+        assert c.result_snapshot("nope") == ([], False)
+
+    def test_record_after_close_ignored(self):
+        c = coord_mod.Coordinator()
+        c.mark_start("inv-1")
+        c.close("inv-1")
+        c.record_node_result("inv-1", "model", "success")
+        node_results, _ = c.result_snapshot("inv-1")
+        assert node_results == []

--- a/tests/unit/telemetry/test_encoder.py
+++ b/tests/unit/telemetry/test_encoder.py
@@ -9,11 +9,13 @@ def _log():
         adapter_version="1.2.3",
         dbt_core_version="1.12.0",
         post_parse=models.PostParsePayload(
-            invocation_config=models.InvocationConfig(thread_count=4, dbt_command="RUN"),
+            invocation_config=models.InvocationConfig(
+                thread_count=4, dbt_command=models.DbtCommand.RUN
+            ),
             manifest_stats=models.ManifestStats(enabled_total=models.ResourceCounts(model_count=3)),
             connection_config=models.ConnectionConfig(
-                default_compute_type=models.COMPUTE_TYPE_SQL_WAREHOUSE,
-                configured_auth_family=models.AUTH_FAMILY_PAT,
+                default_compute_type=models.ComputeType.SQL_WAREHOUSE,
+                configured_auth_family=models.AuthFamily.PAT,
             ),
             project_config=models.ProjectConfig(use_materialization_v2=True),
         ),
@@ -25,11 +27,11 @@ def _post_run_log():
         invocation_id="inv-2",
         adapter_version="1.2.3",
         dbt_core_version="1.12.0",
-        event_type=models.EVENT_TYPE_POST_RUN,
+        event_type=models.EventType.POST_RUN,
         post_run=models.PostRunPayload(
             run_outcome=models.RunOutcome(
-                invocation_status=models.INVOCATION_STATUS_HANDLED_ERROR,
-                termination_reason=models.TERMINATION_REASON_NORMAL,
+                invocation_status=models.InvocationStatus.HANDLED_ERROR,
+                termination_reason=models.TerminationReason.NORMAL,
                 invocation_duration_ms=1234,
                 result_aggregates_available=True,
             ),
@@ -37,7 +39,7 @@ def _post_run_log():
             result_counts=models.NodeStatusCounts(total=8, success=6, fail=1, pass_=5),
             results_by_resource_type=[
                 models.ResourceOutcomeStats(
-                    resource_type=models.RESOURCE_TYPE_MODEL,
+                    resource_type=models.ResourceType.MODEL,
                     status_counts=models.NodeStatusCounts(total=6, success=6),
                 )
             ],

--- a/tests/unit/telemetry/test_encoder.py
+++ b/tests/unit/telemetry/test_encoder.py
@@ -20,6 +20,31 @@ def _log():
     )
 
 
+def _post_run_log():
+    return models.TelemetryLog(
+        invocation_id="inv-2",
+        adapter_version="1.2.3",
+        dbt_core_version="1.12.0",
+        event_type=models.EVENT_TYPE_POST_RUN,
+        post_run=models.PostRunPayload(
+            run_outcome=models.RunOutcome(
+                invocation_status=models.INVOCATION_STATUS_HANDLED_ERROR,
+                termination_reason=models.TERMINATION_REASON_NORMAL,
+                invocation_duration_ms=1234,
+                result_aggregates_available=True,
+            ),
+            selected_resources=10,
+            result_counts=models.NodeStatusCounts(total=8, success=6, fail=1, pass_=5),
+            results_by_resource_type=[
+                models.ResourceOutcomeStats(
+                    resource_type=models.RESOURCE_TYPE_MODEL,
+                    status_counts=models.NodeStatusCounts(total=6, success=6),
+                )
+            ],
+        ),
+    )
+
+
 class TestEncoder:
     def test_request_envelope(self):
         body = encoder.encode_request(_log(), "evt-1", workspace_id="42")
@@ -57,3 +82,33 @@ class TestEncoder:
     def test_missing_workspace_id_is_omitted(self):
         fe = json.loads(encoder.encode_request(_log(), "e")["protoLogs"][0])
         assert "workspace_id" not in fe
+
+    def test_post_parse_omits_unset_phase(self):
+        entry = json.loads(encoder.encode_request(_log(), "e")["protoLogs"][0])["entry"][
+            "dbt_databricks_telemetry_log"
+        ]
+        assert "post_parse" in entry
+        assert "post_run" not in entry
+
+
+class TestPostRunEncoder:
+    def _entry(self):
+        fe = json.loads(encoder.encode_request(_post_run_log(), "e")["protoLogs"][0])
+        return fe["entry"]["dbt_databricks_telemetry_log"]
+
+    def test_only_post_run_phase(self):
+        entry = self._entry()
+        assert entry["event_type"] == "POST_RUN"
+        assert "post_run" in entry
+        assert "post_parse" not in entry
+
+    def test_pass_field_uses_proto_name(self):
+        rc = self._entry()["post_run"]["result_counts"]
+        assert rc["pass"] == 5
+        assert "pass_" not in rc
+
+    def test_outcome_and_resource_enum_names(self):
+        post_run = self._entry()["post_run"]
+        assert post_run["run_outcome"]["invocation_status"] == "HANDLED_ERROR"
+        assert post_run["run_outcome"]["invocation_duration_ms"] == 1234
+        assert post_run["results_by_resource_type"][0]["resource_type"] == "MODEL"

--- a/tests/unit/telemetry/test_encoder.py
+++ b/tests/unit/telemetry/test_encoder.py
@@ -51,26 +51,9 @@ def _post_run_log():
 
 
 class TestEncoder:
-    def test_request_envelope(self):
-        body = encoder.encode_request(_log(), "evt-1", workspace_id="42")
-        assert body["items"] == []
-        assert len(body["protoLogs"]) == 1
-        assert isinstance(body["uploadTime"], int)
-
     def test_uses_dedicated_entry_field(self):
         fe = json.loads(encoder.encode_request(_log(), "evt-1")["protoLogs"][0])
         assert "dbt_databricks_telemetry_log" in fe["entry"]
-
-    def test_event_shape_and_enum_names(self):
-        fe = json.loads(encoder.encode_request(_log(), "evt-1")["protoLogs"][0])
-        entry = fe["entry"]["dbt_databricks_telemetry_log"]
-        assert entry["event_type"] == "POST_PARSE"
-        assert entry["invocation_id"] == "inv-1"
-        cc = entry["post_parse"]["connection_config"]
-        assert cc["default_compute_type"] == "SQL_WAREHOUSE"
-        assert cc["configured_auth_family"] == "PAT"
-        assert entry["post_parse"]["manifest_stats"]["enabled_total"]["model_count"] == 3
-        assert entry["post_parse"]["project_config"]["use_materialization_v2"] is True
 
     def test_post_parse_contains_every_proto_field(self):
         entry = json.loads(encoder.encode_request(_log(), "evt-1")["protoLogs"][0])["entry"][
@@ -132,20 +115,12 @@ class TestEncoder:
             "unit_test_count",
         }
 
-    def test_stable_event_id(self):
-        fe = json.loads(encoder.encode_request(_log(), "stable-id")["protoLogs"][0])
-        assert fe["frontend_log_event_id"] == "stable-id"
-
     def test_numeric_workspace_id_is_coerced(self):
         fe = json.loads(encoder.encode_request(_log(), "e", workspace_id="42")["protoLogs"][0])
         assert fe["workspace_id"] == 42
 
     def test_non_numeric_workspace_id_is_omitted(self):
         fe = json.loads(encoder.encode_request(_log(), "e", workspace_id="abc")["protoLogs"][0])
-        assert "workspace_id" not in fe
-
-    def test_missing_workspace_id_is_omitted(self):
-        fe = json.loads(encoder.encode_request(_log(), "e")["protoLogs"][0])
         assert "workspace_id" not in fe
 
     def test_post_parse_omits_unset_phase(self):

--- a/tests/unit/telemetry/test_encoder.py
+++ b/tests/unit/telemetry/test_encoder.py
@@ -1,0 +1,59 @@
+import json
+
+from dbt.adapters.databricks.telemetry import encoder, models
+
+
+def _log():
+    return models.TelemetryLog(
+        invocation_id="inv-1",
+        adapter_version="1.2.3",
+        dbt_core_version="1.12.0",
+        post_parse=models.PostParsePayload(
+            invocation_config=models.InvocationConfig(thread_count=4, dbt_command="RUN"),
+            manifest_stats=models.ManifestStats(enabled_total=models.ResourceCounts(model_count=3)),
+            connection_config=models.ConnectionConfig(
+                default_compute_type=models.COMPUTE_TYPE_SQL_WAREHOUSE,
+                configured_auth_family=models.AUTH_FAMILY_PAT,
+            ),
+            project_config=models.ProjectConfig(use_materialization_v2=True),
+        ),
+    )
+
+
+class TestEncoder:
+    def test_request_envelope(self):
+        body = encoder.encode_request(_log(), "evt-1", workspace_id="42")
+        assert body["items"] == []
+        assert len(body["protoLogs"]) == 1
+        assert isinstance(body["uploadTime"], int)
+
+    def test_uses_dedicated_entry_field(self):
+        fe = json.loads(encoder.encode_request(_log(), "evt-1")["protoLogs"][0])
+        assert "dbt_databricks_telemetry_log" in fe["entry"]
+
+    def test_event_shape_and_enum_names(self):
+        fe = json.loads(encoder.encode_request(_log(), "evt-1")["protoLogs"][0])
+        entry = fe["entry"]["dbt_databricks_telemetry_log"]
+        assert entry["event_type"] == "POST_PARSE"
+        assert entry["invocation_id"] == "inv-1"
+        cc = entry["post_parse"]["connection_config"]
+        assert cc["default_compute_type"] == "SQL_WAREHOUSE"
+        assert cc["configured_auth_family"] == "PAT"
+        assert entry["post_parse"]["manifest_stats"]["enabled_total"]["model_count"] == 3
+        assert entry["post_parse"]["project_config"]["use_materialization_v2"] is True
+
+    def test_stable_event_id(self):
+        fe = json.loads(encoder.encode_request(_log(), "stable-id")["protoLogs"][0])
+        assert fe["frontend_log_event_id"] == "stable-id"
+
+    def test_numeric_workspace_id_is_coerced(self):
+        fe = json.loads(encoder.encode_request(_log(), "e", workspace_id="42")["protoLogs"][0])
+        assert fe["workspace_id"] == 42
+
+    def test_non_numeric_workspace_id_is_omitted(self):
+        fe = json.loads(encoder.encode_request(_log(), "e", workspace_id="abc")["protoLogs"][0])
+        assert "workspace_id" not in fe
+
+    def test_missing_workspace_id_is_omitted(self):
+        fe = json.loads(encoder.encode_request(_log(), "e")["protoLogs"][0])
+        assert "workspace_id" not in fe

--- a/tests/unit/telemetry/test_encoder.py
+++ b/tests/unit/telemetry/test_encoder.py
@@ -34,6 +34,7 @@ def _post_run_log():
                 termination_reason=models.TerminationReason.NORMAL,
                 invocation_duration_ms=1234,
                 result_aggregates_available=True,
+                expected_result_coverage_complete=True,
             ),
             selected_resources=10,
             result_counts=models.NodeStatusCounts(total=8, success=6, fail=1, pass_=5),
@@ -43,6 +44,8 @@ def _post_run_log():
                     status_counts=models.NodeStatusCounts(total=6, success=6),
                 )
             ],
+            auxiliary_hook_results=models.NodeStatusCounts(),
+            unknown_resource_type_results=1,
         ),
     )
 
@@ -68,6 +71,66 @@ class TestEncoder:
         assert cc["configured_auth_family"] == "PAT"
         assert entry["post_parse"]["manifest_stats"]["enabled_total"]["model_count"] == 3
         assert entry["post_parse"]["project_config"]["use_materialization_v2"] is True
+
+    def test_post_parse_contains_every_proto_field(self):
+        entry = json.loads(encoder.encode_request(_log(), "evt-1")["protoLogs"][0])["entry"][
+            "dbt_databricks_telemetry_log"
+        ]
+        assert set(entry) == {
+            "invocation_id",
+            "event_type",
+            "adapter_version",
+            "dbt_core_version",
+            "post_parse",
+        }
+        assert set(entry["post_parse"]) == {
+            "invocation_config",
+            "manifest_stats",
+            "connection_config",
+            "project_config",
+        }
+        post_parse = entry["post_parse"]
+        assert set(post_parse["invocation_config"]) == {
+            "thread_count",
+            "dbt_command",
+            "full_refresh",
+            "empty",
+            "fail_fast",
+            "warn_error_policy",
+        }
+        assert set(post_parse["connection_config"]) == {
+            "default_compute_type",
+            "configured_auth_family",
+            "named_compute_count",
+            "spog_routing_configured",
+            "use_kernel",
+        }
+        assert set(post_parse["project_config"]) == {
+            "use_user_folder_for_python",
+            "use_materialization_v2",
+            "use_replace_on_for_insert_overwrite",
+            "use_managed_iceberg",
+            "use_concurrent_microbatch",
+            "use_describe_as_json_for_relation_metadata",
+        }
+        assert set(post_parse["manifest_stats"]) == {
+            "enabled_total",
+            "enabled_root_project",
+            "enabled_installed_packages",
+        }
+        assert set(post_parse["manifest_stats"]["enabled_total"]) == {
+            "model_count",
+            "data_test_count",
+            "generic_data_test_count",
+            "seed_count",
+            "snapshot_count",
+            "source_count",
+            "function_count",
+            "exposure_count",
+            "saved_query_count",
+            "other_count",
+            "unit_test_count",
+        }
 
     def test_stable_event_id(self):
         fe = json.loads(encoder.encode_request(_log(), "stable-id")["protoLogs"][0])
@@ -114,3 +177,61 @@ class TestPostRunEncoder:
         assert post_run["run_outcome"]["invocation_status"] == "HANDLED_ERROR"
         assert post_run["run_outcome"]["invocation_duration_ms"] == 1234
         assert post_run["results_by_resource_type"][0]["resource_type"] == "MODEL"
+
+    def test_post_run_contains_every_proto_field(self):
+        post_run = self._entry()["post_run"]
+        assert set(post_run) == {
+            "run_outcome",
+            "selected_resources",
+            "expected_result_resources",
+            "result_counts",
+            "results_by_resource_type",
+            "auxiliary_hook_results",
+            "unknown_resource_type_results",
+        }
+        assert set(post_run["run_outcome"]) == {
+            "invocation_status",
+            "termination_reason",
+            "invocation_duration_ms",
+            "result_aggregates_available",
+            "expected_result_coverage_complete",
+        }
+        assert set(post_run["result_counts"]) == {
+            "total",
+            "success",
+            "error",
+            "fail",
+            "warn",
+            "skipped",
+            "partial_success",
+            "pass",
+            "runtime_error",
+            "no_op",
+            "reused",
+        }
+        assert set(post_run["results_by_resource_type"][0]) == {
+            "resource_type",
+            "status_counts",
+        }
+
+    def test_unavailable_aggregates_are_omitted(self):
+        log = models.TelemetryLog(
+            invocation_id="inv-3",
+            adapter_version="1.2.3",
+            dbt_core_version="1.12.0",
+            event_type=models.EventType.POST_RUN,
+            post_run=models.PostRunPayload(
+                run_outcome=models.RunOutcome(result_aggregates_available=False),
+                expected_result_resources=2,
+            ),
+        )
+        entry = json.loads(encoder.encode_request(log, "e")["protoLogs"][0])["entry"][
+            "dbt_databricks_telemetry_log"
+        ]["post_run"]
+        assert set(entry) == {"run_outcome", "expected_result_resources"}
+        assert set(entry["run_outcome"]) == {
+            "invocation_status",
+            "termination_reason",
+            "invocation_duration_ms",
+            "result_aggregates_available",
+        }

--- a/tests/unit/telemetry/test_hooks.py
+++ b/tests/unit/telemetry/test_hooks.py
@@ -1,0 +1,35 @@
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+from dbt.adapters.databricks.telemetry import hooks
+
+
+def test_post_parse_is_not_rebuilt(monkeypatch):
+    coord = Mock()
+    coord.needs_post_parse.return_value = False
+    build = Mock()
+    monkeypatch.setattr(hooks, "coordinator", lambda: coord)
+    monkeypatch.setattr(hooks, "_current_invocation_id", lambda: "inv-1")
+    monkeypatch.setattr(hooks, "DatabricksCredentials", object)
+    monkeypatch.setattr(hooks, "is_enabled_for_invocation", lambda _: True)
+    monkeypatch.setattr(hooks.builder, "build_post_parse_log", build)
+    adapter = SimpleNamespace(config=SimpleNamespace(credentials=SimpleNamespace()))
+
+    hooks.on_post_parse(adapter, SimpleNamespace())
+
+    coord.needs_post_parse.assert_called_once_with("inv-1")
+    build.assert_not_called()
+
+
+def test_closed_invocation_is_not_finalized_again(monkeypatch):
+    coord = Mock()
+    coord.is_closed.return_value = True
+    build = Mock()
+    monkeypatch.setattr(hooks, "coordinator", lambda: coord)
+    monkeypatch.setattr(hooks.builder, "build_post_run_log", build)
+
+    hooks._finalize_post_run("inv-1", None)
+
+    coord.is_closed.assert_called_once_with("inv-1")
+    coord.result_snapshot.assert_not_called()
+    build.assert_not_called()

--- a/tests/unit/telemetry/test_listener.py
+++ b/tests/unit/telemetry/test_listener.py
@@ -1,0 +1,74 @@
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+from dbt.adapters.databricks.telemetry import listener
+
+
+def _message(name, data):
+    return SimpleNamespace(info=SimpleNamespace(name=name), data=data)
+
+
+def test_end_run_records_authoritative_results_then_finalizes(monkeypatch):
+    coord = Mock()
+    monkeypatch.setattr(listener, "coordinator", lambda: coord)
+    monkeypatch.setattr(listener, "_current_invocation_id", lambda: "inv-1")
+
+    from dbt.adapters.databricks.telemetry import hooks
+
+    finalize = Mock()
+    monkeypatch.setattr(hooks, "on_end_run_result", finalize)
+    results = [SimpleNamespace(status="success")]
+
+    listener._on_event(_message("EndRunResult", SimpleNamespace(results=results, success=True)))
+
+    coord.record_end_run.assert_called_once_with("inv-1", ["success"], success=True)
+    finalize.assert_called_once_with("inv-1")
+
+
+def test_concurrency_line_records_expected_result_count(monkeypatch):
+    coord = Mock()
+    monkeypatch.setattr(listener, "coordinator", lambda: coord)
+    monkeypatch.setattr(listener, "_current_invocation_id", lambda: "inv-1")
+
+    listener._on_event(_message("ConcurrencyLine", SimpleNamespace(node_count=7)))
+
+    coord.record_expected_count.assert_called_once_with("inv-1", 7)
+
+
+def test_hook_end_records_auxiliary_result(monkeypatch):
+    coord = Mock()
+    monkeypatch.setattr(listener, "coordinator", lambda: coord)
+    monkeypatch.setattr(listener, "_current_invocation_id", lambda: "inv-1")
+
+    listener._on_event(_message("LogHookEndLine", SimpleNamespace(status="success")))
+
+    coord.record_hook_result.assert_called_once_with("inv-1", "success")
+
+
+def test_generic_exception_records_typed_error(monkeypatch):
+    coord = Mock()
+    monkeypatch.setattr(listener, "coordinator", lambda: coord)
+    monkeypatch.setattr(listener, "_current_invocation_id", lambda: "inv-1")
+
+    listener._on_event(
+        _message(
+            "GenericExceptionOnRun",
+            SimpleNamespace(
+                unique_id="model.p.m",
+                node_info=SimpleNamespace(unique_id="model.p.m"),
+            ),
+        )
+    )
+
+    coord.record_node_result.assert_called_once_with("inv-1", "model.p.m", "error")
+
+
+def test_pre_end_failure_marks_fail_fast_triggered(monkeypatch):
+    coord = Mock()
+    monkeypatch.setattr(listener, "coordinator", lambda: coord)
+    monkeypatch.setattr(listener, "_current_invocation_id", lambda: "inv-1")
+    monkeypatch.setattr(listener, "_fail_fast_enabled", lambda: True)
+
+    listener._on_event(_message("RunResultFailure", SimpleNamespace()))
+
+    coord.mark_fail_fast_triggered.assert_called_once_with("inv-1")

--- a/tests/unit/telemetry/test_listener.py
+++ b/tests/unit/telemetry/test_listener.py
@@ -25,26 +25,6 @@ def test_end_run_records_authoritative_results_then_finalizes(monkeypatch):
     finalize.assert_called_once_with("inv-1")
 
 
-def test_concurrency_line_records_expected_result_count(monkeypatch):
-    coord = Mock()
-    monkeypatch.setattr(listener, "coordinator", lambda: coord)
-    monkeypatch.setattr(listener, "_current_invocation_id", lambda: "inv-1")
-
-    listener._on_event(_message("ConcurrencyLine", SimpleNamespace(node_count=7)))
-
-    coord.record_expected_count.assert_called_once_with("inv-1", 7)
-
-
-def test_hook_end_records_auxiliary_result(monkeypatch):
-    coord = Mock()
-    monkeypatch.setattr(listener, "coordinator", lambda: coord)
-    monkeypatch.setattr(listener, "_current_invocation_id", lambda: "inv-1")
-
-    listener._on_event(_message("LogHookEndLine", SimpleNamespace(status="success")))
-
-    coord.record_hook_result.assert_called_once_with("inv-1", "success")
-
-
 def test_generic_exception_records_typed_error(monkeypatch):
     coord = Mock()
     monkeypatch.setattr(listener, "coordinator", lambda: coord)


### PR DESCRIPTION
Description:
Adds an opt-in, default-off telemetry subsystem for the Databricks adapter. Enable with `enable_dbt_telemetry: true` in `connection_parameters`.

- Two events per eligible invocation (`build`, `run`, `test`, `seed`, and `snapshot` only): `POST_PARSE` contains invocation configuration, manifest resource counts, connection shape, and behavior flags; `POST_RUN` contains status, termination reason, node and hook result counts, and duration.
- Privacy: no credentials, hostnames, cluster IDs, or object names. Auth is reduced to an enum family, `http_path` to compute type, and only a non-PII workspace ID is sent.
- Best-effort and async: sends run on a background thread with a 10-second request timeout and never block a SQL connection. Run-end waits up to two request timeouts for queued events. Failures are ignored and never affect the dbt command.

Testing:
(will check whether telemetry logs land in the dbt telemetry table)
