### PR TITLE
docs: gate new @available methods behind portable alternatives

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -388,11 +388,34 @@ Models can be configured with Databricks-specific options:
 
 ### Adding New Adapter Method
 
-1. Add method to `DatabricksAdapter` class in `impl.py`
-2. Implement database interaction logic
-3. Add corresponding macro if SQL generation needed
-4. Write unit tests with mocked database calls
-5. Write functional tests with real database
+Every `@available` method is permanent public API. Jinja is late-bound, so nothing
+warns you a method is unused, and each one must be independently re-implemented in the
+Fusion engine's Rust adapter — both its dispatch and its semantic classification —
+before Databricks behavior matches across engines. A macro built on the shared adapter
+contract inherits that machinery for free.
+
+**Before adding one, work down this list and stop at the first that works:**
+
+1. **An existing shared-contract macro.** `get_columns_in_query`,
+   `get_empty_subquery_sql`, `get_columns_in_relation`, `run_query`, and the
+   `statement()` family cover most metadata and schema-inference needs.
+   `get_columns_in_query` in particular infers a query's schema with no DDL and no
+   data scan.
+2. **Jinja expressions on data you already have.** Filters (`map`, `select`, `list`,
+   comparison) handle list and string shaping. A list comparison in a macro does not
+   need a Python helper.
+3. **A relation config component** under `relation_configs/`, if the logic is really
+   about describing or diffing relation state.
+4. **A new `@available` method** — only when the work genuinely cannot happen in
+   Jinja: real Python control flow, SDK/API calls, credential handling, or non-trivial
+   parsing.
+
+When you do reach step 4, justify it in the PR description, keep the signature in
+portable types (strings, lists, dicts — not adapter-internal objects), and note that
+Fusion parity work is now owed.
+
+Then: implement the logic, add the macro if SQL generation is needed, write unit tests
+with mocked database calls, and write functional tests against a real database.
 
 ### Modifying SQL Generation
 
@@ -483,6 +506,10 @@ Models can be configured with Databricks-specific options:
 8. **Jinja2 Whitespace**: Prefer using `-` in Jinja tags (`{%-`, `-%}`) to strip whitespace and prevent blank lines in generated SQL:
    - Preferred: `{%- if condition -%}`
    - Without: `{% if condition %}` (may create blank lines)
+9. **Jinja ↔ Python boundary**: Keep it as narrow as possible. Prefer a shared-contract
+   macro over a new `@available` method; prefer Jinja filters over a Python helper that
+   only reshapes a list or string. Removing an `@available` method in favor of portable
+   macros is a win, not churn.
 
 ## 🚨 Common Pitfalls for Agents
 
@@ -497,6 +524,7 @@ Models can be configured with Databricks-specific options:
 9. **Use capability system for version checks** - Never add new `compare_dbr_version()` calls
 10. **Remember per-compute caching** - Different clusters may have different capabilities in the same run
 11. **Multi-statement SQL**: Don't use semicolons to separate statements - return a list instead and let `execute_multiple_statements()` handle it
+12. **Don't add an `@available` method for logic Jinja can already do** - each one is permanent API and owes a matching Fusion implementation. Check the shared adapter contract first.
 
 ## 🎯 Success Metrics
 


### PR DESCRIPTION
## Summary

Gate new `@available` methods behind portable alternatives in the agent guide.

Each `@available` method is permanent public API — Jinja is late-bound, so nothing flags an unused one — and must be re-implemented in the Fusion engine's Rust adapter before behavior matches across engines. Shared-contract macros get that for free.

`### Adding New Adapter Method` now opens with that cost, then lists options to work down, stopping at the first that works: a shared-contract macro, plain Jinja, a relation config component, and only then a new `@available` method. Reaching the last step asks for a justification, portable types, and an acknowledgement that Fusion parity is owed.

Shorter entries added to `### Code Patterns to Follow` and `### Common Pitfalls for Agents`.

## Test plan

Docs only — no runtime change, no CHANGELOG entry, no tests. `pre-commit run --all-files` passes.
