### PR TITLE
fix: interpolate lazily-formatted connector logs in DbtCoreHandler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Fixes
 
-- Interpolate lazily-formatted `databricks.sql` log records when mirroring them into dbt logs ([#1637](https://github.com/databricks/dbt-databricks/issues/1637))
+- Interpolate lazily-formatted `databricks.sql` log records when mirroring them into dbt logs ([#1642](https://github.com/databricks/dbt-databricks/pull/1642) resolves [#1637](https://github.com/databricks/dbt-databricks/issues/1637))
 
 ## dbt-databricks 1.12.4 (Aug 12, 2026)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## dbt-databricks 1.12.5 (TBD)
+
+### Fixes
+
+- Interpolate lazily-formatted `databricks.sql` log records when mirroring them into dbt logs ([#1637](https://github.com/databricks/dbt-databricks/issues/1637))
+
 ## dbt-databricks 1.12.4 (Aug 12, 2026)
 
 ### Fixes

--- a/dbt/adapters/databricks/logging.py
+++ b/dbt/adapters/databricks/logging.py
@@ -17,7 +17,7 @@ class DbtCoreHandler(Handler):
         # record.levelname will be debug, info, warning, error, or critical
         # these map 1-to-1 with methods of the AdapterLogger
         log_func = getattr(self.logger, record.levelname.lower())
-        log_func(record.msg)
+        log_func(record.getMessage())
 
 
 dbt_adapter_logger = AdapterLogger("databricks-sql-connector")

--- a/tests/unit/events/test_logging.py
+++ b/tests/unit/events/test_logging.py
@@ -6,14 +6,14 @@ import pytest
 from dbt.adapters.databricks.logging import DbtCoreHandler
 
 
-def _record(level, msg):
+def _record(level, msg, args=None):
     return stdlib_logging.LogRecord(
         name="databricks.sql",
         level=level,
         pathname=__file__,
         lineno=1,
         msg=msg,
-        args=None,
+        args=args,
         exc_info=None,
     )
 
@@ -34,3 +34,19 @@ class TestDbtCoreHandler:
         handler.emit(_record(level, msg))
 
         getattr(dbt_logger, method).assert_called_once_with(msg)
+
+    def test_emit__interpolates_lazy_percent_args(self):
+        dbt_logger = Mock()
+        handler = DbtCoreHandler(level=stdlib_logging.DEBUG, dbt_logger=dbt_logger)
+
+        handler.emit(
+            _record(
+                stdlib_logging.WARNING,
+                "Token exchange failed, using external token: %s",
+                args=("access_token",),
+            )
+        )
+
+        dbt_logger.warning.assert_called_once_with(
+            "Token exchange failed, using external token: access_token"
+        )


### PR DESCRIPTION
Resolves #1637

## Summary
- `DbtCoreHandler.emit` now calls `record.getMessage()` so lazily formatted `databricks.sql` log lines keep their interpolated arguments instead of arriving in dbt with literal `%s`.

## Test plan
- [x] `hatch run pytest tests/unit/events/test_logging.py -v` (new interpolation case failed on `record.msg`, passed after the change)
- [x] Live warehouse `dbt run` of a `select 1` model with connector logs at INFO: pre-fix `Successfully opened session %s`, post-fix the actual session UUID