### PR TITLE
fix: silence constraint not enforced

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Fixes
 
-- Honor `warn_error_options` (silence/warn/error) for the unenforced `primary_key`/`foreign_key` constraint warning when `use_materialization_v2: false`, by emitting the structured `ConstraintNotEnforced` event instead of a free-form warning (thanks @frankivo!) ([#XXXX](https://github.com/databricks/dbt-databricks/pull/XXXX) resolves [#1196](https://github.com/databricks/dbt-databricks/issues/1196))
+- Make the unenforced `primary_key`/`foreign_key` constraint warning respect `warn_error_options` when `use_materialization_v2: false` ([#1638](https://github.com/databricks/dbt-databricks/pull/1638) resolves [#1196](https://github.com/databricks/dbt-databricks/issues/1196))
 
 ## dbt-databricks 1.12.4 (Aug 12, 2026)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## dbt-databricks 1.12.5 (TBD)
+
+### Fixes
+
+- Honor `warn_error_options` (silence/warn/error) for the unenforced `primary_key`/`foreign_key` constraint warning when `use_materialization_v2: false`, by emitting the structured `ConstraintNotEnforced` event instead of a free-form warning (thanks @frankivo!) ([#XXXX](https://github.com/databricks/dbt-databricks/pull/XXXX) resolves [#1196](https://github.com/databricks/dbt-databricks/issues/1196))
+
 ## dbt-databricks 1.12.4 (Aug 12, 2026)
 
 ### Fixes

--- a/dbt/adapters/databricks/constraints.py
+++ b/dbt/adapters/databricks/constraints.py
@@ -186,8 +186,6 @@ def validate_constraint(constraint: ColumnLevelConstraint) -> bool:
 
 
 def warn_constraint_not_enforced(constraint_type: str) -> None:
-    # A raw jinja exceptions.warn() only produces an untargetable JinjaLogWarning; firing the
-    # structured event instead lets warn_error_options silence or escalate the warning.
     warn_or_error(ConstraintNotEnforced(constraint=constraint_type, adapter="DatabricksAdapter"))
 
 

--- a/dbt/adapters/databricks/constraints.py
+++ b/dbt/adapters/databricks/constraints.py
@@ -180,11 +180,15 @@ def validate_constraint(constraint: ColumnLevelConstraint) -> bool:
             ConstraintNotSupported(constraint=constraint.type.value, adapter="DatabricksAdapter")
         )
     elif constraint.warn_unenforced and not is_enforced(constraint):
-        warn_or_error(
-            ConstraintNotEnforced(constraint=constraint.type.value, adapter="DatabricksAdapter")
-        )
+        warn_constraint_not_enforced(constraint.type.value)
 
     return supported
+
+
+def warn_constraint_not_enforced(constraint_type: str) -> None:
+    # A raw jinja exceptions.warn() only produces an untargetable JinjaLogWarning; firing the
+    # structured event instead lets warn_error_options silence or escalate the warning.
+    warn_or_error(ConstraintNotEnforced(constraint=constraint_type, adapter="DatabricksAdapter"))
 
 
 def parse_constraints(

--- a/dbt/adapters/databricks/impl.py
+++ b/dbt/adapters/databricks/impl.py
@@ -1035,6 +1035,15 @@ class DatabricksAdapter(SparkAdapter):
 
     @available
     @staticmethod
+    def warn_constraint_not_enforced(constraint_type: str) -> None:
+        # V1 constraint macros can only call jinja's exceptions.warn, which emits an
+        # untargetable JinjaLogWarning; delegating here fires the structured
+        # ConstraintNotEnforced event (as the V2 path does) so warn_error_options applies.
+        # Fusion parity owed: needs a matching Rust-adapter implementation.
+        constraints.warn_constraint_not_enforced(constraint_type)
+
+    @available
+    @staticmethod
     def parse_columns_and_constraints(
         existing_columns: list[DatabricksColumn],
         model_columns: dict[str, dict[str, Any]],

--- a/dbt/adapters/databricks/impl.py
+++ b/dbt/adapters/databricks/impl.py
@@ -1036,10 +1036,6 @@ class DatabricksAdapter(SparkAdapter):
     @available
     @staticmethod
     def warn_constraint_not_enforced(constraint_type: str) -> None:
-        # V1 constraint macros can only call jinja's exceptions.warn, which emits an
-        # untargetable JinjaLogWarning; delegating here fires the structured
-        # ConstraintNotEnforced event (as the V2 path does) so warn_error_options applies.
-        # Fusion parity owed: needs a matching Rust-adapter implementation.
         constraints.warn_constraint_not_enforced(constraint_type)
 
     @available

--- a/dbt/include/databricks/macros/relations/constraints.sql
+++ b/dbt/include/databricks/macros/relations/constraints.sql
@@ -150,7 +150,7 @@
     {% endfor %}
   {% elif type == 'primary_key' %}
     {% if constraint.get('warn_unenforced') %}
-      {{ exceptions.warn("unenforced constraint type: " ~ type)}}
+      {% do adapter.warn_constraint_not_enforced(type) %}
     {% endif %}
     {% set column_names = constraint.get('columns', []) %}
     {% if column and not column_names %}
@@ -189,7 +189,7 @@
   {% elif type == 'foreign_key' %}
 
     {% if constraint.get('warn_unenforced') %}
-      {{ exceptions.warn("unenforced constraint type: " ~ constraint.type)}}
+      {% do adapter.warn_constraint_not_enforced(type) %}
     {% endif %}
 
     {% set name = constraint.get('name') %}

--- a/tests/unit/macros/relations/test_constraint_macros.py
+++ b/tests/unit/macros/relations/test_constraint_macros.py
@@ -474,3 +474,37 @@ class TestConstraintMacros(MacroTestBase):
         }
         r = self.render_constraint_sql(template_bundle, constraint, model)
         assert "raise_compiler_error" in r
+
+    def test_macros_get_constraint_sql_primary_key_warn_unenforced(self, template_bundle, model):
+        # The unenforced warning must go through the structured ConstraintNotEnforced event
+        # (adapter.warn_constraint_not_enforced) so warn_error_options can target it (issue #1196),
+        # not a free-form exceptions.warn that only produces an untargetable JinjaLogWarning.
+        constraint = {
+            "type": "primary_key",
+            "name": "myconstraint",
+            "columns": ["name"],
+            "warn_unenforced": True,
+        }
+        r = self.render_constraint_sql(template_bundle, constraint, model)
+
+        template_bundle.context["adapter"].warn_constraint_not_enforced.assert_called_once_with(
+            "primary_key"
+        )
+        template_bundle.context["exceptions"].warn.assert_not_called()
+        assert "primary key(`name`)" in r
+
+    def test_macros_get_constraint_sql_foreign_key_warn_unenforced(self, template_bundle, model):
+        constraint = {
+            "type": "foreign_key",
+            "name": "myconstraint",
+            "columns": ["name"],
+            "to": "parent_table",
+            "warn_unenforced": True,
+        }
+        r = self.render_constraint_sql(template_bundle, constraint, model)
+
+        template_bundle.context["adapter"].warn_constraint_not_enforced.assert_called_once_with(
+            "foreign_key"
+        )
+        template_bundle.context["exceptions"].warn.assert_not_called()
+        assert "foreign key(`name`)" in r

--- a/tests/unit/macros/relations/test_constraint_macros.py
+++ b/tests/unit/macros/relations/test_constraint_macros.py
@@ -476,9 +476,6 @@ class TestConstraintMacros(MacroTestBase):
         assert "raise_compiler_error" in r
 
     def test_macros_get_constraint_sql_primary_key_warn_unenforced(self, template_bundle, model):
-        # The unenforced warning must go through the structured ConstraintNotEnforced event
-        # (adapter.warn_constraint_not_enforced) so warn_error_options can target it (issue #1196),
-        # not a free-form exceptions.warn that only produces an untargetable JinjaLogWarning.
         constraint = {
             "type": "primary_key",
             "name": "myconstraint",

--- a/tests/unit/test_constraints.py
+++ b/tests/unit/test_constraints.py
@@ -22,6 +22,7 @@ from dbt.adapters.databricks.constraints import (
     parse_model_constraints,
     process_constraint,
     validate_constraint,
+    warn_constraint_not_enforced,
 )
 from dbt.adapters.databricks.impl import DatabricksAdapter
 
@@ -244,6 +245,17 @@ class TestValidateConstraint:
             mock_warn.assert_called_with(
                 constraint=pk_constraint.type.value, adapter="DatabricksAdapter"
             )
+
+
+class TestWarnConstraintNotEnforced:
+    @patch("dbt.adapters.databricks.constraints.warn_or_error")
+    def test_fires_structured_event(self, mock_warn_or_error):
+        with patch("dbt.adapters.databricks.constraints.ConstraintNotEnforced") as mock_event:
+            warn_constraint_not_enforced("primary_key")
+            mock_event.assert_called_once_with(
+                constraint="primary_key", adapter="DatabricksAdapter"
+            )
+            mock_warn_or_error.assert_called_once_with(mock_event.return_value)
 
 
 class TestParseConstraints:


### PR DESCRIPTION
<!-- Please review our pull request review process in CONTRIBUTING.md before your proceed. -->

Resolves #1196 

<!---
  Include the number of the issue addressed by this PR above if applicable.

  Example:
    resolves #1234

  Please review our pull request review process in CONTRIBUTING.md before your proceed.
-->

### Description
Emit the structured ConstraintNotEnforced event instead of a free-form exceptions.warn on the V1 constraint path, so warn_error_options (silence/warn/error) can target the unenforced primary_key/foreign_key warning — matching the V2 path. 
<!--- Describe the Pull Request here -->

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
- [ ] [Optional] I have run the `dbt-databricks-pr-ready` project skill for this PR and addressed its merge-readiness feedback
