### PR TITLE
docs: add code comment discipline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -187,6 +187,10 @@ class TestIncrementalModel:
         assert results[0][0] == 1
 ```
 
+## Code Comment Discipline
+
+Default to no comment. Keep one only when it records a non-obvious constraint, workaround, or rationale the code cannot express. State why, not what, in one concise sentence. Remove comments that narrate code, repeat tests, preserve implementation history, or duplicate PR/changelog rationale. Apply the existing changelog rules without adding explanatory prose around entries.
+
 ## 📝 CHANGELOG Entries
 
 Every PR that changes runtime behavior updates `CHANGELOG.md` (enforced by the PR template). Add the entry under the topmost version heading (the one marked `(TBD)`), in the correct section: `### Features`, `### Fixes`, or `### Under the Hood`.


### PR DESCRIPTION
### Description

Add concise contributor guidance that defaults to no code comment unless it preserves a non-obvious constraint, workaround, or rationale.

The policy discourages comments that narrate code, repeat tests, preserve implementation history, or duplicate pull request and changelog context.

### Checklist

- [x] Tests are not required for this contributor-guidance-only change
- [x] `CHANGELOG.md` is unchanged because this does not affect runtime behavior
