### PR TITLE
Fix: metric_view replacement of an existing table or view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Fixes
 
-- Replace an existing table or view with a metric view using backup-and-create instead of `CREATE OR REPLACE VIEW ... WITH METRICS` (resolves [#1639](https://github.com/databricks/dbt-databricks/issues/1639))
+- Replace an existing table or view with a metric view using backup-and-create instead of `CREATE OR REPLACE VIEW ... WITH METRICS` ([#1640](https://github.com/databricks/dbt-databricks/pull/1640) resolves [#1639](https://github.com/databricks/dbt-databricks/issues/1639))
 
 ## dbt-databricks 1.12.4 (Aug 12, 2026)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## dbt-databricks 1.12.5 (TBD)
+
+### Fixes
+
+- Replace an existing table or view with a metric view using backup-and-create instead of `CREATE OR REPLACE VIEW ... WITH METRICS` (resolves [#1639](https://github.com/databricks/dbt-databricks/issues/1639))
+
 ## dbt-databricks 1.12.4 (Aug 12, 2026)
 
 ### Fixes

--- a/dbt/include/databricks/macros/relations/replace.sql
+++ b/dbt/include/databricks/macros/relations/replace.sql
@@ -9,9 +9,8 @@
     {{ exceptions.raise_not_implemented('get_replace_sql not implemented for target of table') }}
   {% endif %}
 
-  {#- Metric views always support CREATE OR REPLACE (no delta/file_format dependency) -#}
-  {#- Note: existing relation is typed as VIEW from DB, so check target for metric_view -#}
-  {% if target_relation.is_metric_view %}
+  {#- CREATE OR REPLACE VIEW WITH METRICS is same-type only; UC lists metric views as METRIC_VIEW. -#}
+  {% if target_relation.is_metric_view and existing_relation.is_metric_view %}
     {{ return(get_replace_metric_view_sql(target_relation, sql)) }}
   {% endif %}
 

--- a/docs/flow/replace_flow.md
+++ b/docs/flow/replace_flow.md
@@ -1,6 +1,6 @@
 # Replace Flow
 
-_Last updated: 2026-08-09_
+_Last updated: 2026-08-14_
 
 Shared decision tree used when view, materialized-view, streaming-table, or metric-view helpers must
 replace an existing relation. Table and incremental V2 use their dedicated
@@ -8,14 +8,15 @@ replace an existing relation. Table and incremental V2 use their dedicated
 `dbt/include/databricks/macros/relations/replace.sql`.
 
 `get_replace_sql` does not support a table target: that input raises a not-implemented compiler
-error before any replacement decision. Metric-view targets always use direct
-`CREATE OR REPLACE`, independently of `use_safer_relation_operations`.
+error before any replacement decision. Direct `CREATE OR REPLACE` for a metric-view target is used
+only when the existing relation is also a metric view; otherwise the incompatible-type fallback
+tree runs (table/view → `backup_and_create_in_place`, since metric views cannot be renamed).
 
 ```mermaid
 flowchart TD
     START[get_replace_sql] --> TABLE{Target is a table?}
     TABLE -- yes --> ERROR[Raise not-implemented compiler error]
-    TABLE -- no --> METRIC{Target is a metric view?}
+    TABLE -- no --> METRIC{Target and existing are both metric views?}
     METRIC -- yes --> METRICSQL[get_replace_metric_view_sql]
     METRIC -- no --> SAFE{use_safer_relation_operations?}
 

--- a/tests/functional/adapter/metric_views/fixtures.py
+++ b/tests/functional/adapter/metric_views/fixtures.py
@@ -114,3 +114,36 @@ measures:
   - name: order_count
     expr: count(1)
 """
+
+order_metrics_as_table = """
+{{ config(materialized='table') }}
+select * from {{ ref('source_orders') }}
+"""
+
+order_metrics_as_view = """
+{{ config(materialized='view') }}
+select * from {{ ref('source_orders') }}
+"""
+
+
+def query_uc_table_type(project, identifier: str):
+    row = project.run_sql(
+        "select table_type from `system`.`information_schema`.`tables`"
+        f" where table_catalog = '{project.database}'"
+        f" and table_schema = '{project.test_schema}'"
+        f" and table_name = '{identifier}'",
+        fetch="one",
+    )
+    return row[0] if row else None
+
+
+def query_schema_relation_names(project, like: str) -> list[str]:
+    rows = project.run_sql(
+        "select table_name from `system`.`information_schema`.`tables`"
+        f" where table_catalog = '{project.database}'"
+        f" and table_schema = '{project.test_schema}'"
+        f" and table_name like '{like}'"
+        " order by table_name",
+        fetch="all",
+    )
+    return [row[0] for row in rows]

--- a/tests/functional/adapter/metric_views/test_metric_view_materialization.py
+++ b/tests/functional/adapter/metric_views/test_metric_view_materialization.py
@@ -1,12 +1,18 @@
 import pytest
+from dbt.tests import util
 from dbt.tests.util import get_manifest, run_dbt
 
+from tests.functional.adapter.fixtures import RerunSafeMixin
 from tests.functional.adapter.metric_views.fixtures import (
     basic_metric_view,
     metric_view_bare_ref,
     metric_view_with_config,
     metric_view_with_filter,
     metric_view_with_tblproperties,
+    order_metrics_as_table,
+    order_metrics_as_view,
+    query_schema_relation_names,
+    query_uc_table_type,
     source_table,
 )
 
@@ -279,3 +285,78 @@ class TestMetricViewCreateTblProperties:
         )
         tblprops = {row[0]: row[1] for row in rows}
         assert tblprops.get("quality") == "gold"
+
+
+class _NonMetricToMetricViewBase(RerunSafeMixin):
+    expected_initial_type: str
+
+    @pytest.fixture(scope="class")
+    def relations_to_reset(self):
+        return ("source_orders", "order_metrics", "order_metrics__dbt_backup")
+
+    def _assert_metric_view_replaced_non_metric(self, project):
+        results = run_dbt(["run"])
+        assert len(results) == 2
+        assert all(result.status == "success" for result in results)
+        assert query_uc_table_type(project, "order_metrics") == self.expected_initial_type
+
+        row_count = project.run_sql(
+            f"select count(*) from {project.database}.{project.test_schema}.order_metrics",
+            fetch="one",
+        )[0]
+        assert row_count == 3
+
+        util.write_file(basic_metric_view, "models", "order_metrics.sql")
+        results = run_dbt(["run", "--models", "order_metrics"])
+        assert len(results) == 1
+        assert results[0].status == "success"
+
+        assert query_uc_table_type(project, "order_metrics") == "METRIC_VIEW"
+        assert query_schema_relation_names(project, "order_metrics%") == ["order_metrics"]
+
+        metric_view_name = f"{project.database}.{project.test_schema}.order_metrics"
+        query_result = project.run_sql(
+            f"""
+            select
+                status,
+                measure(total_orders) as order_count,
+                measure(total_revenue) as revenue
+            from {metric_view_name}
+            group by status
+            order by status
+            """,
+            fetch="all",
+        )
+        status_data = {row[0]: (row[1], row[2]) for row in query_result}
+        assert status_data["completed"] == (2, 250)
+        assert status_data["pending"] == (1, 200)
+
+
+@pytest.mark.skip_profile("databricks_cluster")
+class TestMetricViewReplacesTable(_NonMetricToMetricViewBase):
+    expected_initial_type = "MANAGED"
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "source_orders.sql": source_table,
+            "order_metrics.sql": order_metrics_as_table,
+        }
+
+    def test_table_is_replaced_by_metric_view(self, project):
+        self._assert_metric_view_replaced_non_metric(project)
+
+
+@pytest.mark.skip_profile("databricks_cluster")
+class TestMetricViewReplacesView(_NonMetricToMetricViewBase):
+    expected_initial_type = "VIEW"
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "source_orders.sql": source_table,
+            "order_metrics.sql": order_metrics_as_view,
+        }
+
+    def test_view_is_replaced_by_metric_view(self, project):
+        self._assert_metric_view_replaced_non_metric(project)


### PR DESCRIPTION
Resolves #1639

### Description

`materialized='metric_view'` failed when the target name already held a managed table or regular view. dbt emitted `CREATE OR REPLACE VIEW ... WITH METRICS`, and Databricks rejected that with `EXPECT_VIEW_NOT_TABLE.NO_ALTERNATIVE` / SQLSTATE `42809`. The original relation was left in place.

The shared replace path now uses `CREATE OR REPLACE` only when both the existing relation and the target are metric views. A table or view at the target name goes through backup-and-create: rename the existing relation, create the metric view, then drop the backup.

First-time create, unchanged reruns, in-place updates, and metric-view-to-metric-view replace are unchanged.

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.

### Test plan

- [x] `TestMetricViewReplacesTable` / `TestMetricViewReplacesView` failed on unfixed code with `42809`, then passed after the fix
- [x] Full `tests/functional/adapter/metric_views/` suite (22 passed on `databricks_uc_sql_endpoint`)