### PR TITLE
fix(ci): bound and retry unit coverage tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -90,9 +90,8 @@ jobs:
     runs-on:
       group: databricks-protected-runner-group
       labels: linux-ubuntu-latest
-    # Coverage instrumentation slows the unit suite; give it more headroom
-    # than the other 20-minute unit jobs.
-    timeout-minutes: 30
+    # Keep a finite job-level backstop; unit commands also enforce per-test timeouts.
+    timeout-minutes: 20
 
     permissions:
       id-token: write
@@ -141,6 +140,8 @@ jobs:
           version: "1.17.0"
 
       - name: Run Unit Tests and Generate Coverage
+        env:
+          PYTEST_ADDOPTS: "--reruns=1"
         run: hatch run -v +py=${{ matrix.python-version }} test:unit-with-cov
 
       # Only run coverage comment once (not for all python versions)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ test = [
     "pytest-dotenv>=0.5.2",
     "freezegun>=1.5.1",
     "pytest-cov>=6.0.0",
+    "pytest-timeout>=2.4.0",
 ]
 dev = [
     {include-group = "test"},
@@ -121,15 +122,15 @@ python = "3.10"
 [tool.hatch.envs.default.scripts]
 setup-precommit = "pre-commit install"
 code-quality = "pre-commit run --all-files"
-unit = "pytest --color=yes -v --profile databricks_cluster -n 10 tests/unit"
+unit = "pytest --color=yes -v --profile databricks_cluster --timeout=60 --timeout-method=signal -n 10 tests/unit"
 # `*-dev` scripts run the unsharded suite locally; CI shards via integration.yml.
 cluster-e2e-dev = "pytest --color=yes -v --profile databricks_cluster -n 10 --dist=loadfile tests/functional"
 uc-cluster-e2e-dev = "pytest --color=yes -v --profile databricks_uc_cluster -n 10 --dist=loadfile tests/functional"
 sqlw-e2e-dev = "pytest --color=yes -v --profile databricks_uc_sql_endpoint -n 10 --dist=loadfile tests/functional"
 
 [tool.hatch.envs.test.scripts]
-unit = "pytest --color=yes -v --profile databricks_cluster -n auto --dist=loadscope tests/unit"
-unit-with-cov = "pytest --color=yes -v --profile databricks_cluster -n auto --dist=loadscope tests/unit --cov=dbt"
+unit = "pytest --color=yes -v --profile databricks_cluster --timeout=60 --timeout-method=signal -n auto --dist=loadscope tests/unit"
+unit-with-cov = "pytest --color=yes -v --profile databricks_cluster --timeout=60 --timeout-method=signal -n auto --dist=loadscope tests/unit --cov=dbt"
 
 [[tool.hatch.envs.test.matrix]]
 python = ["3.10", "3.11", "3.12", "3.13"]
@@ -145,7 +146,7 @@ post-install-commands = [
 
 [tool.hatch.envs.min-deps.scripts]
 parse = "dbt parse --project-dir tests/min_deps_smoke --profiles-dir tests/min_deps_smoke"
-unit = "pytest --color=yes -v --profile databricks_cluster -n 10 --dist=loadscope tests/unit"
+unit = "pytest --color=yes -v --profile databricks_cluster --timeout=60 --timeout-method=signal -n 10 --dist=loadscope tests/unit"
 e2e = "pytest --color=yes -v --profile databricks_uc_sql_endpoint -n 10 --dist=loadfile tests/functional"
 
 [tool.ruff]

--- a/requirements.lowest-direct.txt
+++ b/requirements.lowest-direct.txt
@@ -1051,6 +1051,7 @@ pytest==8.3.5 \
     #   pytest-cov
     #   pytest-dotenv
     #   pytest-rerunfailures
+    #   pytest-timeout
     #   pytest-xdist
 pytest-cov==6.0.0 \
     --hash=sha256:eee6f1b9e61008bd34975a4d5bab25801eb31898b032dd55addc93e96fcaaa35 \
@@ -1063,6 +1064,10 @@ pytest-dotenv==0.5.2 \
 pytest-rerunfailures==16.2 \
     --hash=sha256:5f5a32f15674a3d54f7598388fcd3cc1bc5c37284731a4704a44485dcdda5e23 \
     --hash=sha256:c22a53d2827becc76f057d4ded123c0e726523f2f0e5f0bb4efb31fd59e1f14e
+    # via dbt-databricks (pyproject.toml:test)
+pytest-timeout==2.4.0 \
+    --hash=sha256:7e68e90b01f9eff71332b25001f85c75495fc4e3a836701876183c4bcfd0540a \
+    --hash=sha256:c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2
     # via dbt-databricks (pyproject.toml:test)
 pytest-xdist==3.6.1 \
     --hash=sha256:9ed4adfb68a016610848639bb7e02c9352d5d9f03d04809919e2dafc3be4cca7 \

--- a/uv.lock
+++ b/uv.lock
@@ -625,6 +625,7 @@ dev = [
     { name = "pytest-cov" },
     { name = "pytest-dotenv" },
     { name = "pytest-rerunfailures" },
+    { name = "pytest-timeout" },
     { name = "pytest-xdist" },
     { name = "ruff" },
     { name = "types-requests" },
@@ -636,6 +637,7 @@ test = [
     { name = "pytest-cov" },
     { name = "pytest-dotenv" },
     { name = "pytest-rerunfailures" },
+    { name = "pytest-timeout" },
     { name = "pytest-xdist" },
 ]
 
@@ -663,6 +665,7 @@ dev = [
     { name = "pytest-cov", specifier = ">=6.0.0" },
     { name = "pytest-dotenv", specifier = ">=0.5.2" },
     { name = "pytest-rerunfailures", specifier = ">=16.2" },
+    { name = "pytest-timeout", specifier = ">=2.4.0" },
     { name = "pytest-xdist", specifier = ">=3.6.1" },
     { name = "ruff", specifier = "==0.14.2" },
     { name = "types-requests" },
@@ -674,6 +677,7 @@ test = [
     { name = "pytest-cov", specifier = ">=6.0.0" },
     { name = "pytest-dotenv", specifier = ">=0.5.2" },
     { name = "pytest-rerunfailures", specifier = ">=16.2" },
+    { name = "pytest-timeout", specifier = ">=2.4.0" },
     { name = "pytest-xdist", specifier = ">=3.6.1" },
 ]
 
@@ -1992,6 +1996,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/6b/27/fd0209642f3a1069da3e0be3c7e339f942d052d81ccb1fb4eb9b187d3633/pytest_rerunfailures-16.2.tar.gz", hash = "sha256:5f5a32f15674a3d54f7598388fcd3cc1bc5c37284731a4704a44485dcdda5e23", size = 32121, upload-time = "2026-05-13T08:13:26.998Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3f/a5/d8c1ad74529b483044b787ead2d24ecc624bca4084a509002102e4bab8cc/pytest_rerunfailures-16.2-py3-none-any.whl", hash = "sha256:c22a53d2827becc76f057d4ded123c0e726523f2f0e5f0bb4efb31fd59e1f14e", size = 14505, upload-time = "2026-05-13T08:13:25.485Z" },
+]
+
+[[package]]
+name = "pytest-timeout"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/82/4c9ecabab13363e72d880f2fb504c5f750433b2b6f16e99f4ec21ada284c/pytest_timeout-2.4.0.tar.gz", hash = "sha256:7e68e90b01f9eff71332b25001f85c75495fc4e3a836701876183c4bcfd0540a", size = 17973, upload-time = "2025-05-05T19:44:34.99Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/b6/3127540ecdf1464a00e5a01ee60a1b09175f6913f0644ac748494d9c4b21/pytest_timeout-2.4.0-py3-none-any.whl", hash = "sha256:c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2", size = 14382, upload-time = "2025-05-05T19:44:33.502Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Add a 60-second timeout to unit tests so a stuck test fails with an actionable node id.
- Retry unit test failures once across all unit-test runs, including coverage.
- Keep the unit job overall CI timeout at 20 minutes.

## Validation
- Focused Python 3.13 unit test passed locally.
- Pre-commit checks and lock validation passed.