### PR TITLE
fix: skip unnecessary constraint metadata queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Fixes
 
+- Skip unnecessary Unity Catalog constraint metadata queries for incremental models without enforced contracts ([#1643](https://github.com/databricks/dbt-databricks/pull/1643) resolves [#1641](https://github.com/databricks/dbt-databricks/issues/1641))
 - Recreate materialized views when query schema drifts, honoring `on_configuration_change` ([#1621](https://github.com/databricks/dbt-databricks/pull/1621) resolves [#1359](https://github.com/databricks/dbt-databricks/issues/1359))
 - Warn when documented columns are missing from V1 and V2 table and incremental models, and honor `persist_docs.columns` for V2 column comments ([#1563](https://github.com/databricks/dbt-databricks/pull/1563) ports [dbt-adapters#1684](https://github.com/dbt-labs/dbt-adapters/pull/1684), resolving [dbt-adapters#1690](https://github.com/dbt-labs/dbt-adapters/issues/1690)).
 

--- a/dbt/adapters/databricks/impl.py
+++ b/dbt/adapters/databricks/impl.py
@@ -81,6 +81,7 @@ from dbt.adapters.databricks.relation_configs.column_tags import (
     ColumnTagsConfig,
     ColumnTagsProcessor,
 )
+from dbt.adapters.databricks.relation_configs.constraints import ConstraintsProcessor
 from dbt.adapters.databricks.relation_configs.incremental import IncrementalTableConfig
 from dbt.adapters.databricks.relation_configs.materialized_view import (
     MaterializedViewConfig,
@@ -1419,15 +1420,26 @@ class IncrementalTableAPI(RelationAPIBase[IncrementalTableConfig]):
                 results["column_masks"] = relation_metadata.column_masks
                 results["row_filters"] = relation_metadata.row_filters
             else:
-                results["non_null_constraint_columns"] = adapter.execute_macro(
-                    "fetch_non_null_constraint_columns", kwargs=kwargs
+                constraint_config = (
+                    model_config.config.get(ConstraintsProcessor.name) if model_config else None
                 )
-                results["primary_key_constraints"] = adapter.execute_macro(
-                    "fetch_primary_key_constraints", kwargs=kwargs
-                )
-                results["foreign_key_constraints"] = adapter.execute_macro(
-                    "fetch_foreign_key_constraints", kwargs=kwargs
-                )
+                if (
+                    constraint_config is None
+                    or constraint_config.requires_server_metadata_for_diff()
+                ):
+                    results["non_null_constraint_columns"] = adapter.execute_macro(
+                        "fetch_non_null_constraint_columns", kwargs=kwargs
+                    )
+                    results["primary_key_constraints"] = adapter.execute_macro(
+                        "fetch_primary_key_constraints", kwargs=kwargs
+                    )
+                    results["foreign_key_constraints"] = adapter.execute_macro(
+                        "fetch_foreign_key_constraints", kwargs=kwargs
+                    )
+                else:
+                    results["non_null_constraint_columns"] = None
+                    results["primary_key_constraints"] = None
+                    results["foreign_key_constraints"] = None
                 results["column_masks"] = adapter.execute_macro("fetch_column_masks", kwargs=kwargs)
                 results["row_filters"] = adapter.execute_macro("fetch_row_filters", kwargs=kwargs)
 

--- a/dbt/adapters/databricks/relation_configs/constraints.py
+++ b/dbt/adapters/databricks/relation_configs/constraints.py
@@ -259,4 +259,5 @@ class ConstraintsProcessor(DatabricksComponentProcessor[ConstraintsConfig]):
         return ConstraintsConfig(
             set_non_nulls=set(non_nulls),
             set_constraints=set(other_constraints),
+            contract_enforced=True,
         )

--- a/dbt/adapters/databricks/relation_configs/constraints.py
+++ b/dbt/adapters/databricks/relation_configs/constraints.py
@@ -27,6 +27,10 @@ class ConstraintsConfig(DatabricksComponentConfig):
     unset_non_nulls: set[str] = set()
     set_constraints: set[TypedConstraint]
     unset_constraints: set[TypedConstraint] = set()
+    contract_enforced: bool = True
+
+    def requires_server_metadata_for_diff(self) -> bool:
+        return self.contract_enforced
 
     def normalize_expression(self, expression: Optional[str]) -> str:
         if expression:
@@ -232,6 +236,7 @@ class ConstraintsProcessor(DatabricksComponentProcessor[ConstraintsConfig]):
             return ConstraintsConfig(
                 set_non_nulls=set(),
                 set_constraints=set(),
+                contract_enforced=False,
             )
 
         constraints = getattr(relation_config, "constraints", [])

--- a/docs/flow/incremental_flow.md
+++ b/docs/flow/incremental_flow.md
@@ -1,6 +1,6 @@
 # Incremental Flow
 
-_Last updated: 2026-08-10_
+_Last updated: 2026-08-19_
 
 > Two diagrams follow: **Existing** is the default path, **New** is used when the
 > `use_materialization_v2` behavior flag is enabled. See [flow/README.md](README.md) for what the
@@ -88,4 +88,6 @@ the incremental branch even when its configuration changes. Safe staging is sele
 `use_safer_relation_operations` is enabled and the existing relation can be renamed; otherwise a
 non-replaceable relation or shallow clone is dropped before `create_table_at`. Unlike the Existing
 path, V2 does not call `persist_docs` — relation and column comments are handled via
-`apply_config_changeset` or the create/insert path.
+`apply_config_changeset` or the create/insert path. On the fallback metadata path, the three
+constraint-specific `information_schema` queries run only when the model has an enforced contract;
+the consolidated `DESCRIBE TABLE EXTENDED AS JSON` path is unchanged.

--- a/docs/flow/incremental_flow.md
+++ b/docs/flow/incremental_flow.md
@@ -1,6 +1,6 @@
 # Incremental Flow
 
-_Last updated: 2026-08-19_
+_Last updated: 2026-08-20_
 
 > Two diagrams follow: **Existing** is the default path, **New** is used when the
 > `use_materialization_v2` behavior flag is enabled. See [flow/README.md](README.md) for what the
@@ -47,6 +47,9 @@ flowchart LR
 
 For an ordinary existing table, configuration changes are detected before the temporary relation
 is built but are applied only after the incremental SQL runs. This ordering differs from V2.
+On the fallback metadata path, V1 and V2 share `IncrementalTableAPI._describe_relation`: the three
+constraint-specific `information_schema` queries run only when the model has an enforced contract;
+the consolidated `DESCRIBE TABLE EXTENDED AS JSON` path is unchanged.
 
 ## New Incremental Flow
 
@@ -88,6 +91,4 @@ the incremental branch even when its configuration changes. Safe staging is sele
 `use_safer_relation_operations` is enabled and the existing relation can be renamed; otherwise a
 non-replaceable relation or shallow clone is dropped before `create_table_at`. Unlike the Existing
 path, V2 does not call `persist_docs` — relation and column comments are handled via
-`apply_config_changeset` or the create/insert path. On the fallback metadata path, the three
-constraint-specific `information_schema` queries run only when the model has an enforced contract;
-the consolidated `DESCRIBE TABLE EXTENDED AS JSON` path is unchanged.
+`apply_config_changeset` or the create/insert path.

--- a/tests/functional/adapter/incremental/fixtures.py
+++ b/tests/functional/adapter/incremental/fixtures.py
@@ -127,6 +127,30 @@ models:
           classification: internal
 """
 
+record_constraint_fetches_macros = """
+{% macro record_constraint_fetch(relation, fetch_name) %}
+  {% call statement('record_' ~ fetch_name) %}
+    insert into {{ relation.database }}.{{ relation.schema }}.metadata_constraint_fetches
+    values ('{{ fetch_name }}')
+  {% endcall %}
+{% endmacro %}
+
+{% macro fetch_non_null_constraint_columns(relation) %}
+  {{ record_constraint_fetch(relation, 'non_null') }}
+  {% do return(run_query(fetch_non_null_constraint_columns_sql(relation))) %}
+{% endmacro %}
+
+{% macro fetch_primary_key_constraints(relation) %}
+  {{ record_constraint_fetch(relation, 'primary_key') }}
+  {% do return(run_query(fetch_primary_key_constraints_sql(relation))) %}
+{% endmacro %}
+
+{% macro fetch_foreign_key_constraints(relation) %}
+  {{ record_constraint_fetch(relation, 'foreign_key') }}
+  {% do return(run_query(fetch_foreign_key_constraints_sql(relation))) %}
+{% endmacro %}
+"""
+
 tblproperties_a = """
 version: 2
 

--- a/tests/functional/adapter/incremental/test_incremental_metadata_fetch_skips.py
+++ b/tests/functional/adapter/incremental/test_incremental_metadata_fetch_skips.py
@@ -11,6 +11,15 @@ from tests.functional.adapter.incremental import fixtures
 @pytest.mark.skip_profile("databricks_cluster")
 class TestIncrementalMetadataFetchSkips:
     @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {
+            "flags": {
+                "use_materialization_v2": True,
+                "use_describe_as_json_for_relation_metadata": False,
+            }
+        }
+
+    @pytest.fixture(scope="class")
     def models(self):
         return {
             "metadata_fetch_incremental.sql": fixtures.metadata_fetch_incremental_sql,
@@ -19,13 +28,25 @@ class TestIncrementalMetadataFetchSkips:
 
     @pytest.fixture(scope="class")
     def macros(self):
-        return {"fail_if_tag_fetch_called.sql": fail_if_tag_and_column_tag_fetch_called_macros}
+        return {
+            "fail_if_tag_fetch_called.sql": fail_if_tag_and_column_tag_fetch_called_macros,
+            "record_constraint_fetches.sql": fixtures.record_constraint_fetches_macros,
+        }
 
-    def test_second_incremental_run_succeeds_without_tag_fetches(self, project):
+    def test_second_incremental_run_succeeds_without_unneeded_metadata_fetches(self, project):
         # The first run creates the relation; the second run exercises the existing-relation
         # path where adapter.get_relation_config() may attempt metadata fetches.
         util.run_dbt(["run"])
+        project.run_sql("create or replace table metadata_constraint_fetches (fetch_name string)")
         util.run_dbt(["run"])
+
+        fetches = project.run_sql(
+            "select fetch_name from metadata_constraint_fetches order by fetch_name",
+            fetch="all",
+        )
+        rows = project.run_sql("select id from metadata_fetch_incremental", fetch="all")
+        assert fetches == []
+        assert rows == [(1,)]
 
 
 @pytest.mark.skip_profile("databricks_cluster")

--- a/tests/functional/adapter/incremental/test_incremental_metadata_fetch_skips.py
+++ b/tests/functional/adapter/incremental/test_incremental_metadata_fetch_skips.py
@@ -8,17 +8,7 @@ from tests.functional.adapter.fixtures import (
 from tests.functional.adapter.incremental import fixtures
 
 
-@pytest.mark.skip_profile("databricks_cluster")
-class TestIncrementalMetadataFetchSkips:
-    @pytest.fixture(scope="class")
-    def project_config_update(self):
-        return {
-            "flags": {
-                "use_materialization_v2": True,
-                "use_describe_as_json_for_relation_metadata": False,
-            }
-        }
-
+class IncrementalMetadataFetchSkipsMixin:
     @pytest.fixture(scope="class")
     def models(self):
         return {
@@ -47,6 +37,30 @@ class TestIncrementalMetadataFetchSkips:
         rows = project.run_sql("select id from metadata_fetch_incremental", fetch="all")
         assert fetches == []
         assert rows == [(1,)]
+
+
+@pytest.mark.skip_profile("databricks_cluster")
+class TestIncrementalMetadataFetchSkips(IncrementalMetadataFetchSkipsMixin):
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {
+            "flags": {
+                "use_materialization_v2": False,
+                "use_describe_as_json_for_relation_metadata": False,
+            }
+        }
+
+
+@pytest.mark.skip_profile("databricks_cluster")
+class TestIncrementalMetadataFetchSkipsV2(IncrementalMetadataFetchSkipsMixin):
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {
+            "flags": {
+                "use_materialization_v2": True,
+                "use_describe_as_json_for_relation_metadata": False,
+            }
+        }
 
 
 @pytest.mark.skip_profile("databricks_cluster")

--- a/tests/unit/record/test_record_types.py
+++ b/tests/unit/record/test_record_types.py
@@ -439,6 +439,7 @@ class TestRecordTypes:
                         "columns": [],
                     }
                 ],
+                "contract_enforced": True,
             },
             "row_filter": {
                 "function": "cat.sch.filt",

--- a/tests/unit/relation_configs/test_constraint.py
+++ b/tests/unit/relation_configs/test_constraint.py
@@ -148,7 +148,11 @@ class TestConstraintsProcessor:
             )
         ]
         spec = ConstraintsProcessor.from_relation_config(model)
-        assert spec == ConstraintsConfig(set_non_nulls=set(), set_constraints=set())
+        assert spec == ConstraintsConfig(
+            set_non_nulls=set(),
+            set_constraints=set(),
+            contract_enforced=False,
+        )
 
     def test_from_relation_config__with_check_constraint(self):
         model = self._make_model_with_contract(
@@ -247,6 +251,21 @@ class TestConstraintsProcessor:
 
 
 class TestConstraintsConfig:
+    def test_requires_server_metadata_for_diff(self):
+        enforced = ConstraintsConfig(
+            set_non_nulls=set(),
+            set_constraints=set(),
+            contract_enforced=True,
+        )
+        unenforced = ConstraintsConfig(
+            set_non_nulls=set(),
+            set_constraints=set(),
+            contract_enforced=False,
+        )
+
+        assert enforced.requires_server_metadata_for_diff() is True
+        assert unenforced.requires_server_metadata_for_diff() is False
+
     def test_get_diff__empty_and_some_exist(self):
         config = ConstraintsConfig(set_non_nulls=set(), set_constraints=set())
         other = ConstraintsConfig(

--- a/tests/unit/relation_configs/test_constraint.py
+++ b/tests/unit/relation_configs/test_constraint.py
@@ -133,7 +133,11 @@ class TestConstraintsProcessor:
     def test_from_relation_config__without_constraints(self):
         model = self._make_model_with_contract(constraints=[], columns={})
         spec = ConstraintsProcessor.from_relation_config(model)
-        assert spec == ConstraintsConfig(set_non_nulls=set(), set_constraints=set())
+        assert spec == ConstraintsConfig(
+            set_non_nulls=set(),
+            set_constraints=set(),
+            contract_enforced=True,
+        )
 
     def test_from_relation_config__without_contract(self):
         """Constraints should be empty when contract is not enforced (issue #1342)."""

--- a/tests/unit/test_adapter.py
+++ b/tests/unit/test_adapter.py
@@ -1718,6 +1718,10 @@ class TestDescribeRelationMetadataFetchPlanning:
         assert results["non_null_constraint_columns"] == "fetch_non_null_constraint_columns_result"
         assert results["primary_key_constraints"] == "fetch_primary_key_constraints_result"
         assert results["foreign_key_constraints"] == "fetch_foreign_key_constraints_result"
+        called_macro_names = self._called_macro_names(adapter)
+        assert "fetch_non_null_constraint_columns" in called_macro_names
+        assert "fetch_primary_key_constraints" in called_macro_names
+        assert "fetch_foreign_key_constraints" in called_macro_names
 
     def test_incremental_describe_relation_skips_tag_queries_for_hive_metastore(self):
         adapter = self._create_adapter()

--- a/tests/unit/test_adapter.py
+++ b/tests/unit/test_adapter.py
@@ -44,6 +44,10 @@ from dbt.adapters.databricks.relation_configs.column_tags import (
     ColumnTagsConfig,
     ColumnTagsProcessor,
 )
+from dbt.adapters.databricks.relation_configs.constraints import (
+    ConstraintsConfig,
+    ConstraintsProcessor,
+)
 from dbt.adapters.databricks.relation_configs.incremental import IncrementalTableConfig
 from dbt.adapters.databricks.relation_configs.materialized_view import MaterializedViewConfig
 from dbt.adapters.databricks.relation_configs.streaming_table import StreamingTableConfig
@@ -1550,11 +1554,17 @@ class TestDescribeRelationMetadataFetchPlanning:
     def _create_incremental_config(
         tags: dict[str, str] | None = None,
         column_tags: dict[str, dict[str, str]] | None = None,
+        contract_enforced: bool = True,
     ) -> IncrementalTableConfig:
         return IncrementalTableConfig(
             config={
                 TagsProcessor.name: TagsConfig(set_tags=tags or {}),
                 ColumnTagsProcessor.name: ColumnTagsConfig(set_column_tags=column_tags or {}),
+                ConstraintsProcessor.name: ConstraintsConfig(
+                    set_non_nulls=set(),
+                    set_constraints=set(),
+                    contract_enforced=contract_enforced,
+                ),
             }
         )
 
@@ -1675,6 +1685,39 @@ class TestDescribeRelationMetadataFetchPlanning:
         called_macro_names = self._called_macro_names(adapter)
         assert "fetch_tags" in called_macro_names
         assert "fetch_column_tags" in called_macro_names
+        assert "fetch_non_null_constraint_columns" in called_macro_names
+        assert "fetch_primary_key_constraints" in called_macro_names
+        assert "fetch_foreign_key_constraints" in called_macro_names
+
+    def test_incremental_describe_relation_skips_constraint_queries_without_enforced_contract(
+        self,
+    ):
+        adapter = self._create_adapter()
+        relation = self._create_incremental_relation()
+        relation_config = self._create_incremental_config(contract_enforced=False)
+
+        results = IncrementalTableAPI._describe_relation(adapter, relation, relation_config)
+
+        assert results["non_null_constraint_columns"] is None
+        assert results["primary_key_constraints"] is None
+        assert results["foreign_key_constraints"] is None
+        assert results["column_masks"] == "fetch_column_masks_result"
+        assert results["row_filters"] == "fetch_row_filters_result"
+        called_macro_names = self._called_macro_names(adapter)
+        assert "fetch_non_null_constraint_columns" not in called_macro_names
+        assert "fetch_primary_key_constraints" not in called_macro_names
+        assert "fetch_foreign_key_constraints" not in called_macro_names
+
+    def test_incremental_describe_relation_fetches_constraint_queries_with_enforced_contract(self):
+        adapter = self._create_adapter()
+        relation = self._create_incremental_relation()
+        relation_config = self._create_incremental_config(contract_enforced=True)
+
+        results = IncrementalTableAPI._describe_relation(adapter, relation, relation_config)
+
+        assert results["non_null_constraint_columns"] == "fetch_non_null_constraint_columns_result"
+        assert results["primary_key_constraints"] == "fetch_primary_key_constraints_result"
+        assert results["foreign_key_constraints"] == "fetch_foreign_key_constraints_result"
 
     def test_incremental_describe_relation_skips_tag_queries_for_hive_metastore(self):
         adapter = self._create_adapter()


### PR DESCRIPTION
Resolves #1641

### Description

For incremental models without enforced contracts, skip the three separate fallback `information_schema` queries for non-null, primary-key, and foreign-key metadata during relation-config reconciliation.

Enforced contracts retain the existing metadata reads. The consolidated `DESCRIBE TABLE EXTENDED AS JSON` path and metadata reads for tags, masks, and row filters are unchanged. Because V1 and V2 incremental materializations share this reconciliation path, the fix applies to both.

### Testing

- `hatch run unit` — 1358 passed, 4 skipped
- `hatch run pytest tests/functional/adapter/incremental/test_incremental_metadata_fetch_skips.py --profile databricks_uc_sql_endpoint -v` — 3 passed
- `hatch run pytest tests/functional/adapter/constraints/test_constraints.py::TestIncrementalContractOffPreservesConstraints --profile databricks_uc_sql_endpoint -v` — 1 passed
- `hatch run pre-commit run --all-files` — passed

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
- [ ] [Optional] I have run the `dbt-databricks-pr-ready` project skill for this PR and addressed its merge-readiness feedback