### PR TITLE
feat: add opt-in POST_PARSE adapter telemetry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Features
 
-- Add opt-in POST_PARSE invocation telemetry for eligible commands via `connection_parameters.enable_dbt_telemetry`
+- Add opt-in POST_PARSE invocation telemetry for eligible commands via `connection_parameters.enable_dbt_telemetry` ([#1647](https://github.com/databricks/dbt-databricks/pull/1647))
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## dbt-databricks next
 
+### Features
+
+- Add opt-in POST_PARSE invocation telemetry for eligible commands via `connection_parameters.enable_dbt_telemetry`
+
 ### Fixes
 
 - Skip unnecessary Unity Catalog constraint metadata queries for incremental models without enforced contracts ([#1643](https://github.com/databricks/dbt-databricks/pull/1643) resolves [#1641](https://github.com/databricks/dbt-databricks/issues/1641))

--- a/dbt/adapters/databricks/connections.py
+++ b/dbt/adapters/databricks/connections.py
@@ -483,9 +483,7 @@ class DatabricksConnectionManager(SparkConnectionManager):
         creds: DatabricksCredentials = connection.credentials
         timeout = creds.connect_timeout
 
-        # Avoid a manager overwritten by another concurrent open.
-        credentials_manager = creds.authenticate()
-        cls.credentials_manager = credentials_manager
+        cls.credentials_manager = creds.authenticate()
 
         # SPOG decision matrix: collect every http_path in play (default +
         # per-compute) and validate them against the host's discovery probe.
@@ -505,7 +503,7 @@ class DatabricksConnectionManager(SparkConnectionManager):
             merged_query_tags = QueryConfigUtils.get_merged_query_tags(query_header_context, creds)
 
         conn_args = SqlUtils.prepare_connection_arguments(
-            creds, credentials_manager, databricks_connection.http_path, merged_query_tags
+            creds, cls.credentials_manager, databricks_connection.http_path, merged_query_tags
         )
 
         def connect() -> DatabricksHandle:
@@ -523,7 +521,7 @@ class DatabricksConnectionManager(SparkConnectionManager):
                     )
 
                     telemetry_hooks.on_connection_open(
-                        creds, credentials_manager, databricks_connection.http_path
+                        creds, cls.credentials_manager, databricks_connection.http_path
                     )
                     return conn
                 else:

--- a/dbt/adapters/databricks/connections.py
+++ b/dbt/adapters/databricks/connections.py
@@ -522,7 +522,9 @@ class DatabricksConnectionManager(SparkConnectionManager):
                         databricks_connection.http_path
                     )
 
-                    telemetry_hooks.on_connection_open(creds, credentials_manager)
+                    telemetry_hooks.on_connection_open(
+                        creds, credentials_manager, databricks_connection.http_path
+                    )
                     return conn
                 else:
                     raise DbtDatabaseError("Failed to create connection")

--- a/dbt/adapters/databricks/connections.py
+++ b/dbt/adapters/databricks/connections.py
@@ -55,6 +55,7 @@ from dbt.adapters.databricks.handle import (
 from dbt.adapters.databricks.logging import logger
 from dbt.adapters.databricks.python_models.run_tracking import PythonRunTracker
 from dbt.adapters.databricks.spog.decision import check_spog_preconditions
+from dbt.adapters.databricks.telemetry import hooks as telemetry_hooks
 from dbt.adapters.databricks.utils import QueryTagsUtils, is_cluster_http_path, redact_credentials
 
 if TYPE_CHECKING:
@@ -482,7 +483,9 @@ class DatabricksConnectionManager(SparkConnectionManager):
         creds: DatabricksCredentials = connection.credentials
         timeout = creds.connect_timeout
 
-        cls.credentials_manager = creds.authenticate()
+        # Avoid a manager overwritten by another concurrent open.
+        credentials_manager = creds.authenticate()
+        cls.credentials_manager = credentials_manager
 
         # SPOG decision matrix: collect every http_path in play (default +
         # per-compute) and validate them against the host's discovery probe.
@@ -502,7 +505,7 @@ class DatabricksConnectionManager(SparkConnectionManager):
             merged_query_tags = QueryConfigUtils.get_merged_query_tags(query_header_context, creds)
 
         conn_args = SqlUtils.prepare_connection_arguments(
-            creds, cls.credentials_manager, databricks_connection.http_path, merged_query_tags
+            creds, credentials_manager, databricks_connection.http_path, merged_query_tags
         )
 
         def connect() -> DatabricksHandle:
@@ -518,6 +521,8 @@ class DatabricksConnectionManager(SparkConnectionManager):
                     databricks_connection.capabilities = cls._get_capabilities_for_http_path(
                         databricks_connection.http_path
                     )
+
+                    telemetry_hooks.on_connection_open(creds, credentials_manager)
                     return conn
                 else:
                     raise DbtDatabaseError("Failed to create connection")

--- a/dbt/adapters/databricks/handle.py
+++ b/dbt/adapters/databricks/handle.py
@@ -394,6 +394,8 @@ class SqlUtils:
 
         connection_parameters = creds.connection_parameters.copy()  # type: ignore[union-attr]
 
+        connection_parameters.pop("enable_dbt_telemetry", None)
+
         http_headers: list[tuple[str, str]] = list(
             creds.get_all_http_headers(connection_parameters.pop("http_headers", {})).items()
         )

--- a/dbt/adapters/databricks/impl.py
+++ b/dbt/adapters/databricks/impl.py
@@ -102,6 +102,7 @@ from dbt.adapters.databricks.spog.capabilities import (
     sdk_supports_workspace_id,
 )
 from dbt.adapters.databricks.spog.extract import extract_workspace_id
+from dbt.adapters.databricks.telemetry import hooks as telemetry_hooks
 from dbt.adapters.databricks.utils import (
     get_first_row,
     handle_missing_objects,
@@ -295,6 +296,8 @@ class DatabricksAdapter(SparkAdapter):
         GlobalState.set_use_managed_iceberg(
             self.get_behavior_flag_no_warn(USE_MANAGED_ICEBERG["name"])
         )
+
+        telemetry_hooks.on_adapter_init(self)
 
         # Warehouses always meet capability cutoffs at parse time; clusters keep the
         # conservative False until a real connection is available.
@@ -902,6 +905,14 @@ class DatabricksAdapter(SparkAdapter):
         # As intended - This method will error out if the behavior flag is missing.
         behavior_flag = getattr(self.behavior, behavior_flag_name)
         return behavior_flag.no_warn
+
+    def set_macro_resolver(self, macro_resolver: Any) -> None:
+        super().set_macro_resolver(macro_resolver)
+        telemetry_hooks.on_post_parse(self, macro_resolver)
+
+    def cleanup_connections(self) -> None:
+        telemetry_hooks.on_run_end(self)
+        super().cleanup_connections()
 
     @available.parse(lambda *a, **k: (None, None))
     @record_function(

--- a/dbt/adapters/databricks/telemetry/__init__.py
+++ b/dbt/adapters/databricks/telemetry/__init__.py
@@ -1,0 +1,3 @@
+from dbt.adapters.databricks.telemetry.config import is_enabled
+
+__all__ = ["is_enabled"]

--- a/dbt/adapters/databricks/telemetry/builder.py
+++ b/dbt/adapters/databricks/telemetry/builder.py
@@ -1,0 +1,229 @@
+from importlib.metadata import version as _pkg_version
+from typing import Any, Callable, Optional
+
+from dbt.adapters.databricks.__version__ import version as _adapter_version
+from dbt.adapters.databricks.credentials import DatabricksCredentials
+from dbt.adapters.databricks.spog.extract import extract_workspace_id
+from dbt.adapters.databricks.telemetry import models
+
+# Mirrored from impl.py to avoid an import cycle.
+_BEHAVIOR_FLAGS = (
+    "use_user_folder_for_python",
+    "use_materialization_v2",
+    "use_replace_on_for_insert_overwrite",
+    "use_managed_iceberg",
+    "use_concurrent_microbatch",
+    "use_describe_as_json_for_relation_metadata",
+)
+
+_COMMAND_MAP = {
+    "run": models.DbtCommand.RUN,
+    "build": models.DbtCommand.BUILD,
+    "test": models.DbtCommand.TEST,
+    "seed": models.DbtCommand.SEED,
+    "snapshot": models.DbtCommand.SNAPSHOT,
+    "compile": models.DbtCommand.COMPILE,
+    "docs": models.DbtCommand.DOCS,
+    "clone": models.DbtCommand.CLONE,
+    "retry": models.DbtCommand.RETRY,
+    "show": models.DbtCommand.SHOW,
+    "list": models.DbtCommand.LIST,
+    "source": models.DbtCommand.SOURCE,
+    "run_operation": models.DbtCommand.RUN_OPERATION,
+}
+
+
+def classify_compute_type(http_path: Optional[str]) -> models.ComputeType:
+    if not http_path:
+        return models.ComputeType.TYPE_UNSPECIFIED
+    path = http_path.split("?", 1)[0]
+    if path.startswith(("/sql/1.0/warehouses/", "/sql/1.0/endpoints/")):
+        return models.ComputeType.SQL_WAREHOUSE
+    if path.startswith("/sql/protocolv1/"):
+        return models.ComputeType.ALL_PURPOSE_CLUSTER
+    return models.ComputeType.OTHER
+
+
+def classify_auth_family(creds: DatabricksCredentials) -> models.AuthFamily:
+    if getattr(creds, "token", None):
+        return models.AuthFamily.PAT
+    if getattr(creds, "azure_client_id", None) and getattr(creds, "azure_client_secret", None):
+        return models.AuthFamily.AZURE_SERVICE_PRINCIPAL
+    if not getattr(creds, "client_secret", None):
+        return models.AuthFamily.OAUTH_U2M
+    # client_secret is ambiguous between M2M and legacy Azure.
+    return models.AuthFamily.LEGACY_CLIENT_SECRET_AMBIGUOUS
+
+
+def classify_command(which: Optional[str]) -> models.DbtCommand:
+    if not which:
+        return models.DbtCommand.TYPE_UNSPECIFIED
+    token = str(which).strip().lower().replace("-", "_").split()[0]
+    return _COMMAND_MAP.get(token, models.DbtCommand.OTHER)
+
+
+def classify_warn_error_policy(warn_error: Any, warn_error_options: Any) -> models.WarnErrorPolicy:
+    # The legacy boolean takes precedence.
+    if warn_error:
+        return models.WarnErrorPolicy.WARN_ERROR_ALL
+    if warn_error_options:
+        opts = warn_error_options
+        get = lambda name: (  # noqa: E731 - keeps object/dict compatibility together
+            opts.get(name) if isinstance(opts, dict) else getattr(opts, name, None)
+        )
+        error = get("error") or get("include") or []
+        warn = get("warn") or get("exclude") or []
+        silence = get("silence") or []
+        # Named overrides make `error: all` custom.
+        if error in ("all", "*") and not warn and not silence:
+            return models.WarnErrorPolicy.WARN_ERROR_ALL
+        has_policy = bool(error or warn or silence)
+        if has_policy:
+            return models.WarnErrorPolicy.WARN_ERROR_CUSTOM_POLICY
+    return models.WarnErrorPolicy.WARN_ERROR_DISABLED
+
+
+def _resource_type(node: Any) -> str:
+    rt = getattr(node, "resource_type", None)
+    return str(getattr(rt, "value", rt))
+
+
+def _bump(counts: models.ResourceCounts, node: Any, resource_type: str) -> None:
+    if resource_type == "model":
+        counts.model_count += 1
+    elif resource_type == "test":
+        counts.data_test_count += 1
+        if getattr(node, "test_metadata", None) is not None:
+            counts.generic_data_test_count += 1
+    elif resource_type == "seed":
+        counts.seed_count += 1
+    elif resource_type == "snapshot":
+        counts.snapshot_count += 1
+    elif resource_type == "source":
+        counts.source_count += 1
+    elif resource_type == "function":
+        counts.function_count += 1
+    elif resource_type == "exposure":
+        counts.exposure_count += 1
+    elif resource_type == "saved_query":
+        counts.saved_query_count += 1
+    elif resource_type == "unit_test":
+        counts.unit_test_count += 1
+    else:
+        counts.other_count += 1
+
+
+def aggregate_manifest(manifest: Any) -> models.ManifestStats:
+    stats = models.ManifestStats()
+    project_name = None
+    metadata = getattr(manifest, "metadata", None)
+    if metadata is not None:
+        project_name = getattr(metadata, "project_name", None)
+
+    collections = [
+        "nodes",
+        "sources",
+        "exposures",
+        "metrics",
+        "semantic_models",
+        "saved_queries",
+        "functions",
+        "unit_tests",
+    ]
+    for collection in collections:
+        items = getattr(manifest, collection, None)
+        if not items:
+            continue
+        for node in items.values():
+            resource_type = _resource_type(node)
+            _bump(stats.enabled_total, node, resource_type)
+            is_root = getattr(node, "package_name", None) == project_name
+            _bump(
+                stats.enabled_root_project if is_root else stats.enabled_installed_packages,
+                node,
+                resource_type,
+            )
+    return stats
+
+
+def _get_flags() -> Any:
+    try:
+        from dbt.flags import get_flags
+
+        return get_flags()
+    except Exception:
+        return None
+
+
+def build_invocation_config(config: Any) -> models.InvocationConfig:
+    flags = _get_flags()
+    thread_count = getattr(config, "threads", None) or getattr(flags, "THREADS", None) or 0
+    return models.InvocationConfig(
+        thread_count=int(thread_count),
+        dbt_command=classify_command(getattr(flags, "WHICH", None)),
+        full_refresh=bool(getattr(flags, "FULL_REFRESH", False)),
+        empty=bool(getattr(flags, "EMPTY", False)),
+        fail_fast=bool(getattr(flags, "FAIL_FAST", False)),
+        warn_error_policy=classify_warn_error_policy(
+            getattr(flags, "WARN_ERROR", None), getattr(flags, "WARN_ERROR_OPTIONS", None)
+        ),
+    )
+
+
+def build_connection_config(creds: DatabricksCredentials) -> models.ConnectionConfig:
+    http_path = getattr(creds, "http_path", None)
+    connection_parameters = getattr(creds, "connection_parameters", None) or {}
+    return models.ConnectionConfig(
+        default_compute_type=classify_compute_type(http_path),
+        configured_auth_family=classify_auth_family(creds),
+        named_compute_count=len(getattr(creds, "compute", None) or {}),
+        # Parse only the `o` parameter; discard its value.
+        spog_routing_configured=extract_workspace_id(http_path) is not None,
+        use_kernel=bool(connection_parameters.get("use_kernel")),
+    )
+
+
+def build_project_config(behavior_flag: Callable[[str], bool]) -> models.ProjectConfig:
+    values = {name: bool(behavior_flag(name)) for name in _BEHAVIOR_FLAGS}
+    return models.ProjectConfig(**values)
+
+
+def build_post_parse_log(
+    manifest: Any,
+    config: Any,
+    creds: DatabricksCredentials,
+    behavior_flag: Callable[[str], bool],
+) -> models.TelemetryLog:
+    invocation_id = _invocation_id(manifest)
+    payload = models.PostParsePayload(
+        invocation_config=build_invocation_config(config),
+        manifest_stats=aggregate_manifest(manifest),
+        connection_config=build_connection_config(creds),
+        project_config=build_project_config(behavior_flag),
+    )
+    return models.TelemetryLog(
+        invocation_id=invocation_id,
+        adapter_version=_adapter_version,
+        dbt_core_version=_dbt_core_version(),
+        post_parse=payload,
+    )
+
+
+def _invocation_id(manifest: Any) -> str:
+    try:
+        from dbt_common.invocation import get_invocation_id
+
+        invocation_id = get_invocation_id()
+        if invocation_id:
+            return str(invocation_id)
+    except Exception:
+        pass
+    metadata = getattr(manifest, "metadata", None)
+    return str(getattr(metadata, "invocation_id", "") or "")
+
+
+def _dbt_core_version() -> str:
+    try:
+        return _pkg_version("dbt-core")
+    except Exception:
+        return ""

--- a/dbt/adapters/databricks/telemetry/builder.py
+++ b/dbt/adapters/databricks/telemetry/builder.py
@@ -172,6 +172,18 @@ def build_invocation_config(config: Any) -> models.InvocationConfig:
     )
 
 
+def _profile_http_paths(creds: DatabricksCredentials) -> list[str]:
+    paths: list[str] = []
+    default = getattr(creds, "http_path", None)
+    if default:
+        paths.append(default)
+    for cfg in (getattr(creds, "compute", None) or {}).values():
+        path = cfg.get("http_path") if cfg else None
+        if path:
+            paths.append(path)
+    return paths
+
+
 def build_connection_config(creds: DatabricksCredentials) -> models.ConnectionConfig:
     http_path = getattr(creds, "http_path", None)
     connection_parameters = getattr(creds, "connection_parameters", None) or {}
@@ -180,7 +192,9 @@ def build_connection_config(creds: DatabricksCredentials) -> models.ConnectionCo
         configured_auth_family=classify_auth_family(creds),
         named_compute_count=len(getattr(creds, "compute", None) or {}),
         # Parse only the `o` parameter; discard its value.
-        spog_routing_configured=extract_workspace_id(http_path) is not None,
+        spog_routing_configured=any(
+            extract_workspace_id(path) is not None for path in _profile_http_paths(creds)
+        ),
         use_kernel=bool(connection_parameters.get("use_kernel")),
     )
 

--- a/dbt/adapters/databricks/telemetry/builder.py
+++ b/dbt/adapters/databricks/telemetry/builder.py
@@ -37,6 +37,8 @@ def classify_compute_type(http_path: Optional[str]) -> models.ComputeType:
     if not http_path:
         return models.ComputeType.TYPE_UNSPECIFIED
     path = http_path.split("?", 1)[0]
+    if path and not path.startswith("/"):
+        path = f"/{path}"
     if path.startswith(("/sql/1.0/warehouses/", "/sql/1.0/endpoints/")):
         return models.ComputeType.SQL_WAREHOUSE
     if path.startswith("/sql/protocolv1/"):

--- a/dbt/adapters/databricks/telemetry/client.py
+++ b/dbt/adapters/databricks/telemetry/client.py
@@ -1,0 +1,61 @@
+from typing import Any, Callable, Optional
+
+import requests
+
+from dbt.adapters.databricks.credentials import BearerAuth
+
+TELEMETRY_AUTHENTICATED_PATH = "/telemetry-ext"
+TELEMETRY_UNAUTHENTICATED_PATH = "/telemetry-unauth"
+
+_TIMEOUT_SECONDS = 10
+
+HeaderFactory = Callable[[], dict[str, str]]
+
+
+def _normalize_host(host: str) -> str:
+    host = host.rstrip("/")
+    if not host.startswith(("http://", "https://")):
+        host = f"https://{host}"
+    return host
+
+
+def send(
+    host: Optional[str],
+    body: dict[str, Any],
+    header_factory: Optional[HeaderFactory] = None,
+    workspace_id: Optional[int] = None,
+) -> bool:
+    if not host:
+        return False
+
+    try:
+        headers = {"Accept": "application/json", "Content-Type": "application/json"}
+        path = TELEMETRY_AUTHENTICATED_PATH
+        if header_factory is not None:
+            auth = BearerAuth(header_factory)
+        else:
+            auth = None
+            path = TELEMETRY_UNAUTHENTICATED_PATH
+
+        if workspace_id is not None:
+            headers["x-databricks-org-id"] = str(workspace_id)
+
+        url = _normalize_host(host) + path
+
+        response = requests.post(
+            url,
+            json=body,
+            headers=headers,
+            auth=auth,
+            timeout=_TIMEOUT_SECONDS,
+        )
+
+        if response.status_code // 100 != 2:
+            return False
+        try:
+            ack = response.json()
+        except ValueError:
+            return False
+        return ack.get("numProtoSuccess", 0) >= 1 and not ack.get("errors")
+    except Exception:
+        return False

--- a/dbt/adapters/databricks/telemetry/client.py
+++ b/dbt/adapters/databricks/telemetry/client.py
@@ -3,6 +3,7 @@ from typing import Any, Callable, Optional
 import requests
 
 from dbt.adapters.databricks.credentials import BearerAuth
+from dbt.adapters.databricks.telemetry.encoder import coerce_workspace_id
 
 TELEMETRY_AUTHENTICATED_PATH = "/telemetry-ext"
 TELEMETRY_UNAUTHENTICATED_PATH = "/telemetry-unauth"
@@ -23,7 +24,7 @@ def send(
     host: Optional[str],
     body: dict[str, Any],
     header_factory: Optional[HeaderFactory] = None,
-    workspace_id: Optional[int] = None,
+    workspace_id: Optional[Any] = None,
 ) -> bool:
     if not host:
         return False
@@ -37,8 +38,9 @@ def send(
             auth = None
             path = TELEMETRY_UNAUTHENTICATED_PATH
 
-        if workspace_id is not None:
-            headers["x-databricks-org-id"] = str(workspace_id)
+        coerced_workspace_id = coerce_workspace_id(workspace_id)
+        if coerced_workspace_id is not None:
+            headers["x-databricks-org-id"] = str(coerced_workspace_id)
 
         url = _normalize_host(host) + path
 

--- a/dbt/adapters/databricks/telemetry/config.py
+++ b/dbt/adapters/databricks/telemetry/config.py
@@ -1,0 +1,50 @@
+from typing import Optional
+
+from dbt.adapters.databricks.credentials import DatabricksCredentials
+
+ENABLE_FLAG = "enable_dbt_telemetry"
+ELIGIBLE_COMMANDS = {"build", "run", "test", "seed", "snapshot"}
+
+
+def is_enabled(credentials: Optional[DatabricksCredentials]) -> bool:
+    if credentials is None:
+        return False
+    params = credentials.connection_parameters or {}
+    value = params.get(ENABLE_FLAG, False)
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, int):
+        return value == 1
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+    return False
+
+
+def is_eligible_command() -> bool:
+    try:
+        from dbt.flags import get_flags
+
+        which = getattr(get_flags(), "WHICH", None)
+        command = str(which or "").strip().lower().replace("_", "-").split()[0]
+        return command in ELIGIBLE_COMMANDS
+    except Exception:
+        return False
+
+
+def is_enabled_for_invocation(credentials: Optional[DatabricksCredentials]) -> bool:
+    return is_enabled(credentials) and is_eligible_command()
+
+
+def has_reusable_transport(credentials: Optional[DatabricksCredentials]) -> bool:
+    """Kernel OAuth U2M credentials are not reusable."""
+    if credentials is None:
+        return False
+    params = credentials.connection_parameters or {}
+    kernel_u2m = (
+        bool(params.get("use_kernel"))
+        and credentials.auth_type == "oauth"
+        and not credentials.token
+        and not credentials.client_secret
+        and not credentials.azure_client_secret
+    )
+    return not kernel_u2m

--- a/dbt/adapters/databricks/telemetry/coordinator.py
+++ b/dbt/adapters/databricks/telemetry/coordinator.py
@@ -34,6 +34,7 @@ class _InvocationState:
         "transport",
         "post_parse_event_id",
         "post_parse_sent",
+        "post_parse_timestamp_millis",
         "sending",
         "closed",
     )
@@ -43,6 +44,7 @@ class _InvocationState:
         self.transport: Optional[Transport] = None
         self.post_parse_event_id: str = str(uuid.uuid4())
         self.post_parse_sent: bool = False
+        self.post_parse_timestamp_millis: Optional[int] = None
         self.sending: bool = False
         self.closed: bool = False
 
@@ -70,6 +72,7 @@ class Coordinator:
                 return
             if state.post_parse is None:
                 state.post_parse = payload
+                state.post_parse_timestamp_millis = int(time.time() * 1000)
         self.send_if_ready(invocation_id)
 
     def set_transport(self, invocation_id: str, transport: Transport) -> None:
@@ -123,7 +126,9 @@ class Coordinator:
 
     def _claim_send(
         self, state: Optional[_InvocationState]
-    ) -> Optional[tuple[Optional[str], TelemetryLog, str, HeaderFactory, Optional[Any]]]:
+    ) -> Optional[
+        tuple[Optional[str], TelemetryLog, str, HeaderFactory, Optional[Any], Optional[int]]
+    ]:
         if not self._ready_to_send(state) or state is None or state.transport is None:
             return None
         header_factory = state.transport.header_factory
@@ -132,6 +137,7 @@ class Coordinator:
         transport = state.transport
         payload = state.post_parse
         event_id = state.post_parse_event_id
+        event_timestamp_millis = state.post_parse_timestamp_millis
         state.post_parse_sent = True
         state.sending = True
         return (
@@ -140,6 +146,7 @@ class Coordinator:
             event_id,
             header_factory,
             transport.workspace_id,
+            event_timestamp_millis,
         )
 
     def flush(self, timeout: Optional[float] = None) -> None:
@@ -165,8 +172,9 @@ class Coordinator:
         event_id: str,
         header_factory: HeaderFactory,
         workspace_id: Optional[Any],
+        event_timestamp_millis: Optional[int],
     ) -> None:
-        self._send(host, payload, event_id, header_factory, workspace_id)
+        self._send(host, payload, event_id, header_factory, workspace_id, event_timestamp_millis)
         with self._lock:
             state = self._states.get(invocation_id)
             if state is None or state.closed:
@@ -180,9 +188,15 @@ class Coordinator:
         event_id: str,
         header_factory: Optional[HeaderFactory],
         workspace_id: Optional[Any],
+        event_timestamp_millis: Optional[int] = None,
     ) -> None:
         try:
-            body = encoder.encode_request(payload, event_id, workspace_id=workspace_id)
+            body = encoder.encode_request(
+                payload,
+                event_id,
+                workspace_id=workspace_id,
+                event_timestamp_millis=event_timestamp_millis,
+            )
             client.send(host, body, header_factory=header_factory, workspace_id=workspace_id)
         except Exception:  # pragma: no cover - best-effort
             return

--- a/dbt/adapters/databricks/telemetry/coordinator.py
+++ b/dbt/adapters/databricks/telemetry/coordinator.py
@@ -83,6 +83,11 @@ class Coordinator:
 
     def mark_start(self, invocation_id: str) -> None:
         with self._lock:
+            self._states = {
+                key: state
+                for key, state in self._states.items()
+                if key == invocation_id or not state.closed
+            }
             self._state(invocation_id)
 
     def needs_post_parse(self, invocation_id: str) -> bool:

--- a/dbt/adapters/databricks/telemetry/coordinator.py
+++ b/dbt/adapters/databricks/telemetry/coordinator.py
@@ -1,0 +1,188 @@
+import threading
+import time
+import uuid
+from typing import Any, Callable, Optional
+
+from dbt.adapters.databricks.telemetry import client, encoder
+from dbt.adapters.databricks.telemetry.models import TelemetryLog
+
+HeaderFactory = Callable[[], dict[str, str]]
+
+
+class Transport:
+    """Reusable transport with a redacted representation."""
+
+    __slots__ = ("host", "header_factory", "workspace_id")
+
+    def __init__(
+        self,
+        host: Optional[str],
+        header_factory: Optional[HeaderFactory],
+        workspace_id: Optional[Any],
+    ) -> None:
+        self.host = host
+        self.header_factory = header_factory
+        self.workspace_id = workspace_id
+
+    def __repr__(self) -> str:  # pragma: no cover - defensive redaction
+        return "<dbt telemetry Transport (redacted)>"
+
+
+class _InvocationState:
+    __slots__ = (
+        "post_parse",
+        "transport",
+        "post_parse_event_id",
+        "post_parse_sent",
+        "sending",
+        "closed",
+    )
+
+    def __init__(self) -> None:
+        self.post_parse: Optional[TelemetryLog] = None
+        self.transport: Optional[Transport] = None
+        self.post_parse_event_id: str = str(uuid.uuid4())
+        self.post_parse_sent: bool = False
+        self.sending: bool = False
+        self.closed: bool = False
+
+
+class Coordinator:
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._states: dict[str, _InvocationState] = {}
+        self._threads_lock = threading.Lock()
+        self._threads: list[threading.Thread] = []
+
+    def _state(self, invocation_id: str) -> Optional[_InvocationState]:
+        state = self._states.get(invocation_id)
+        if state is None:
+            state = _InvocationState()
+            self._states[invocation_id] = state
+        elif state.closed:
+            return None
+        return state
+
+    def set_post_parse(self, invocation_id: str, payload: TelemetryLog) -> None:
+        with self._lock:
+            state = self._state(invocation_id)
+            if state is None:
+                return
+            if state.post_parse is None:
+                state.post_parse = payload
+        self.send_if_ready(invocation_id)
+
+    def set_transport(self, invocation_id: str, transport: Transport) -> None:
+        with self._lock:
+            state = self._state(invocation_id)
+            if state is None:
+                return
+            if state.transport is None:
+                state.transport = transport
+        self.send_if_ready(invocation_id)
+
+    def mark_start(self, invocation_id: str) -> None:
+        with self._lock:
+            self._state(invocation_id)
+
+    def needs_post_parse(self, invocation_id: str) -> bool:
+        with self._lock:
+            state = self._states.get(invocation_id)
+            return state is None or (not state.closed and state.post_parse is None)
+
+    def send_if_ready(self, invocation_id: str) -> None:
+        # Keep connection-open off the network path.
+        with self._lock:
+            if not self._ready_to_send(self._states.get(invocation_id)):
+                return
+        thread = threading.Thread(
+            target=self._drain,
+            args=(invocation_id,),
+            name="dbt-telemetry-send",
+            daemon=True,
+        )
+        with self._threads_lock:
+            self._threads = [t for t in self._threads if t.is_alive()]
+            self._threads.append(thread)
+        thread.start()
+
+    def _ready_to_send(self, state: Optional[_InvocationState]) -> bool:
+        if state is None or state.closed or state.sending:
+            return False
+        transport = state.transport
+        if transport is None or transport.header_factory is None:
+            return False
+        return state.post_parse is not None and not state.post_parse_sent
+
+    def flush(self, timeout: Optional[float] = None) -> None:
+        if timeout is None:
+            timeout = float(client._TIMEOUT_SECONDS * 2)
+        deadline = time.monotonic() + timeout
+        while True:
+            with self._threads_lock:
+                self._threads = [t for t in self._threads if t.is_alive()]
+                pending = list(self._threads)
+            if not pending:
+                return
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            pending[0].join(remaining)
+
+    def _drain(self, invocation_id: str) -> None:
+        with self._lock:
+            state = self._states.get(invocation_id)
+            if state is None or state.closed or state.sending:
+                return
+            transport = state.transport
+            if transport is None or transport.header_factory is None:
+                return
+            if state.post_parse is None or state.post_parse_sent:
+                return
+            payload = state.post_parse
+            event_id = state.post_parse_event_id
+            state.post_parse_sent = True
+            state.sending = True
+            host = transport.host
+            header_factory = transport.header_factory
+            workspace_id = transport.workspace_id
+
+        self._send(host, payload, event_id, header_factory, workspace_id)
+
+        with self._lock:
+            state = self._states.get(invocation_id)
+            if state is None or state.closed:
+                return
+            state.sending = False
+
+    def _send(
+        self,
+        host: Optional[str],
+        payload: TelemetryLog,
+        event_id: str,
+        header_factory: Optional[HeaderFactory],
+        workspace_id: Optional[Any],
+    ) -> None:
+        try:
+            body = encoder.encode_request(payload, event_id, workspace_id=workspace_id)
+            client.send(host, body, header_factory=header_factory, workspace_id=workspace_id)
+        except Exception:  # pragma: no cover - best-effort
+            return
+
+    def close(self, invocation_id: str) -> None:
+        with self._lock:
+            # Reject late callbacks and clear sensitive state.
+            state = self._states.get(invocation_id)
+            if state is None:
+                state = _InvocationState()
+                self._states[invocation_id] = state
+            state.closed = True
+            state.post_parse = None
+            state.transport = None
+
+
+_COORDINATOR = Coordinator()
+
+
+def coordinator() -> Coordinator:
+    return _COORDINATOR

--- a/dbt/adapters/databricks/telemetry/coordinator.py
+++ b/dbt/adapters/databricks/telemetry/coordinator.py
@@ -121,7 +121,8 @@ class Coordinator:
     ) -> Optional[tuple[Optional[str], TelemetryLog, str, HeaderFactory, Optional[Any]]]:
         if not self._ready_to_send(state) or state is None or state.transport is None:
             return None
-        if state.post_parse is None or state.transport.header_factory is None:
+        header_factory = state.transport.header_factory
+        if state.post_parse is None or header_factory is None:
             return None
         transport = state.transport
         payload = state.post_parse
@@ -132,7 +133,7 @@ class Coordinator:
             transport.host,
             payload,
             event_id,
-            transport.header_factory,
+            header_factory,
             transport.workspace_id,
         )
 

--- a/dbt/adapters/databricks/telemetry/coordinator.py
+++ b/dbt/adapters/databricks/telemetry/coordinator.py
@@ -91,13 +91,15 @@ class Coordinator:
             return state is None or (not state.closed and state.post_parse is None)
 
     def send_if_ready(self, invocation_id: str) -> None:
-        # Keep connection-open off the network path.
+        # Keep connection-open off the network path. Claim send inputs under
+        # the lock so a later close() cannot cancel already-scheduled work.
         with self._lock:
-            if not self._ready_to_send(self._states.get(invocation_id)):
+            claimed = self._claim_send(self._states.get(invocation_id))
+            if claimed is None:
                 return
         thread = threading.Thread(
-            target=self._drain,
-            args=(invocation_id,),
+            target=self._send_claimed,
+            args=(invocation_id, *claimed),
             name="dbt-telemetry-send",
             daemon=True,
         )
@@ -114,6 +116,26 @@ class Coordinator:
             return False
         return state.post_parse is not None and not state.post_parse_sent
 
+    def _claim_send(
+        self, state: Optional[_InvocationState]
+    ) -> Optional[tuple[Optional[str], TelemetryLog, str, HeaderFactory, Optional[Any]]]:
+        if not self._ready_to_send(state) or state is None or state.transport is None:
+            return None
+        if state.post_parse is None or state.transport.header_factory is None:
+            return None
+        transport = state.transport
+        payload = state.post_parse
+        event_id = state.post_parse_event_id
+        state.post_parse_sent = True
+        state.sending = True
+        return (
+            transport.host,
+            payload,
+            event_id,
+            transport.header_factory,
+            transport.workspace_id,
+        )
+
     def flush(self, timeout: Optional[float] = None) -> None:
         if timeout is None:
             timeout = float(client._TIMEOUT_SECONDS * 2)
@@ -129,26 +151,16 @@ class Coordinator:
                 return
             pending[0].join(remaining)
 
-    def _drain(self, invocation_id: str) -> None:
-        with self._lock:
-            state = self._states.get(invocation_id)
-            if state is None or state.closed or state.sending:
-                return
-            transport = state.transport
-            if transport is None or transport.header_factory is None:
-                return
-            if state.post_parse is None or state.post_parse_sent:
-                return
-            payload = state.post_parse
-            event_id = state.post_parse_event_id
-            state.post_parse_sent = True
-            state.sending = True
-            host = transport.host
-            header_factory = transport.header_factory
-            workspace_id = transport.workspace_id
-
+    def _send_claimed(
+        self,
+        invocation_id: str,
+        host: Optional[str],
+        payload: TelemetryLog,
+        event_id: str,
+        header_factory: HeaderFactory,
+        workspace_id: Optional[Any],
+    ) -> None:
         self._send(host, payload, event_id, header_factory, workspace_id)
-
         with self._lock:
             state = self._states.get(invocation_id)
             if state is None or state.closed:

--- a/dbt/adapters/databricks/telemetry/encoder.py
+++ b/dbt/adapters/databricks/telemetry/encoder.py
@@ -21,7 +21,7 @@ def _proto_dict(log: TelemetryLog) -> dict[str, Any]:
     return dataclasses.asdict(log, dict_factory=factory)
 
 
-def _coerce_workspace_id(workspace_id: Optional[Any]) -> Optional[int]:
+def coerce_workspace_id(workspace_id: Optional[Any]) -> Optional[int]:
     try:
         return int(workspace_id) if workspace_id is not None else None
     except (TypeError, ValueError):
@@ -44,7 +44,7 @@ def encode_frontend_log(
         },
         "entry": entry,
     }
-    coerced = _coerce_workspace_id(workspace_id)
+    coerced = coerce_workspace_id(workspace_id)
     if coerced is not None:
         frontend_log["workspace_id"] = coerced
     return json.dumps(frontend_log)

--- a/dbt/adapters/databricks/telemetry/encoder.py
+++ b/dbt/adapters/databricks/telemetry/encoder.py
@@ -32,13 +32,19 @@ def encode_frontend_log(
     log: TelemetryLog,
     frontend_log_event_id: str,
     workspace_id: Optional[Any] = None,
+    event_timestamp_millis: Optional[int] = None,
 ) -> str:
     entry = {"dbt_databricks_telemetry_log": _proto_dict(log)}
+    timestamp_millis = (
+        int(event_timestamp_millis)
+        if event_timestamp_millis is not None
+        else int(time.time() * 1000)
+    )
     frontend_log: dict[str, Any] = {
         "frontend_log_event_id": frontend_log_event_id,
         "context": {
             "client_context": {
-                "timestamp_millis": int(time.time() * 1000),
+                "timestamp_millis": timestamp_millis,
                 "user_agent": f"{DRIVER_NAME}/{log.adapter_version}",
             }
         },
@@ -54,9 +60,17 @@ def encode_request(
     log: TelemetryLog,
     frontend_log_event_id: str,
     workspace_id: Optional[Any] = None,
+    event_timestamp_millis: Optional[int] = None,
 ) -> dict[str, Any]:
     return {
         "uploadTime": int(time.time() * 1000),
         "items": [],
-        "protoLogs": [encode_frontend_log(log, frontend_log_event_id, workspace_id)],
+        "protoLogs": [
+            encode_frontend_log(
+                log,
+                frontend_log_event_id,
+                workspace_id,
+                event_timestamp_millis=event_timestamp_millis,
+            )
+        ],
     }

--- a/dbt/adapters/databricks/telemetry/encoder.py
+++ b/dbt/adapters/databricks/telemetry/encoder.py
@@ -1,0 +1,62 @@
+import dataclasses
+import json
+import time
+from enum import Enum
+from typing import Any, Optional
+
+from dbt.adapters.databricks.telemetry.models import TelemetryLog
+
+DRIVER_NAME = "dbt-databricks"
+
+
+def _proto_dict(log: TelemetryLog) -> dict[str, Any]:
+    def factory(items: list) -> dict:
+        out = {}
+        for k, v in items:
+            if v is None:
+                continue
+            out[k[:-1] if k.endswith("_") else k] = v.value if isinstance(v, Enum) else v
+        return out
+
+    return dataclasses.asdict(log, dict_factory=factory)
+
+
+def _coerce_workspace_id(workspace_id: Optional[Any]) -> Optional[int]:
+    try:
+        return int(workspace_id) if workspace_id is not None else None
+    except (TypeError, ValueError):
+        return None
+
+
+def encode_frontend_log(
+    log: TelemetryLog,
+    frontend_log_event_id: str,
+    workspace_id: Optional[Any] = None,
+) -> str:
+    entry = {"dbt_databricks_telemetry_log": _proto_dict(log)}
+    frontend_log: dict[str, Any] = {
+        "frontend_log_event_id": frontend_log_event_id,
+        "context": {
+            "client_context": {
+                "timestamp_millis": int(time.time() * 1000),
+                "user_agent": f"{DRIVER_NAME}/{log.adapter_version}",
+            }
+        },
+        "entry": entry,
+    }
+    coerced = _coerce_workspace_id(workspace_id)
+    if coerced is not None:
+        frontend_log["workspace_id"] = coerced
+    return json.dumps(frontend_log)
+
+
+def encode_request(
+    log: TelemetryLog,
+    frontend_log_event_id: str,
+    workspace_id: Optional[Any] = None,
+) -> dict[str, Any]:
+    return {
+        "uploadTime": int(time.time() * 1000),
+        "items": [],
+        "protoLogs": [encode_frontend_log(log, frontend_log_event_id, workspace_id)],
+    }

--- a/dbt/adapters/databricks/telemetry/hooks.py
+++ b/dbt/adapters/databricks/telemetry/hooks.py
@@ -1,6 +1,7 @@
 from typing import Any, Optional
 
 from dbt.adapters.databricks.credentials import DatabricksCredentials
+from dbt.adapters.databricks.logging import logger
 from dbt.adapters.databricks.spog.extract import extract_workspace_id
 from dbt.adapters.databricks.telemetry import builder
 from dbt.adapters.databricks.telemetry.config import (
@@ -34,6 +35,11 @@ def on_adapter_init(adapter: Any) -> None:
         creds = getattr(getattr(adapter, "config", None), "credentials", None)
         if not isinstance(creds, DatabricksCredentials) or not is_enabled_for_invocation(creds):
             return
+        if not has_reusable_transport(creds):
+            logger.warning(
+                "enable_dbt_telemetry is set but kernel OAuth U2M credentials cannot be "
+                "reused for telemetry HTTP; events will not be sent."
+            )
         invocation_id = _current_invocation_id()
         if not invocation_id:
             return

--- a/dbt/adapters/databricks/telemetry/hooks.py
+++ b/dbt/adapters/databricks/telemetry/hooks.py
@@ -1,0 +1,95 @@
+from typing import Any, Optional
+
+from dbt.adapters.databricks.credentials import DatabricksCredentials
+from dbt.adapters.databricks.telemetry import builder
+from dbt.adapters.databricks.telemetry.config import (
+    has_reusable_transport,
+    is_enabled_for_invocation,
+)
+from dbt.adapters.databricks.telemetry.coordinator import Transport, coordinator
+
+
+def _current_invocation_id() -> Optional[str]:
+    try:
+        from dbt_common.invocation import get_invocation_id
+
+        invocation_id = get_invocation_id()
+        return str(invocation_id) if invocation_id else None
+    except Exception:
+        return None
+
+
+def on_adapter_init(adapter: Any) -> None:
+    try:
+        creds = getattr(getattr(adapter, "config", None), "credentials", None)
+        if not isinstance(creds, DatabricksCredentials) or not is_enabled_for_invocation(creds):
+            return
+        invocation_id = _current_invocation_id()
+        if not invocation_id:
+            return
+        coordinator().mark_start(invocation_id)
+    except Exception:  # pragma: no cover - best-effort
+        return
+
+
+def on_post_parse(adapter: Any, manifest: Any) -> None:
+    try:
+        config = getattr(adapter, "config", None)
+        creds = getattr(config, "credentials", None)
+        if not isinstance(creds, DatabricksCredentials) or not is_enabled_for_invocation(creds):
+            return
+        invocation_id = _current_invocation_id()
+        coord = coordinator()
+        if invocation_id and not coord.needs_post_parse(invocation_id):
+            return
+        log = builder.build_post_parse_log(
+            manifest=manifest,
+            config=config,
+            creds=creds,
+            behavior_flag=adapter.get_behavior_flag_no_warn,
+        )
+        if not log.invocation_id:
+            return
+        coord.set_post_parse(log.invocation_id, log)
+    except Exception:  # pragma: no cover - best-effort
+        return
+
+
+def on_connection_open(
+    credentials: Optional[DatabricksCredentials],
+    credentials_manager: Optional[Any],
+) -> None:
+    try:
+        if (
+            not is_enabled_for_invocation(credentials)
+            or not has_reusable_transport(credentials)
+            or credentials_manager is None
+        ):
+            return
+        invocation_id = _current_invocation_id()
+        if not invocation_id:
+            return
+        transport = Transport(
+            host=getattr(credentials_manager, "host", None),
+            header_factory=getattr(credentials_manager, "header_factory", None),
+            workspace_id=getattr(credentials_manager, "workspace_id", None),
+        )
+        coordinator().set_transport(invocation_id, transport)
+    except Exception:  # pragma: no cover - best-effort
+        return
+
+
+def on_run_end(adapter: Any) -> None:
+    try:
+        config = getattr(adapter, "config", None)
+        creds = getattr(config, "credentials", None)
+        if not isinstance(creds, DatabricksCredentials) or not is_enabled_for_invocation(creds):
+            return
+        invocation_id = _current_invocation_id()
+        if not invocation_id:
+            return
+        coord = coordinator()
+        coord.flush()
+        coord.close(invocation_id)
+    except Exception:  # pragma: no cover - best-effort
+        return

--- a/dbt/adapters/databricks/telemetry/hooks.py
+++ b/dbt/adapters/databricks/telemetry/hooks.py
@@ -88,8 +88,6 @@ def on_run_end(adapter: Any) -> None:
         invocation_id = _current_invocation_id()
         if not invocation_id:
             return
-        coord = coordinator()
-        coord.flush()
-        coord.close(invocation_id)
+        coordinator().close(invocation_id)
     except Exception:  # pragma: no cover - best-effort
         return

--- a/dbt/adapters/databricks/telemetry/hooks.py
+++ b/dbt/adapters/databricks/telemetry/hooks.py
@@ -8,6 +8,10 @@ from dbt.adapters.databricks.telemetry.config import (
 )
 from dbt.adapters.databricks.telemetry.coordinator import Transport, coordinator
 
+# Bound at adapter init. dbt-core resets the process-global invocation ID
+# before leftover adapter cleanup, so teardown must not read the live ID.
+_INVOCATION_ID_ATTR = "_dbt_telemetry_invocation_id"
+
 
 def _current_invocation_id() -> Optional[str]:
     try:
@@ -19,6 +23,11 @@ def _current_invocation_id() -> Optional[str]:
         return None
 
 
+def _stored_invocation_id(adapter: Any) -> Optional[str]:
+    invocation_id = getattr(adapter, _INVOCATION_ID_ATTR, None)
+    return str(invocation_id) if invocation_id else None
+
+
 def on_adapter_init(adapter: Any) -> None:
     try:
         creds = getattr(getattr(adapter, "config", None), "credentials", None)
@@ -27,6 +36,7 @@ def on_adapter_init(adapter: Any) -> None:
         invocation_id = _current_invocation_id()
         if not invocation_id:
             return
+        setattr(adapter, _INVOCATION_ID_ATTR, invocation_id)
         coordinator().mark_start(invocation_id)
     except Exception:  # pragma: no cover - best-effort
         return
@@ -85,7 +95,7 @@ def on_run_end(adapter: Any) -> None:
         creds = getattr(config, "credentials", None)
         if not isinstance(creds, DatabricksCredentials) or not is_enabled_for_invocation(creds):
             return
-        invocation_id = _current_invocation_id()
+        invocation_id = _stored_invocation_id(adapter)
         if not invocation_id:
             return
         coordinator().close(invocation_id)

--- a/dbt/adapters/databricks/telemetry/hooks.py
+++ b/dbt/adapters/databricks/telemetry/hooks.py
@@ -1,6 +1,7 @@
 from typing import Any, Optional
 
 from dbt.adapters.databricks.credentials import DatabricksCredentials
+from dbt.adapters.databricks.spog.extract import extract_workspace_id
 from dbt.adapters.databricks.telemetry import builder
 from dbt.adapters.databricks.telemetry.config import (
     has_reusable_transport,
@@ -68,6 +69,7 @@ def on_post_parse(adapter: Any, manifest: Any) -> None:
 def on_connection_open(
     credentials: Optional[DatabricksCredentials],
     credentials_manager: Optional[Any],
+    http_path: Optional[str] = None,
 ) -> None:
     try:
         if (
@@ -79,10 +81,13 @@ def on_connection_open(
         invocation_id = _current_invocation_id()
         if not invocation_id:
             return
+        workspace_id = extract_workspace_id(http_path)
+        if workspace_id is None:
+            workspace_id = getattr(credentials_manager, "workspace_id", None)
         transport = Transport(
             host=getattr(credentials_manager, "host", None),
             header_factory=getattr(credentials_manager, "header_factory", None),
-            workspace_id=getattr(credentials_manager, "workspace_id", None),
+            workspace_id=workspace_id,
         )
         coordinator().set_transport(invocation_id, transport)
     except Exception:  # pragma: no cover - best-effort

--- a/dbt/adapters/databricks/telemetry/models.py
+++ b/dbt/adapters/databricks/telemetry/models.py
@@ -1,0 +1,118 @@
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Optional
+
+
+class EventType(Enum):
+    TYPE_UNSPECIFIED = "TYPE_UNSPECIFIED"
+    POST_PARSE = "POST_PARSE"
+
+
+class ComputeType(Enum):
+    TYPE_UNSPECIFIED = "TYPE_UNSPECIFIED"
+    SQL_WAREHOUSE = "SQL_WAREHOUSE"
+    ALL_PURPOSE_CLUSTER = "ALL_PURPOSE_CLUSTER"
+    OTHER = "OTHER"
+
+
+class AuthFamily(Enum):
+    TYPE_UNSPECIFIED = "TYPE_UNSPECIFIED"
+    PAT = "PAT"
+    OAUTH_U2M = "OAUTH_U2M"
+    OAUTH_M2M = "OAUTH_M2M"
+    AZURE_SERVICE_PRINCIPAL = "AZURE_SERVICE_PRINCIPAL"
+    LEGACY_CLIENT_SECRET_AMBIGUOUS = "LEGACY_CLIENT_SECRET_AMBIGUOUS"
+    OTHER = "OTHER"
+
+
+class DbtCommand(Enum):
+    TYPE_UNSPECIFIED = "TYPE_UNSPECIFIED"
+    RUN = "RUN"
+    BUILD = "BUILD"
+    TEST = "TEST"
+    SEED = "SEED"
+    SNAPSHOT = "SNAPSHOT"
+    COMPILE = "COMPILE"
+    DOCS = "DOCS"
+    CLONE = "CLONE"
+    RETRY = "RETRY"
+    SHOW = "SHOW"
+    LIST = "LIST"
+    SOURCE = "SOURCE"
+    RUN_OPERATION = "RUN_OPERATION"
+    OTHER = "OTHER"
+
+
+class WarnErrorPolicy(Enum):
+    TYPE_UNSPECIFIED = "TYPE_UNSPECIFIED"
+    WARN_ERROR_DISABLED = "WARN_ERROR_DISABLED"
+    WARN_ERROR_ALL = "WARN_ERROR_ALL"
+    WARN_ERROR_CUSTOM_POLICY = "WARN_ERROR_CUSTOM_POLICY"
+
+
+@dataclass
+class ResourceCounts:
+    model_count: int = 0
+    data_test_count: int = 0
+    generic_data_test_count: int = 0
+    seed_count: int = 0
+    snapshot_count: int = 0
+    source_count: int = 0
+    function_count: int = 0
+    exposure_count: int = 0
+    saved_query_count: int = 0
+    other_count: int = 0
+    unit_test_count: int = 0
+
+
+@dataclass
+class ManifestStats:
+    enabled_total: ResourceCounts = field(default_factory=ResourceCounts)
+    enabled_root_project: ResourceCounts = field(default_factory=ResourceCounts)
+    enabled_installed_packages: ResourceCounts = field(default_factory=ResourceCounts)
+
+
+@dataclass
+class InvocationConfig:
+    thread_count: int = 0
+    dbt_command: DbtCommand = DbtCommand.TYPE_UNSPECIFIED
+    full_refresh: bool = False
+    empty: bool = False
+    fail_fast: bool = False
+    warn_error_policy: WarnErrorPolicy = WarnErrorPolicy.WARN_ERROR_DISABLED
+
+
+@dataclass
+class ConnectionConfig:
+    default_compute_type: ComputeType = ComputeType.TYPE_UNSPECIFIED
+    configured_auth_family: AuthFamily = AuthFamily.TYPE_UNSPECIFIED
+    named_compute_count: int = 0
+    spog_routing_configured: bool = False
+    use_kernel: bool = False
+
+
+@dataclass
+class ProjectConfig:
+    use_user_folder_for_python: bool = False
+    use_materialization_v2: bool = False
+    use_replace_on_for_insert_overwrite: bool = False
+    use_managed_iceberg: bool = False
+    use_concurrent_microbatch: bool = False
+    use_describe_as_json_for_relation_metadata: bool = False
+
+
+@dataclass
+class PostParsePayload:
+    invocation_config: InvocationConfig
+    manifest_stats: ManifestStats
+    connection_config: ConnectionConfig
+    project_config: ProjectConfig
+
+
+@dataclass
+class TelemetryLog:
+    invocation_id: str
+    adapter_version: str
+    dbt_core_version: str
+    event_type: EventType = EventType.POST_PARSE
+    post_parse: Optional[PostParsePayload] = None

--- a/tests/unit/telemetry/test_builder.py
+++ b/tests/unit/telemetry/test_builder.py
@@ -52,6 +52,14 @@ class TestClassifyComputeType:
     def test_missing_is_unspecified(self):
         assert builder.classify_compute_type(None) == models.ComputeType.TYPE_UNSPECIFIED
 
+    def test_optional_leading_slash(self):
+        assert builder.classify_compute_type("sql/1.0/warehouses/a") == (
+            models.ComputeType.SQL_WAREHOUSE
+        )
+        assert builder.classify_compute_type("sql/protocolv1/o/1/2") == (
+            models.ComputeType.ALL_PURPOSE_CLUSTER
+        )
+
 
 class TestClassifyAuthFamily:
     def test_token_is_pat(self):

--- a/tests/unit/telemetry/test_builder.py
+++ b/tests/unit/telemetry/test_builder.py
@@ -162,6 +162,16 @@ class TestBuildConnectionConfig:
         )
         assert cc.spog_routing_configured is False
 
+    def test_named_compute_o_parameter_sets_spog_flag(self):
+        cc = builder.build_connection_config(
+            _creds(
+                token="dapi",
+                http_path="/sql/1.0/warehouses/default",
+                compute={"named": {"http_path": "/sql/1.0/warehouses/named?o=42"}},
+            )
+        )
+        assert cc.spog_routing_configured is True
+
 
 class TestAggregateManifest:
     def _manifest(self):

--- a/tests/unit/telemetry/test_builder.py
+++ b/tests/unit/telemetry/test_builder.py
@@ -1,0 +1,196 @@
+from types import SimpleNamespace
+
+from dbt.adapters.databricks.telemetry import builder, models
+
+
+def _creds(**kw):
+    base = dict(
+        token=None,
+        client_id=None,
+        client_secret=None,
+        azure_client_id=None,
+        azure_client_secret=None,
+        auth_type=None,
+        http_path="/sql/1.0/warehouses/x",
+        compute=None,
+        connection_parameters=None,
+    )
+    base.update(kw)
+    return SimpleNamespace(**base)
+
+
+def _node(resource_type, package_name="root", test_metadata=None):
+    return SimpleNamespace(
+        resource_type=resource_type, package_name=package_name, test_metadata=test_metadata
+    )
+
+
+class TestClassifyComputeType:
+    def test_sql_warehouse(self):
+        assert builder.classify_compute_type("/sql/1.0/warehouses/a") == (
+            models.ComputeType.SQL_WAREHOUSE
+        )
+
+    def test_endpoints_form_is_warehouse(self):
+        assert builder.classify_compute_type("/sql/1.0/endpoints/a") == (
+            models.ComputeType.SQL_WAREHOUSE
+        )
+
+    def test_all_purpose_cluster(self):
+        assert builder.classify_compute_type("/sql/protocolv1/o/1/2") == (
+            models.ComputeType.ALL_PURPOSE_CLUSTER
+        )
+
+    def test_query_string_ignored(self):
+        assert builder.classify_compute_type("/sql/1.0/warehouses/a?o=9") == (
+            models.ComputeType.SQL_WAREHOUSE
+        )
+
+    def test_unknown_form_is_other(self):
+        assert builder.classify_compute_type("/unknown") == models.ComputeType.OTHER
+
+    def test_missing_is_unspecified(self):
+        assert builder.classify_compute_type(None) == models.ComputeType.TYPE_UNSPECIFIED
+
+
+class TestClassifyAuthFamily:
+    def test_token_is_pat(self):
+        assert builder.classify_auth_family(_creds(token="dapi")) == models.AuthFamily.PAT
+
+    def test_azure_service_principal(self):
+        assert (
+            builder.classify_auth_family(_creds(azure_client_id="a", azure_client_secret="b"))
+            == models.AuthFamily.AZURE_SERVICE_PRINCIPAL
+        )
+
+    def test_no_secret_is_u2m(self):
+        assert builder.classify_auth_family(_creds(auth_type="oauth")) == (
+            models.AuthFamily.OAUTH_U2M
+        )
+
+    def test_client_secret_is_ambiguous(self):
+        assert builder.classify_auth_family(_creds(client_id="c", client_secret="s")) == (
+            models.AuthFamily.LEGACY_CLIENT_SECRET_AMBIGUOUS
+        )
+
+
+class TestClassifyCommand:
+    def test_known(self):
+        assert builder.classify_command("run") == models.DbtCommand.RUN
+        assert builder.classify_command("build") == models.DbtCommand.BUILD
+
+    def test_normalized_forms(self):
+        assert builder.classify_command("run-operation") == models.DbtCommand.RUN_OPERATION
+        assert builder.classify_command("source freshness") == models.DbtCommand.SOURCE
+        assert builder.classify_command("docs generate") == models.DbtCommand.DOCS
+
+    def test_unknown_is_other(self):
+        assert builder.classify_command("parse") == models.DbtCommand.OTHER
+
+    def test_missing_is_unspecified(self):
+        assert builder.classify_command(None) == models.DbtCommand.TYPE_UNSPECIFIED
+
+
+class TestClassifyWarnErrorPolicy:
+    def test_disabled(self):
+        assert builder.classify_warn_error_policy(None, None) == (
+            models.WarnErrorPolicy.WARN_ERROR_DISABLED
+        )
+
+    def test_all(self):
+        assert builder.classify_warn_error_policy(True, None) == (
+            models.WarnErrorPolicy.WARN_ERROR_ALL
+        )
+
+    def test_error_all_without_overrides_is_all(self):
+        options = SimpleNamespace(error="all", warn=[], silence=[])
+        assert builder.classify_warn_error_policy(False, options) == (
+            models.WarnErrorPolicy.WARN_ERROR_ALL
+        )
+
+    def test_error_all_with_named_override_is_custom(self):
+        options = SimpleNamespace(error="all", warn=["SomeWarning"], silence=[])
+        assert builder.classify_warn_error_policy(False, options) == (
+            models.WarnErrorPolicy.WARN_ERROR_CUSTOM_POLICY
+        )
+
+    def test_legacy_warn_error_takes_precedence(self):
+        options = SimpleNamespace(error=[], warn=[], silence=["SomeWarning"])
+        assert builder.classify_warn_error_policy(True, options) == (
+            models.WarnErrorPolicy.WARN_ERROR_ALL
+        )
+
+    def test_custom_policy(self):
+        assert builder.classify_warn_error_policy(False, {"include": ["X"]}) == (
+            models.WarnErrorPolicy.WARN_ERROR_CUSTOM_POLICY
+        )
+
+
+class TestBuildConnectionConfig:
+    def test_derives_all_fields(self):
+        cc = builder.build_connection_config(
+            _creds(
+                client_id="c",
+                client_secret="s",
+                http_path="/sql/protocolv1/o/1/2?o=42",
+                compute={"a": {}, "b": {}},
+                connection_parameters={"use_kernel": True},
+            )
+        )
+        assert cc.default_compute_type == models.ComputeType.ALL_PURPOSE_CLUSTER
+        assert cc.configured_auth_family == models.AuthFamily.LEGACY_CLIENT_SECRET_AMBIGUOUS
+        assert cc.named_compute_count == 2
+        assert cc.spog_routing_configured is True
+        assert cc.use_kernel is True
+
+    def test_spog_parameter_is_parsed_not_substring_matched(self):
+        cc = builder.build_connection_config(
+            _creds(token="dapi", http_path="/sql/1.0/warehouses/w?foo=x&o=42")
+        )
+        assert cc.spog_routing_configured is True
+
+        cc = builder.build_connection_config(
+            _creds(token="dapi", http_path="/sql/1.0/warehouses/w?foo=?o=42")
+        )
+        assert cc.spog_routing_configured is False
+
+
+class TestAggregateManifest:
+    def _manifest(self):
+        return SimpleNamespace(
+            metadata=SimpleNamespace(project_name="root", invocation_id="inv-1"),
+            nodes={
+                "m1": _node("model", "root"),
+                "m2": _node("model", "dep_pkg"),
+                "t_generic": _node("test", "root", test_metadata={"name": "not_null"}),
+                "t_singular": _node("test", "root"),
+                "sd": _node("seed", "root"),
+                "sn": _node("snapshot", "root"),
+                "op": _node("operation", "root"),
+            },
+            sources={"s1": _node("source", "root")},
+            exposures={"e1": _node("exposure", "root")},
+            metrics={"me1": _node("metric", "root")},
+            saved_queries={"sq1": _node("saved_query", "root")},
+            functions={},
+            semantic_models={"sem1": _node("semantic_model", "root")},
+            unit_tests={"ut2": _node("unit_test", "root")},
+        )
+
+    def test_total_counts(self):
+        ms = builder.aggregate_manifest(self._manifest())
+        assert ms.enabled_total.model_count == 2
+        assert ms.enabled_total.data_test_count == 2
+        assert ms.enabled_total.generic_data_test_count == 1
+        assert ms.enabled_total.seed_count == 1
+        assert ms.enabled_total.snapshot_count == 1
+        assert ms.enabled_total.source_count == 1
+        assert ms.enabled_total.exposure_count == 1
+        assert ms.enabled_total.saved_query_count == 1
+        assert ms.enabled_total.other_count == 3
+        assert ms.enabled_total.unit_test_count == 1
+
+    def test_root_vs_installed_split(self):
+        ms = builder.aggregate_manifest(self._manifest())
+        assert ms.enabled_root_project.model_count == 1
+        assert ms.enabled_installed_packages.model_count == 1

--- a/tests/unit/telemetry/test_client.py
+++ b/tests/unit/telemetry/test_client.py
@@ -1,0 +1,35 @@
+from types import SimpleNamespace
+
+from dbt.adapters.databricks.telemetry import client
+
+
+def _ack(**overrides):
+    payload = {"numProtoSuccess": 1, "errors": None}
+    payload.update(overrides)
+    return SimpleNamespace(status_code=200, json=lambda: payload)
+
+
+def test_numeric_workspace_id_is_sent_in_header(monkeypatch):
+    captured = {}
+
+    def post(url, json=None, headers=None, auth=None, timeout=None):
+        captured["headers"] = headers
+        return _ack()
+
+    monkeypatch.setattr(client.requests, "post", post)
+
+    assert client.send("https://h", {}, workspace_id="42") is True
+    assert captured["headers"]["x-databricks-org-id"] == "42"
+
+
+def test_non_numeric_workspace_id_is_omitted_from_header(monkeypatch):
+    captured = {}
+
+    def post(url, json=None, headers=None, auth=None, timeout=None):
+        captured["headers"] = headers
+        return _ack()
+
+    monkeypatch.setattr(client.requests, "post", post)
+
+    assert client.send("https://h", {}, workspace_id="customer-name") is True
+    assert "x-databricks-org-id" not in captured["headers"]

--- a/tests/unit/telemetry/test_config.py
+++ b/tests/unit/telemetry/test_config.py
@@ -1,0 +1,53 @@
+from types import SimpleNamespace
+
+from dbt.adapters.databricks.telemetry import config
+
+
+def _creds(connection_parameters):
+    return SimpleNamespace(
+        connection_parameters=connection_parameters,
+        auth_type=None,
+        token=None,
+        client_secret=None,
+        azure_client_secret=None,
+    )
+
+
+class TestOptIn:
+    def test_defaults_off(self):
+        assert config.is_enabled(_creds({})) is False
+        assert config.is_enabled(_creds(None)) is False
+
+    def test_explicit_opt_in(self):
+        assert config.is_enabled(_creds({"enable_dbt_telemetry": True})) is True
+
+
+class TestCommandEligibility:
+    def test_warehouse_graph_commands_are_eligible(self, monkeypatch):
+        from dbt import flags
+
+        monkeypatch.setattr(flags, "get_flags", lambda: SimpleNamespace(WHICH="build"))
+        assert config.is_eligible_command() is True
+
+    def test_parse_only_and_unwired_task_shapes_are_ineligible(self, monkeypatch):
+        from dbt import flags
+
+        for command in ("compile", "source freshness", "run-operation"):
+            monkeypatch.setattr(
+                flags,
+                "get_flags",
+                lambda command=command: SimpleNamespace(WHICH=command),
+            )
+            assert config.is_eligible_command() is False
+
+
+class TestTransportEligibility:
+    def test_kernel_u2m_is_ineligible(self):
+        creds = _creds({"use_kernel": True})
+        creds.auth_type = "oauth"
+        assert config.has_reusable_transport(creds) is False
+
+    def test_kernel_pat_is_eligible(self):
+        creds = _creds({"use_kernel": True})
+        creds.token = "token"
+        assert config.has_reusable_transport(creds) is True

--- a/tests/unit/telemetry/test_coordinator.py
+++ b/tests/unit/telemetry/test_coordinator.py
@@ -1,0 +1,123 @@
+import threading
+
+from dbt.adapters.databricks.telemetry import coordinator as coord_mod
+from dbt.adapters.databricks.telemetry import models
+
+
+def _log(invocation_id="inv-1"):
+    return models.TelemetryLog(
+        invocation_id=invocation_id,
+        adapter_version="1.2.3",
+        dbt_core_version="1.12.0",
+        post_parse=models.PostParsePayload(
+            invocation_config=models.InvocationConfig(),
+            manifest_stats=models.ManifestStats(),
+            connection_config=models.ConnectionConfig(),
+            project_config=models.ProjectConfig(),
+        ),
+    )
+
+
+def _transport(header_factory=lambda: {"Authorization": "Bearer x"}, workspace_id="42"):
+    return coord_mod.Transport(
+        host="https://h", header_factory=header_factory, workspace_id=workspace_id
+    )
+
+
+class _Capture:
+    def __init__(self):
+        self.calls = []
+
+    def __call__(self, host, body, header_factory=None, workspace_id=None):
+        self.calls.append((host, body, header_factory, workspace_id))
+        return True
+
+
+class TestTransportOpacity:
+    def test_repr_is_redacted(self):
+        t = _transport()
+        assert "redacted" in repr(t)
+        assert "Bearer" not in repr(t)
+
+    def test_not_a_dataclass_and_no_dict(self):
+        t = _transport()
+        assert not hasattr(t, "__dict__")
+
+
+class TestSendOrdering:
+    def test_parse_then_transport_sends_once(self, monkeypatch):
+        capture = _Capture()
+        monkeypatch.setattr(coord_mod.client, "send", capture)
+        c = coord_mod.Coordinator()
+        c.set_post_parse("inv-1", _log())
+        assert capture.calls == []
+        c.set_transport("inv-1", _transport())
+        c.flush()
+        assert len(capture.calls) == 1
+
+    def test_transport_then_parse_sends_once(self, monkeypatch):
+        capture = _Capture()
+        monkeypatch.setattr(coord_mod.client, "send", capture)
+        c = coord_mod.Coordinator()
+        c.set_transport("inv-1", _transport())
+        assert capture.calls == []
+        c.set_post_parse("inv-1", _log())
+        c.flush()
+        assert len(capture.calls) == 1
+
+    def test_repeated_parse_is_idempotent(self, monkeypatch):
+        capture = _Capture()
+        monkeypatch.setattr(coord_mod.client, "send", capture)
+        c = coord_mod.Coordinator()
+        c.set_transport("inv-1", _transport())
+        c.set_post_parse("inv-1", _log())
+        c.set_post_parse("inv-1", _log())
+        c.flush()
+        assert len(capture.calls) == 1
+
+    def test_transport_without_auth_headers_does_not_send(self, monkeypatch):
+        capture = _Capture()
+        monkeypatch.setattr(coord_mod.client, "send", capture)
+        c = coord_mod.Coordinator()
+        c.set_post_parse("inv-1", _log())
+        c.set_transport("inv-1", _transport(header_factory=None))
+        c.flush()
+        assert capture.calls == []
+
+    def test_transport_does_not_block_on_slow_send(self, monkeypatch):
+        in_send = threading.Event()
+        release = threading.Event()
+
+        def slow_send(host, body, header_factory=None, workspace_id=None):
+            in_send.set()
+            assert release.wait(timeout=2)
+            return True
+
+        monkeypatch.setattr(coord_mod.client, "send", slow_send)
+        c = coord_mod.Coordinator()
+        c.set_post_parse("inv-1", _log())
+        c.set_transport("inv-1", _transport())
+        assert in_send.wait(timeout=2)
+        release.set()
+        c.flush(timeout=2)
+
+
+class TestIsolationAndClose:
+    def test_distinct_invocations_do_not_cross_pair(self, monkeypatch):
+        capture = _Capture()
+        monkeypatch.setattr(coord_mod.client, "send", capture)
+        c = coord_mod.Coordinator()
+        c.set_post_parse("inv-A", _log("inv-A"))
+        c.set_transport("inv-B", _transport())
+        c.flush()
+        assert capture.calls == []
+
+    def test_closed_invocation_rejects_late_callbacks(self, monkeypatch):
+        capture = _Capture()
+        monkeypatch.setattr(coord_mod.client, "send", capture)
+        c = coord_mod.Coordinator()
+        c.close("inv-1")
+        c.set_post_parse("inv-1", _log())
+        c.set_transport("inv-1", _transport())
+        c.flush()
+        assert capture.calls == []

--- a/tests/unit/telemetry/test_coordinator.py
+++ b/tests/unit/telemetry/test_coordinator.py
@@ -148,3 +148,17 @@ class TestIsolationAndClose:
         pending[0].target(*pending[0].args)
 
         assert len(capture.calls) == 1
+
+    def test_mark_start_prunes_closed_invocations(self):
+        c = coord_mod.Coordinator()
+        c.mark_start("inv-1")
+        c.close("inv-1")
+        c.mark_start("inv-2")
+
+        assert "inv-1" not in c._states
+        assert "inv-2" in c._states
+        assert c.needs_post_parse("inv-2") is True
+
+        c.close("inv-1")
+        assert c._states["inv-1"].closed
+        assert not c._states["inv-2"].closed

--- a/tests/unit/telemetry/test_coordinator.py
+++ b/tests/unit/telemetry/test_coordinator.py
@@ -121,3 +121,30 @@ class TestIsolationAndClose:
         c.set_transport("inv-1", _transport())
         c.flush()
         assert capture.calls == []
+
+    def test_close_does_not_cancel_already_queued_send(self, monkeypatch):
+        pending = []
+
+        class DelayedThread:
+            def __init__(self, target, args, name, daemon):
+                self.target = target
+                self.args = args
+
+            def is_alive(self):
+                return False
+
+            def start(self):
+                pending.append(self)
+
+        capture = _Capture()
+        monkeypatch.setattr(coord_mod.threading, "Thread", DelayedThread)
+        monkeypatch.setattr(coord_mod.client, "send", capture)
+        c = coord_mod.Coordinator()
+        c.set_post_parse("inv-1", _log())
+        c.set_transport("inv-1", _transport())
+
+        assert len(pending) == 1
+        c.close("inv-1")
+        pending[0].target(*pending[0].args)
+
+        assert len(capture.calls) == 1

--- a/tests/unit/telemetry/test_coordinator.py
+++ b/tests/unit/telemetry/test_coordinator.py
@@ -1,3 +1,4 @@
+import json
 import threading
 
 from dbt.adapters.databricks.telemetry import coordinator as coord_mod
@@ -100,6 +101,22 @@ class TestSendOrdering:
         assert in_send.wait(timeout=2)
         release.set()
         c.flush(timeout=2)
+
+    def test_timestamp_millis_is_parse_time_not_send_time(self, monkeypatch):
+        clock = {"now": 10.0}
+        monkeypatch.setattr(coord_mod.time, "time", lambda: clock["now"])
+        monkeypatch.setattr(coord_mod.encoder.time, "time", lambda: clock["now"])
+        capture = _Capture()
+        monkeypatch.setattr(coord_mod.client, "send", capture)
+        c = coord_mod.Coordinator()
+        c.set_post_parse("inv-1", _log())
+        clock["now"] = 40.0
+        c.set_transport("inv-1", _transport())
+        c.flush()
+        body = capture.calls[0][1]
+        fe = json.loads(body["protoLogs"][0])
+        assert fe["context"]["client_context"]["timestamp_millis"] == 10_000
+        assert body["uploadTime"] == 40_000
 
 
 class TestIsolationAndClose:

--- a/tests/unit/telemetry/test_encoder.py
+++ b/tests/unit/telemetry/test_encoder.py
@@ -1,0 +1,103 @@
+import json
+
+from dbt.adapters.databricks.telemetry import encoder, models
+
+
+def _log():
+    return models.TelemetryLog(
+        invocation_id="inv-1",
+        adapter_version="1.2.3",
+        dbt_core_version="1.12.0",
+        post_parse=models.PostParsePayload(
+            invocation_config=models.InvocationConfig(
+                thread_count=4, dbt_command=models.DbtCommand.RUN
+            ),
+            manifest_stats=models.ManifestStats(enabled_total=models.ResourceCounts(model_count=3)),
+            connection_config=models.ConnectionConfig(
+                default_compute_type=models.ComputeType.SQL_WAREHOUSE,
+                configured_auth_family=models.AuthFamily.PAT,
+            ),
+            project_config=models.ProjectConfig(use_materialization_v2=True),
+        ),
+    )
+
+
+class TestEncoder:
+    def test_uses_dedicated_entry_field(self):
+        fe = json.loads(encoder.encode_request(_log(), "evt-1")["protoLogs"][0])
+        assert "dbt_databricks_telemetry_log" in fe["entry"]
+
+    def test_post_parse_contains_every_proto_field(self):
+        entry = json.loads(encoder.encode_request(_log(), "evt-1")["protoLogs"][0])["entry"][
+            "dbt_databricks_telemetry_log"
+        ]
+        assert set(entry) == {
+            "invocation_id",
+            "event_type",
+            "adapter_version",
+            "dbt_core_version",
+            "post_parse",
+        }
+        assert set(entry["post_parse"]) == {
+            "invocation_config",
+            "manifest_stats",
+            "connection_config",
+            "project_config",
+        }
+        post_parse = entry["post_parse"]
+        assert set(post_parse["invocation_config"]) == {
+            "thread_count",
+            "dbt_command",
+            "full_refresh",
+            "empty",
+            "fail_fast",
+            "warn_error_policy",
+        }
+        assert set(post_parse["connection_config"]) == {
+            "default_compute_type",
+            "configured_auth_family",
+            "named_compute_count",
+            "spog_routing_configured",
+            "use_kernel",
+        }
+        assert set(post_parse["project_config"]) == {
+            "use_user_folder_for_python",
+            "use_materialization_v2",
+            "use_replace_on_for_insert_overwrite",
+            "use_managed_iceberg",
+            "use_concurrent_microbatch",
+            "use_describe_as_json_for_relation_metadata",
+        }
+        assert set(post_parse["manifest_stats"]) == {
+            "enabled_total",
+            "enabled_root_project",
+            "enabled_installed_packages",
+        }
+        assert set(post_parse["manifest_stats"]["enabled_total"]) == {
+            "model_count",
+            "data_test_count",
+            "generic_data_test_count",
+            "seed_count",
+            "snapshot_count",
+            "source_count",
+            "function_count",
+            "exposure_count",
+            "saved_query_count",
+            "other_count",
+            "unit_test_count",
+        }
+
+    def test_numeric_workspace_id_is_coerced(self):
+        fe = json.loads(encoder.encode_request(_log(), "e", workspace_id="42")["protoLogs"][0])
+        assert fe["workspace_id"] == 42
+
+    def test_non_numeric_workspace_id_is_omitted(self):
+        fe = json.loads(encoder.encode_request(_log(), "e", workspace_id="abc")["protoLogs"][0])
+        assert "workspace_id" not in fe
+
+    def test_post_parse_omits_unset_phase(self):
+        entry = json.loads(encoder.encode_request(_log(), "e")["protoLogs"][0])["entry"][
+            "dbt_databricks_telemetry_log"
+        ]
+        assert "post_parse" in entry
+        assert "post_run" not in entry

--- a/tests/unit/telemetry/test_encoder.py
+++ b/tests/unit/telemetry/test_encoder.py
@@ -101,3 +101,10 @@ class TestEncoder:
         ]
         assert "post_parse" in entry
         assert "post_run" not in entry
+
+    def test_timestamp_millis_uses_event_time_not_upload_time(self, monkeypatch):
+        monkeypatch.setattr(encoder.time, "time", lambda: 40.0)
+        body = encoder.encode_request(_log(), "e", event_timestamp_millis=10_000)
+        fe = json.loads(body["protoLogs"][0])
+        assert fe["context"]["client_context"]["timestamp_millis"] == 10_000
+        assert body["uploadTime"] == 40_000

--- a/tests/unit/telemetry/test_hooks.py
+++ b/tests/unit/telemetry/test_hooks.py
@@ -2,6 +2,7 @@ from types import SimpleNamespace
 from unittest.mock import Mock
 
 from dbt.adapters.databricks.telemetry import hooks
+from dbt.adapters.databricks.telemetry.coordinator import Coordinator
 
 
 def test_post_parse_is_not_rebuilt(monkeypatch):
@@ -24,12 +25,51 @@ def test_post_parse_is_not_rebuilt(monkeypatch):
 def test_run_end_closes_without_waiting(monkeypatch):
     coord = Mock()
     monkeypatch.setattr(hooks, "coordinator", lambda: coord)
-    monkeypatch.setattr(hooks, "_current_invocation_id", lambda: "inv-1")
     monkeypatch.setattr(hooks, "DatabricksCredentials", object)
     monkeypatch.setattr(hooks, "is_enabled_for_invocation", lambda _: True)
-    adapter = SimpleNamespace(config=SimpleNamespace(credentials=SimpleNamespace()))
+    adapter = SimpleNamespace(
+        config=SimpleNamespace(credentials=SimpleNamespace()),
+        _dbt_telemetry_invocation_id="inv-1",
+    )
 
     hooks.on_run_end(adapter)
 
     coord.flush.assert_not_called()
     coord.close.assert_called_once_with("inv-1")
+
+
+def test_run_end_closes_stored_invocation_not_current_global(monkeypatch):
+    coord = Mock()
+    monkeypatch.setattr(hooks, "coordinator", lambda: coord)
+    monkeypatch.setattr(hooks, "_current_invocation_id", lambda: "inv-2")
+    monkeypatch.setattr(hooks, "DatabricksCredentials", object)
+    monkeypatch.setattr(hooks, "is_enabled_for_invocation", lambda _: True)
+    adapter = SimpleNamespace(
+        config=SimpleNamespace(credentials=SimpleNamespace()),
+        _dbt_telemetry_invocation_id="inv-1",
+    )
+
+    hooks.on_run_end(adapter)
+
+    coord.close.assert_called_once_with("inv-1")
+
+
+def test_stale_cleanup_does_not_tombstone_next_invocation(monkeypatch):
+    coord = Coordinator()
+    current = ["inv-1"]
+    monkeypatch.setattr(hooks, "coordinator", lambda: coord)
+    monkeypatch.setattr(hooks, "DatabricksCredentials", object)
+    monkeypatch.setattr(hooks, "is_enabled_for_invocation", lambda _: True)
+    monkeypatch.setattr(hooks, "_current_invocation_id", lambda: current[0])
+    leftover = SimpleNamespace(config=SimpleNamespace(credentials=object()))
+
+    hooks.on_adapter_init(leftover)
+    hooks.on_run_end(leftover)
+    current[0] = "inv-2"
+    hooks.on_run_end(leftover)
+    next_adapter = SimpleNamespace(config=SimpleNamespace(credentials=object()))
+    hooks.on_adapter_init(next_adapter)
+
+    assert leftover._dbt_telemetry_invocation_id == "inv-1"
+    assert next_adapter._dbt_telemetry_invocation_id == "inv-2"
+    assert coord.needs_post_parse("inv-2") is True

--- a/tests/unit/telemetry/test_hooks.py
+++ b/tests/unit/telemetry/test_hooks.py
@@ -84,9 +84,7 @@ def test_connection_open_uses_opened_path_workspace_id(monkeypatch):
     monkeypatch.setattr(hooks, "has_reusable_transport", lambda _: True)
     manager = SimpleNamespace(host="https://h", header_factory=lambda: {}, workspace_id=None)
 
-    hooks.on_connection_open(
-        SimpleNamespace(), manager, "/sql/1.0/warehouses/named?o=42"
-    )
+    hooks.on_connection_open(SimpleNamespace(), manager, "/sql/1.0/warehouses/named?o=42")
 
     transport = coord.set_transport.call_args.args[1]
     assert transport.workspace_id == "42"

--- a/tests/unit/telemetry/test_hooks.py
+++ b/tests/unit/telemetry/test_hooks.py
@@ -1,0 +1,35 @@
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+from dbt.adapters.databricks.telemetry import hooks
+
+
+def test_post_parse_is_not_rebuilt(monkeypatch):
+    coord = Mock()
+    coord.needs_post_parse.return_value = False
+    build = Mock()
+    monkeypatch.setattr(hooks, "coordinator", lambda: coord)
+    monkeypatch.setattr(hooks, "_current_invocation_id", lambda: "inv-1")
+    monkeypatch.setattr(hooks, "DatabricksCredentials", object)
+    monkeypatch.setattr(hooks, "is_enabled_for_invocation", lambda _: True)
+    monkeypatch.setattr(hooks.builder, "build_post_parse_log", build)
+    adapter = SimpleNamespace(config=SimpleNamespace(credentials=SimpleNamespace()))
+
+    hooks.on_post_parse(adapter, SimpleNamespace())
+
+    coord.needs_post_parse.assert_called_once_with("inv-1")
+    build.assert_not_called()
+
+
+def test_run_end_flushes_and_closes(monkeypatch):
+    coord = Mock()
+    monkeypatch.setattr(hooks, "coordinator", lambda: coord)
+    monkeypatch.setattr(hooks, "_current_invocation_id", lambda: "inv-1")
+    monkeypatch.setattr(hooks, "DatabricksCredentials", object)
+    monkeypatch.setattr(hooks, "is_enabled_for_invocation", lambda _: True)
+    adapter = SimpleNamespace(config=SimpleNamespace(credentials=SimpleNamespace()))
+
+    hooks.on_run_end(adapter)
+
+    coord.flush.assert_called_once_with()
+    coord.close.assert_called_once_with("inv-1")

--- a/tests/unit/telemetry/test_hooks.py
+++ b/tests/unit/telemetry/test_hooks.py
@@ -60,6 +60,7 @@ def test_stale_cleanup_does_not_tombstone_next_invocation(monkeypatch):
     monkeypatch.setattr(hooks, "coordinator", lambda: coord)
     monkeypatch.setattr(hooks, "DatabricksCredentials", object)
     monkeypatch.setattr(hooks, "is_enabled_for_invocation", lambda _: True)
+    monkeypatch.setattr(hooks, "has_reusable_transport", lambda _: True)
     monkeypatch.setattr(hooks, "_current_invocation_id", lambda: current[0])
     leftover = SimpleNamespace(config=SimpleNamespace(credentials=object()))
 
@@ -74,6 +75,41 @@ def test_stale_cleanup_does_not_tombstone_next_invocation(monkeypatch):
     assert next_adapter._dbt_telemetry_invocation_id == "inv-2"
     assert coord.needs_post_parse("inv-2") is True
     assert "inv-1" not in coord._states
+
+
+def test_kernel_u2m_warns_when_telemetry_enabled(monkeypatch):
+    coord = Mock()
+    log = Mock()
+    monkeypatch.setattr(hooks, "coordinator", lambda: coord)
+    monkeypatch.setattr(hooks, "logger", log)
+    monkeypatch.setattr(hooks, "_current_invocation_id", lambda: "inv-1")
+    monkeypatch.setattr(hooks, "DatabricksCredentials", object)
+    monkeypatch.setattr(hooks, "is_enabled_for_invocation", lambda _: True)
+    monkeypatch.setattr(hooks, "has_reusable_transport", lambda _: False)
+    adapter = SimpleNamespace(config=SimpleNamespace(credentials=object()))
+
+    hooks.on_adapter_init(adapter)
+
+    log.warning.assert_called_once()
+    assert "kernel" in log.warning.call_args.args[0].lower()
+    coord.mark_start.assert_called_once_with("inv-1")
+
+
+def test_reusable_transport_does_not_warn_on_init(monkeypatch):
+    coord = Mock()
+    log = Mock()
+    monkeypatch.setattr(hooks, "coordinator", lambda: coord)
+    monkeypatch.setattr(hooks, "logger", log)
+    monkeypatch.setattr(hooks, "_current_invocation_id", lambda: "inv-1")
+    monkeypatch.setattr(hooks, "DatabricksCredentials", object)
+    monkeypatch.setattr(hooks, "is_enabled_for_invocation", lambda _: True)
+    monkeypatch.setattr(hooks, "has_reusable_transport", lambda _: True)
+    adapter = SimpleNamespace(config=SimpleNamespace(credentials=object()))
+
+    hooks.on_adapter_init(adapter)
+
+    log.warning.assert_not_called()
+    coord.mark_start.assert_called_once_with("inv-1")
 
 
 def test_connection_open_uses_opened_path_workspace_id(monkeypatch):

--- a/tests/unit/telemetry/test_hooks.py
+++ b/tests/unit/telemetry/test_hooks.py
@@ -73,3 +73,34 @@ def test_stale_cleanup_does_not_tombstone_next_invocation(monkeypatch):
     assert leftover._dbt_telemetry_invocation_id == "inv-1"
     assert next_adapter._dbt_telemetry_invocation_id == "inv-2"
     assert coord.needs_post_parse("inv-2") is True
+    assert "inv-1" not in coord._states
+
+
+def test_connection_open_uses_opened_path_workspace_id(monkeypatch):
+    coord = Mock()
+    monkeypatch.setattr(hooks, "coordinator", lambda: coord)
+    monkeypatch.setattr(hooks, "_current_invocation_id", lambda: "inv-1")
+    monkeypatch.setattr(hooks, "is_enabled_for_invocation", lambda _: True)
+    monkeypatch.setattr(hooks, "has_reusable_transport", lambda _: True)
+    manager = SimpleNamespace(host="https://h", header_factory=lambda: {}, workspace_id=None)
+
+    hooks.on_connection_open(
+        SimpleNamespace(), manager, "/sql/1.0/warehouses/named?o=42"
+    )
+
+    transport = coord.set_transport.call_args.args[1]
+    assert transport.workspace_id == "42"
+
+
+def test_connection_open_falls_back_to_manager_workspace_id(monkeypatch):
+    coord = Mock()
+    monkeypatch.setattr(hooks, "coordinator", lambda: coord)
+    monkeypatch.setattr(hooks, "_current_invocation_id", lambda: "inv-1")
+    monkeypatch.setattr(hooks, "is_enabled_for_invocation", lambda _: True)
+    monkeypatch.setattr(hooks, "has_reusable_transport", lambda _: True)
+    manager = SimpleNamespace(host="https://h", header_factory=lambda: {}, workspace_id="7")
+
+    hooks.on_connection_open(SimpleNamespace(), manager, "/sql/1.0/warehouses/default")
+
+    transport = coord.set_transport.call_args.args[1]
+    assert transport.workspace_id == "7"

--- a/tests/unit/telemetry/test_hooks.py
+++ b/tests/unit/telemetry/test_hooks.py
@@ -21,7 +21,7 @@ def test_post_parse_is_not_rebuilt(monkeypatch):
     build.assert_not_called()
 
 
-def test_run_end_flushes_and_closes(monkeypatch):
+def test_run_end_closes_without_waiting(monkeypatch):
     coord = Mock()
     monkeypatch.setattr(hooks, "coordinator", lambda: coord)
     monkeypatch.setattr(hooks, "_current_invocation_id", lambda: "inv-1")
@@ -31,5 +31,5 @@ def test_run_end_flushes_and_closes(monkeypatch):
 
     hooks.on_run_end(adapter)
 
-    coord.flush.assert_called_once_with()
+    coord.flush.assert_not_called()
     coord.close.assert_called_once_with("inv-1")


### PR DESCRIPTION
## Description
- Adds default-off, opt-in `POST_PARSE` telemetry for `build`, `run`, `test`, `seed`, and `snapshot`.
-  Events contain aggregate invocation, manifest, compute/auth, and behavior-flag data.
- Sending is asynchronous and best-effort, requires a successful SQL connection, and never affects dbt execution.
- Stacked follow-up: **POST_RUN** (#1648).

## Testing
Ran dbt build with telemetry opted in and manually verified the POST_PARSE event landed in the dbt telemetry table