### PR TITLE
perf: skip constraint catalog lookups when the model contract is not enforced

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 - Replace an existing table or view with a metric view using backup-and-create instead of `CREATE OR REPLACE VIEW ... WITH METRICS` ([#1640](https://github.com/databricks/dbt-databricks/pull/1640) resolves [#1639](https://github.com/databricks/dbt-databricks/issues/1639))
 - Interpolate lazily-formatted `databricks.sql` log records when mirroring them into dbt logs ([#1642](https://github.com/databricks/dbt-databricks/pull/1642) resolves [#1637](https://github.com/databricks/dbt-databricks/issues/1637))
 
+### Under the Hood
+
+- Skip the `information_schema` constraint metadata fetches for models whose contract is not enforced, since the result cannot be applied. (thanks @TangoEnSkai!) ([#1646](https://github.com/databricks/dbt-databricks/pull/1646) resolves [#1641](https://github.com/databricks/dbt-databricks/issues/1641))
+
 ## dbt-databricks 1.12.4 (Aug 12, 2026)
 
 ### Fixes

--- a/dbt/adapters/databricks/impl.py
+++ b/dbt/adapters/databricks/impl.py
@@ -81,6 +81,7 @@ from dbt.adapters.databricks.relation_configs.column_tags import (
     ColumnTagsConfig,
     ColumnTagsProcessor,
 )
+from dbt.adapters.databricks.relation_configs.constraints import ConstraintsProcessor
 from dbt.adapters.databricks.relation_configs.incremental import IncrementalTableConfig
 from dbt.adapters.databricks.relation_configs.materialized_view import (
     MaterializedViewConfig,
@@ -1419,15 +1420,29 @@ class IncrementalTableAPI(RelationAPIBase[IncrementalTableConfig]):
                 results["column_masks"] = relation_metadata.column_masks
                 results["row_filters"] = relation_metadata.row_filters
             else:
-                results["non_null_constraint_columns"] = adapter.execute_macro(
-                    "fetch_non_null_constraint_columns", kwargs=kwargs
+                # To be backward compatible model_config can be None. In that case, constraints
+                # should be fetched to maintain backward compatibility.
+                constraint_config = (
+                    model_config.config.get(ConstraintsProcessor.name) if model_config else None
                 )
-                results["primary_key_constraints"] = adapter.execute_macro(
-                    "fetch_primary_key_constraints", kwargs=kwargs
-                )
-                results["foreign_key_constraints"] = adapter.execute_macro(
-                    "fetch_foreign_key_constraints", kwargs=kwargs
-                )
+                if (
+                    constraint_config is None
+                    or constraint_config.requires_server_metadata_for_diff()
+                ):
+                    results["non_null_constraint_columns"] = adapter.execute_macro(
+                        "fetch_non_null_constraint_columns", kwargs=kwargs
+                    )
+                    results["primary_key_constraints"] = adapter.execute_macro(
+                        "fetch_primary_key_constraints", kwargs=kwargs
+                    )
+                    results["foreign_key_constraints"] = adapter.execute_macro(
+                        "fetch_foreign_key_constraints", kwargs=kwargs
+                    )
+                else:
+                    results["non_null_constraint_columns"] = None
+                    results["primary_key_constraints"] = None
+                    results["foreign_key_constraints"] = None
+
                 results["column_masks"] = adapter.execute_macro("fetch_column_masks", kwargs=kwargs)
                 results["row_filters"] = adapter.execute_macro("fetch_row_filters", kwargs=kwargs)
 

--- a/dbt/adapters/databricks/relation_configs/constraints.py
+++ b/dbt/adapters/databricks/relation_configs/constraints.py
@@ -27,6 +27,7 @@ class ConstraintsConfig(DatabricksComponentConfig):
     unset_non_nulls: set[str] = set()
     set_constraints: set[TypedConstraint]
     unset_constraints: set[TypedConstraint] = set()
+    contract_enforced: bool = True
 
     def normalize_expression(self, expression: Optional[str]) -> str:
         if expression:
@@ -113,6 +114,15 @@ class ConstraintsConfig(DatabricksComponentConfig):
                 unset_constraints=constraints_to_unset,
             )
         return None
+
+    def requires_server_metadata_for_diff(self) -> bool:
+        """
+        Indicates whether server metadata is required to compute the diff for this component.
+        """
+        # Both consumers of a constraint diff (the incremental and table materializations) apply
+        # it only when the contract is enforced, so without enforcement the catalog lookups the
+        # diff needs cannot change what dbt does.
+        return self.contract_enforced
 
 
 class ConstraintsProcessor(DatabricksComponentProcessor[ConstraintsConfig]):
@@ -232,6 +242,7 @@ class ConstraintsProcessor(DatabricksComponentProcessor[ConstraintsConfig]):
             return ConstraintsConfig(
                 set_non_nulls=set(),
                 set_constraints=set(),
+                contract_enforced=False,
             )
 
         constraints = getattr(relation_config, "constraints", [])

--- a/tests/unit/record/test_record_types.py
+++ b/tests/unit/record/test_record_types.py
@@ -439,6 +439,7 @@ class TestRecordTypes:
                         "columns": [],
                     }
                 ],
+                "contract_enforced": True,
             },
             "row_filter": {
                 "function": "cat.sch.filt",

--- a/tests/unit/relation_configs/test_constraint.py
+++ b/tests/unit/relation_configs/test_constraint.py
@@ -148,7 +148,19 @@ class TestConstraintsProcessor:
             )
         ]
         spec = ConstraintsProcessor.from_relation_config(model)
-        assert spec == ConstraintsConfig(set_non_nulls=set(), set_constraints=set())
+        assert spec == ConstraintsConfig(
+            set_non_nulls=set(), set_constraints=set(), contract_enforced=False
+        )
+        assert spec.requires_server_metadata_for_diff() is False
+
+    def test_from_relation_config__with_contract_requires_server_metadata(self):
+        model = self._make_model_with_contract(constraints=[], columns={})
+        spec = ConstraintsProcessor.from_relation_config(model)
+        assert spec.requires_server_metadata_for_diff() is True
+
+    def test_from_relation_results__requires_server_metadata(self):
+        spec = ConstraintsProcessor.from_relation_results({})
+        assert spec.requires_server_metadata_for_diff() is True
 
     def test_from_relation_config__with_check_constraint(self):
         model = self._make_model_with_contract(

--- a/tests/unit/test_adapter.py
+++ b/tests/unit/test_adapter.py
@@ -44,6 +44,10 @@ from dbt.adapters.databricks.relation_configs.column_tags import (
     ColumnTagsConfig,
     ColumnTagsProcessor,
 )
+from dbt.adapters.databricks.relation_configs.constraints import (
+    ConstraintsConfig,
+    ConstraintsProcessor,
+)
 from dbt.adapters.databricks.relation_configs.incremental import IncrementalTableConfig
 from dbt.adapters.databricks.relation_configs.materialized_view import MaterializedViewConfig
 from dbt.adapters.databricks.relation_configs.streaming_table import StreamingTableConfig
@@ -1550,13 +1554,19 @@ class TestDescribeRelationMetadataFetchPlanning:
     def _create_incremental_config(
         tags: dict[str, str] | None = None,
         column_tags: dict[str, dict[str, str]] | None = None,
+        contract_enforced: bool | None = None,
     ) -> IncrementalTableConfig:
-        return IncrementalTableConfig(
-            config={
-                TagsProcessor.name: TagsConfig(set_tags=tags or {}),
-                ColumnTagsProcessor.name: ColumnTagsConfig(set_column_tags=column_tags or {}),
-            }
-        )
+        config = {
+            TagsProcessor.name: TagsConfig(set_tags=tags or {}),
+            ColumnTagsProcessor.name: ColumnTagsConfig(set_column_tags=column_tags or {}),
+        }
+        if contract_enforced is not None:
+            config[ConstraintsProcessor.name] = ConstraintsConfig(
+                set_non_nulls=set(),
+                set_constraints=set(),
+                contract_enforced=contract_enforced,
+            )
+        return IncrementalTableConfig(config=config)
 
     @staticmethod
     def _create_view_config(
@@ -1693,6 +1703,48 @@ class TestDescribeRelationMetadataFetchPlanning:
         assert "fetch_column_tags" not in called_macro_names
         assert "fetch_tbl_properties" in called_macro_names
         assert DESCRIBE_TABLE_EXTENDED_MACRO_NAME in called_macro_names
+
+    def test_incremental_describe_relation_skips_constraint_queries_without_contract(self):
+        adapter = self._create_adapter()
+        relation = self._create_incremental_relation()
+        relation_config = self._create_incremental_config(contract_enforced=False)
+
+        results = IncrementalTableAPI._describe_relation(adapter, relation, relation_config)
+
+        assert results["non_null_constraint_columns"] is None
+        assert results["primary_key_constraints"] is None
+        assert results["foreign_key_constraints"] is None
+        called_macro_names = self._called_macro_names(adapter)
+        assert "fetch_non_null_constraint_columns" not in called_macro_names
+        assert "fetch_primary_key_constraints" not in called_macro_names
+        assert "fetch_foreign_key_constraints" not in called_macro_names
+        assert "fetch_column_masks" in called_macro_names
+        assert "fetch_row_filters" in called_macro_names
+
+    def test_incremental_describe_relation_fetches_constraint_queries_with_contract(self):
+        adapter = self._create_adapter()
+        relation = self._create_incremental_relation()
+        relation_config = self._create_incremental_config(contract_enforced=True)
+
+        results = IncrementalTableAPI._describe_relation(adapter, relation, relation_config)
+
+        assert results["primary_key_constraints"] == "fetch_primary_key_constraints_result"
+        called_macro_names = self._called_macro_names(adapter)
+        assert "fetch_non_null_constraint_columns" in called_macro_names
+        assert "fetch_primary_key_constraints" in called_macro_names
+        assert "fetch_foreign_key_constraints" in called_macro_names
+
+    def test_incremental_describe_relation_fetches_constraint_queries_when_config_is_none(self):
+        adapter = self._create_adapter()
+        relation = self._create_incremental_relation()
+
+        results = IncrementalTableAPI._describe_relation(adapter, relation, None)
+
+        assert results["primary_key_constraints"] == "fetch_primary_key_constraints_result"
+        called_macro_names = self._called_macro_names(adapter)
+        assert "fetch_non_null_constraint_columns" in called_macro_names
+        assert "fetch_primary_key_constraints" in called_macro_names
+        assert "fetch_foreign_key_constraints" in called_macro_names
 
     def test_view_describe_relation_skips_tag_query_without_tags(self):
         adapter = self._create_adapter()


### PR DESCRIPTION
Resolves #1641

### Description

**Context**

`IncrementalTableAPI._describe_relation` unconditionally issues three
`information_schema` lookups per relation (`fetch_non_null_constraint_columns`,
`fetch_primary_key_constraints`, `fetch_foreign_key_constraints`) to build the
server side of the constraint diff. Both consumers of that diff already refuse
to act on it unless the contract is enforced:

- `materializations/incremental/incremental.sql:211` — `{% if constraints and contract_config and contract_config.enforced ... %}`
- `relations/table/alter.sql:33` — `{% if constraints and contract_config and contract_config.enforced %}`

and `ConstraintsProcessor.from_relation_config` already returns an empty config
when the contract is not enforced (#1342). So for a model without
`contract.enforced: true` those lookups are computed and then discarded. In the
reported project 255 of 303 models set `primary_key` for documentation only,
which made this a meaningful share of that account's `information_schema`
traffic — enough to contribute to
`UC_INFORMATION_SCHEMA_PER_METASTORE_DB_RATE_LIMIT_EXCEEDED` on a shared
metastore.

**What**

- `ConstraintsConfig` carries `contract_enforced` and implements
  `requires_server_metadata_for_diff()`, the same opt-out hook `TagsConfig` and
  `ColumnTagsConfig` already use.
- `ConstraintsProcessor.from_relation_config` sets it to `False` on the
  not-enforced path it already short-circuits.
- `IncrementalTableAPI._describe_relation` skips the three constraint fetches
  when the model config says server metadata cannot affect the diff, mirroring
  the existing tag-fetch gating (including `model_config is None` still
  fetching, for backward compatibility).

**Why this is behavior-preserving**

With the contract off, the model side of the diff is empty and the server side
is now empty too, so `get_diff` returns `None` instead of an
`unset_constraints` set that both materializations were already dropping on the
floor. Nothing that reaches a `statement()` call changes. The
`DESCRIBE AS JSON` path is untouched: it derives constraints from a single
metadata call that is needed for column masks and row filters anyway, so there
is nothing to save there.

The `contract_enforced=True` default means every other construction site —
including `from_relation_results` — keeps today's behavior. When the contract
*is* enforced, the lookups still run, so removing a constraint from an enforced
model still produces the `ALTER ... DROP CONSTRAINT`.

**Testing**

- `hatch run unit` equivalent: 1348 passed, 4 skipped.
- `pre-commit run --all-files`: all hooks pass.
- New unit tests in `tests/unit/test_adapter.py` cover the three
  `_describe_relation` cases (contract off / contract on / `model_config` is
  `None`); the "contract off" test fails against `main` and passes with this
  change.
- New unit tests in `tests/unit/relation_configs/test_constraint.py` cover
  `requires_server_metadata_for_diff()` from both the model and results sides.
- No functional test: the change is a query-planning optimization with no
  server-observable effect, and per `docs/testing.md` functional tests must
  assert server-observable state. The user-visible behavior it must not break —
  constraints not applied without a contract — is already covered by
  `TestPrimaryKeyNotAppliedWithoutContractV1/V2` in
  `tests/functional/adapter/incremental/test_incremental_constraints.py`
  (the #1342 regression tests), which exercise exactly this path. I do not have
  a Databricks workspace, so I have not run the functional suite.

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
- [ ] [Optional] I have run the `dbt-databricks-pr-ready` project skill for this PR and addressed its merge-readiness feedback
