### PR TITLE
ci: raise coverage unit-test job timeout to 30 minutes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -90,7 +90,9 @@ jobs:
     runs-on:
       group: databricks-protected-runner-group
       labels: linux-ubuntu-latest
-    timeout-minutes: 20
+    # Coverage instrumentation slows the unit suite; give it more headroom
+    # than the other 20-minute unit jobs.
+    timeout-minutes: 30
 
     permissions:
       id-token: write


### PR DESCRIPTION
## Description

The unit test job in `main.yml` runs the suite with coverage instrumentation (`test:unit-with-cov`), which is slower than the other unit jobs and can exceed the shared 20-minute timeout.

This raises the timeout for that job to 30 minutes, leaving the other unit jobs (including `main-min-deps.yml`) at 20.

Example timeout: https://github.com/databricks/dbt-databricks/actions/runs/31261109055/job/93111926509?pr=1621

## Checklist

- [x] CI-only change; no runtime behavior change, so no CHANGELOG entry required.