### PR TITLE
Plan typed table and incremental materialization operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 
 ### Under the Hood
 
-- Add typed table and incremental operation planning for compatible dbt-core versions, including explicit catalog-provider and DBR-capability facts and distinct Delta, UniForm Iceberg, and managed Iceberg replacement behavior.
+- Add typed table and incremental operation planning for compatible dbt-core versions, including explicit catalog-provider and DBR-capability facts and distinct Delta, UniForm Iceberg, and managed Iceberg replacement behavior. ([#1651](https://github.com/databricks/dbt-databricks/pull/1651))
 
 ## dbt-databricks 1.12.4 (Aug 12, 2026)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 - Replace an existing table or view with a metric view using backup-and-create instead of `CREATE OR REPLACE VIEW ... WITH METRICS` ([#1640](https://github.com/databricks/dbt-databricks/pull/1640) resolves [#1639](https://github.com/databricks/dbt-databricks/issues/1639))
 - Interpolate lazily-formatted `databricks.sql` log records when mirroring them into dbt logs ([#1642](https://github.com/databricks/dbt-databricks/pull/1642) resolves [#1637](https://github.com/databricks/dbt-databricks/issues/1637))
 
+### Under the Hood
+
+- Add typed table and incremental operation planning for compatible dbt-core versions, including explicit catalog-provider and DBR-capability facts and distinct Delta, UniForm Iceberg, and managed Iceberg replacement behavior.
+
 ## dbt-databricks 1.12.4 (Aug 12, 2026)
 
 ### Fixes

--- a/dbt/adapters/databricks/catalogs/_hive_metastore.py
+++ b/dbt/adapters/databricks/catalogs/_hive_metastore.py
@@ -4,7 +4,10 @@ from dbt.adapters.catalogs import CatalogIntegration, CatalogIntegrationConfig
 from dbt.adapters.contracts.relation import RelationConfig
 
 from dbt.adapters.databricks import constants, parse_model
-from dbt.adapters.databricks.catalogs._relation import DatabricksCatalogRelation
+from dbt.adapters.databricks.catalogs._relation import (
+    DatabricksCatalogRelation,
+    normalize_catalog_provider,
+)
 
 
 class HiveMetastoreCatalogIntegration(CatalogIntegration):
@@ -14,6 +17,9 @@ class HiveMetastoreCatalogIntegration(CatalogIntegration):
     def __init__(self, config: CatalogIntegrationConfig) -> None:
         super().__init__(config)
         self.file_format: Optional[str] = config.file_format
+        self.catalog_provider = normalize_catalog_provider(
+            config.adapter_properties.get("catalog_provider")
+        )
 
     @property
     def location_root(self) -> Optional[str]:
@@ -42,4 +48,5 @@ class HiveMetastoreCatalogIntegration(CatalogIntegration):
             file_format=parse_model.file_format(model) or self.file_format,
             external_volume=parse_model.location_root(model) or self.external_volume,
             location_path=parse_model.location_path(model),
+            catalog_provider=self.catalog_provider,
         )

--- a/dbt/adapters/databricks/catalogs/_relation.py
+++ b/dbt/adapters/databricks/catalogs/_relation.py
@@ -7,6 +7,15 @@ from dbt_common.exceptions import DbtConfigError
 from dbt.adapters.databricks import constants
 
 
+def normalize_catalog_provider(value: object) -> Optional[str]:
+    if value is None:
+        return None
+    provider = str(value).strip().casefold()
+    if not provider:
+        raise DbtConfigError("Databricks catalog_provider cannot be blank")
+    return provider
+
+
 @dataclass
 class DatabricksCatalogRelation:
     catalog_type: str = constants.DEFAULT_CATALOG.catalog_type
@@ -18,6 +27,7 @@ class DatabricksCatalogRelation:
     # The physical Unity catalog to route models to, independent of the dbt catalog
     # label. Takes precedence over catalog_name in generate_database_name.
     catalog_database: Optional[str] = None
+    catalog_provider: Optional[str] = None
 
     @property
     def location_root(self) -> Optional[str]:

--- a/dbt/adapters/databricks/catalogs/_unity.py
+++ b/dbt/adapters/databricks/catalogs/_unity.py
@@ -5,7 +5,10 @@ from dbt.adapters.contracts.relation import RelationConfig
 from dbt_common.exceptions import DbtValidationError
 
 from dbt.adapters.databricks import constants, parse_model
-from dbt.adapters.databricks.catalogs._relation import DatabricksCatalogRelation
+from dbt.adapters.databricks.catalogs._relation import (
+    DatabricksCatalogRelation,
+    normalize_catalog_provider,
+)
 from dbt.adapters.databricks.logging import logger
 
 
@@ -28,6 +31,9 @@ class UnityCatalogIntegration(CatalogIntegration):
                 )
             self.external_volume: Optional[str] = location_root
         self.file_format: Optional[str] = config.file_format
+        self.catalog_provider = normalize_catalog_provider(
+            config.adapter_properties.get("catalog_provider")
+        )
         if config.adapter_properties.get("use_uniform") is not None:
             logger.warning(
                 f"Catalog '{config.name}': use_uniform is not yet supported by the adapter "
@@ -64,4 +70,5 @@ class UnityCatalogIntegration(CatalogIntegration):
             external_volume=parse_model.location_root(model) or self.external_volume,
             location_path=parse_model.location_path(model),
             catalog_database=self.catalog_database,
+            catalog_provider=self.catalog_provider,
         )

--- a/dbt/adapters/databricks/impl.py
+++ b/dbt/adapters/databricks/impl.py
@@ -23,6 +23,9 @@ from dbt.adapters.contracts.relation import RelationConfig, RelationType
 from dbt.adapters.planning import (
     CreateFromQueryFacts,
     FormatFacts,
+    IncrementalLifecyclePlan,
+    IncrementalMaterializationPlan,
+    IncrementalMutationPlan,
     MaterializationExecutionFacts,
     MaterializationHookStrategy,
     MaterializationOperation,
@@ -583,6 +586,234 @@ class DatabricksAdapter(SparkAdapter):
                         "Databricks SQL table materialization uses an ordered "
                         f"{'create-then-insert' if use_v2 else 'direct replacement'} "
                         "program resolved from physical Delta or Iceberg provider facts"
+                    ),
+                ),
+            ),
+        )
+
+    @available.parse_none
+    def plan_incremental_materialization(
+        self,
+        materialization_macro_id: str,
+        language: str,
+        model: Optional[RelationConfig] = None,
+    ) -> Optional[IncrementalMaterializationPlan]:
+        if (
+            language != "sql"
+            or materialization_macro_id
+            != "macro.dbt_databricks.materialization_incremental_databricks"
+            or not self.get_behavior_flag_no_warn(USE_MATERIALIZATION_V2["name"])
+        ):
+            return None
+        return IncrementalMaterializationPlan(
+            materialization_macro_id=materialization_macro_id,
+            provenance=(
+                PlanProvenance(
+                    rule="databricks.incremental.v2",
+                    detail=(
+                        "Databricks v2 SQL incremental materialization uses an ordered "
+                        "create-then-insert or mutation program"
+                    ),
+                ),
+            ),
+        )
+
+    @available
+    def resolve_incremental_lifecycle_plan(
+        self,
+        mutation_plan: IncrementalMutationPlan,
+        model: RelationConfig,
+        target_relation: BaseRelation,
+        existing_relation: Optional[BaseRelation],
+        *,
+        full_refresh: bool,
+        on_schema_change: Optional[str],
+        staging_is_temporary: bool,
+        contract_enforced: bool,
+        materialization_plan: Optional[IncrementalMaterializationPlan] = None,
+    ) -> IncrementalLifecyclePlan:
+        if (
+            materialization_plan is None
+            or materialization_plan.materialization_macro_id
+            != "macro.dbt_databricks.materialization_incremental_databricks"
+        ):
+            return super().resolve_incremental_lifecycle_plan(
+                mutation_plan,
+                model,
+                target_relation,
+                existing_relation,
+                full_refresh=full_refresh,
+                on_schema_change=on_schema_change,
+                staging_is_temporary=staging_is_temporary,
+                contract_enforced=contract_enforced,
+                materialization_plan=materialization_plan,
+            )
+
+        base_plan = super().resolve_incremental_lifecycle_plan(
+            mutation_plan,
+            model,
+            target_relation,
+            existing_relation,
+            full_refresh=full_refresh,
+            on_schema_change=on_schema_change,
+            staging_is_temporary=staging_is_temporary,
+            contract_enforced=contract_enforced,
+            materialization_plan=materialization_plan,
+        )
+        if model.config is None:
+            raise DbtConfigError("Databricks incremental planning requires model configuration")
+        config = model.config
+        existing = MaterializationRelationRole.EXISTING
+        target = MaterializationRelationRole.TARGET
+        intermediate = MaterializationRelationRole.INTERMEDIATE
+        staging = MaterializationRelationRole.STAGING
+        backup = MaterializationRelationRole.BACKUP
+        operations = [
+            MaterializationOperation(
+                kind=MaterializationOperationKind.RUN_HOOKS,
+                name="pre",
+                inside_transaction=False,
+            ),
+            MaterializationOperation(
+                kind=MaterializationOperationKind.RUN_HOOKS,
+                name="pre",
+                inside_transaction=True,
+            ),
+            MaterializationOperation(
+                kind=MaterializationOperationKind.CREATE_FROM_QUERY,
+                relation=intermediate,
+                temporary=True,
+                auto_begin=False,
+            ),
+        ]
+        replacing = existing_relation is not None and full_refresh
+        safe_create = bool(config.get("use_safer_relation_operations", False))
+        if existing_relation is None or replacing:
+            if (
+                replacing
+                and safe_create
+                and base_plan.facts.existing is not None
+                and base_plan.facts.existing.can_be_renamed
+            ):
+                operations.extend(
+                    (
+                        MaterializationOperation(
+                            kind=MaterializationOperationKind.CREATE_FROM_RELATION,
+                            relation=staging,
+                            source=intermediate,
+                        ),
+                        MaterializationOperation(
+                            kind=MaterializationOperationKind.DROP_RELATION_IF_EXISTS,
+                            relation=backup,
+                        ),
+                        MaterializationOperation(
+                            kind=MaterializationOperationKind.RENAME_RELATION,
+                            relation=existing,
+                            destination=backup,
+                        ),
+                        MaterializationOperation(
+                            kind=MaterializationOperationKind.RENAME_RELATION,
+                            relation=staging,
+                            destination=target,
+                        ),
+                        MaterializationOperation(
+                            kind=MaterializationOperationKind.DROP_RELATION_IF_EXISTS,
+                            relation=backup,
+                        ),
+                        MaterializationOperation(
+                            kind=MaterializationOperationKind.DROP_RELATION_IF_EXISTS,
+                            relation=intermediate,
+                        ),
+                    )
+                )
+            else:
+                if (
+                    replacing
+                    and base_plan.facts.existing is not None
+                    and base_plan.facts.existing.requires_drop_before_replace
+                ):
+                    operations.append(
+                        MaterializationOperation(
+                            kind=MaterializationOperationKind.DROP_RELATION_IF_EXISTS,
+                            relation=existing,
+                        )
+                    )
+                operations.append(
+                    MaterializationOperation(
+                        kind=MaterializationOperationKind.CREATE_FROM_RELATION,
+                        relation=target,
+                        source=intermediate,
+                    )
+                )
+        else:
+            use_dynamic_overwrite = mutation_plan.requested_strategy == "insert_overwrite" and bool(
+                config.get("partition_by")
+            )
+            if use_dynamic_overwrite:
+                operations.append(
+                    MaterializationOperation(
+                        kind=MaterializationOperationKind.SET_INCREMENTAL_OVERWRITE_MODE,
+                        name="DYNAMIC",
+                    )
+                )
+            operations.extend(
+                (
+                    MaterializationOperation(
+                        kind=MaterializationOperationKind.PROCESS_SCHEMA_CHANGES,
+                        relation=existing,
+                        source=intermediate,
+                    ),
+                    MaterializationOperation(
+                        kind=MaterializationOperationKind.PROCESS_CONFIG_CHANGES,
+                        relation=target,
+                        source=existing,
+                    ),
+                    MaterializationOperation(
+                        kind=MaterializationOperationKind.EXECUTE_INCREMENTAL_MUTATION,
+                        relation=target,
+                        source=intermediate,
+                    ),
+                )
+            )
+            if mutation_plan.requested_strategy == "insert_overwrite":
+                operations.append(
+                    MaterializationOperation(
+                        kind=MaterializationOperationKind.SET_INCREMENTAL_OVERWRITE_MODE,
+                        name="STATIC",
+                    )
+                )
+        operations.extend(
+            (
+                MaterializationOperation(
+                    kind=MaterializationOperationKind.APPLY_GRANTS,
+                    relation=target,
+                ),
+                MaterializationOperation(
+                    kind=MaterializationOperationKind.OPTIMIZE,
+                    relation=target,
+                ),
+                MaterializationOperation(
+                    kind=MaterializationOperationKind.RUN_HOOKS,
+                    name="post",
+                    inside_transaction=True,
+                ),
+                MaterializationOperation(
+                    kind=MaterializationOperationKind.RUN_HOOKS,
+                    name="post",
+                    inside_transaction=False,
+                ),
+            )
+        )
+        return replace(
+            base_plan,
+            operations=tuple(operations),
+            provenance=base_plan.provenance
+            + (
+                PlanProvenance(
+                    rule="databricks.incremental.v2.operations",
+                    detail=(
+                        "Databricks v2 staging, replacement or mutation, config changes, "
+                        "overwrite mode, grants, optimize, and hooks are ordered explicitly"
                     ),
                 ),
             ),

--- a/dbt/adapters/databricks/impl.py
+++ b/dbt/adapters/databricks/impl.py
@@ -527,7 +527,14 @@ class DatabricksAdapter(SparkAdapter):
             if managed_iceberg
             else facts.format.file_format
         )
-        capabilities.append("managed_iceberg" if managed_iceberg else "uniform_or_native_format")
+        if managed_iceberg:
+            capabilities.append("managed_iceberg")
+        elif table_format == constants.ICEBERG_TABLE_FORMAT and provider == (
+            constants.DELTA_FILE_FORMAT
+        ):
+            capabilities.append("uniform_iceberg")
+        else:
+            capabilities.append("native_table_format")
         return replace(
             facts,
             format=replace(facts.format, table_provider=provider),
@@ -565,7 +572,9 @@ class DatabricksAdapter(SparkAdapter):
         provider = facts.format.table_provider
         runtime_capabilities = set(facts.capabilities)
         if effective == "insert_overwrite":
-            use_replace_on = "replace_on" in runtime_capabilities and (
+            use_replace_on = provider == constants.DELTA_FILE_FORMAT and (
+                "replace_on" in runtime_capabilities
+            ) and (
                 facts.runtime.engine == "databricks_runtime"
                 or "replace_on_for_insert_overwrite" in runtime_capabilities
             )
@@ -593,6 +602,12 @@ class DatabricksAdapter(SparkAdapter):
                 "replace_where_by_name"
                 if "insert_by_name_replace_where" in runtime_capabilities
                 else "replace_where_positional"
+            )
+        elif effective == "append":
+            renderer_variant = (
+                "append_by_name"
+                if "insert_by_name" in runtime_capabilities
+                else "append_positional"
             )
         else:
             renderer_variant = f"{effective}_{provider or 'unknown'}"
@@ -661,8 +676,13 @@ class DatabricksAdapter(SparkAdapter):
     def _create_and_populate_from_relation_operations(
         relation: MaterializationRelationRole,
         source: MaterializationRelationRole,
+        *,
+        use_insert_by_name: bool,
+        apply_tags: bool,
+        apply_column_tags: bool,
+        tag_renderer_variant: str,
     ) -> tuple[MaterializationOperation, ...]:
-        return (
+        operations = [
             MaterializationOperation(
                 kind=MaterializationOperationKind.CREATE_STRUCTURE_FROM_RELATION,
                 relation=relation,
@@ -672,20 +692,112 @@ class DatabricksAdapter(SparkAdapter):
                 kind=MaterializationOperationKind.APPLY_ALTER_CONSTRAINTS,
                 relation=relation,
             ),
-            MaterializationOperation(
-                kind=MaterializationOperationKind.APPLY_TAGS,
-                relation=relation,
-            ),
-            MaterializationOperation(
-                kind=MaterializationOperationKind.APPLY_COLUMN_TAGS,
-                relation=relation,
-            ),
+        ]
+        if apply_tags:
+            operations.append(
+                MaterializationOperation(
+                    kind=MaterializationOperationKind.APPLY_TAGS,
+                    relation=relation,
+                    renderer_variant=tag_renderer_variant,
+                )
+            )
+        if apply_column_tags:
+            operations.append(
+                MaterializationOperation(
+                    kind=MaterializationOperationKind.APPLY_COLUMN_TAGS,
+                    relation=relation,
+                    renderer_variant=tag_renderer_variant,
+                )
+            )
+        operations.append(
             MaterializationOperation(
                 kind=MaterializationOperationKind.INSERT_FROM_RELATION,
                 relation=relation,
                 source=source,
-            ),
+                renderer_variant="by_name" if use_insert_by_name else "positional",
+            )
         )
+        return tuple(operations)
+
+    @staticmethod
+    def _config_as_bool(value: Any, *, default: bool = False) -> bool:
+        """Match Jinja's ``as_bool`` semantics for planner inputs."""
+
+        if value is None:
+            return default
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, str):
+            normalized = value.strip().casefold()
+            if normalized in {"1", "true", "yes", "on"}:
+                return True
+            if normalized in {"0", "false", "no", "off", ""}:
+                return False
+        return bool(value)
+
+    @classmethod
+    def _planned_optimize_variant(
+        cls,
+        config: Mapping[str, Any],
+        facts: TableMaterializationFacts,
+    ) -> Optional[str]:
+        """Resolve whether and how OPTIMIZE renders before execution begins."""
+
+        if (
+            facts.create.format.table_provider != constants.DELTA_FILE_FORMAT
+            or cls._config_as_bool(config.get("skip_optimize"))
+        ):
+            return None
+        liquid = bool(config.get("liquid_clustered_by")) or cls._config_as_bool(
+            config.get("auto_liquid_cluster")
+        )
+        zorder = bool(config.get("zorder"))
+        if not liquid and not zorder:
+            return None
+        return "plain" if liquid else "zorder"
+
+    @staticmethod
+    def _column_comment_renderer_variant(facts: TableMaterializationFacts) -> str:
+        provider = facts.create.format.table_provider
+        if provider not in {constants.DELTA_FILE_FORMAT, constants.HUDI_FILE_FORMAT}:
+            return "unsupported"
+        if "comment_on_column" in facts.execution.capabilities:
+            return "comment_on_column"
+        return "alter_column"
+
+    @classmethod
+    def _constraints_requested(cls, config: Mapping[str, Any]) -> bool:
+        contract = config.get("contract")
+        contract_enforced = (
+            contract.get("enforced")
+            if isinstance(contract, Mapping)
+            else getattr(contract, "enforced", False)
+        )
+        return cls._config_as_bool(contract_enforced) or cls._config_as_bool(
+            config.get("persist_constraints")
+        )
+
+    @staticmethod
+    def _constraint_renderer_variant(facts: TableMaterializationFacts) -> str:
+        if facts.create.format.table_provider == constants.DELTA_FILE_FORMAT:
+            return "delta"
+        return "unsupported"
+
+    def _planned_tag_operations(
+        self,
+        model: RelationConfig,
+        config: Mapping[str, Any],
+        facts: TableMaterializationFacts,
+    ) -> tuple[bool, bool, str]:
+        apply_tags = bool(config.get("databricks_tags"))
+        column_tags = self.get_column_tags_from_model(model)
+        apply_column_tags = bool(column_tags and column_tags.set_column_tags)
+        catalog_type = facts.create.catalog.catalog_type or "unknown"
+        if catalog_type == constants.HIVE_METASTORE_CATALOG_TYPE and (
+            apply_tags or apply_column_tags
+        ):
+            raise DbtConfigError("Tags are only supported for Unity Catalog")
+        return apply_tags, apply_column_tags, catalog_type
 
     def get_table_materialization_execution_facts(
         self,
@@ -873,13 +985,31 @@ class DatabricksAdapter(SparkAdapter):
             contract_enforced=contract_enforced,
             materialization_plan=materialization_plan,
         )
+        use_insert_by_name = "insert_by_name" in base_plan.facts.execution.capabilities
         if model.config is None:
             raise DbtConfigError("Databricks incremental planning requires model configuration")
         config = model.config
+        apply_config_changes = self._config_as_bool(
+            config.get("incremental_apply_config_changes"), default=True
+        )
+        optimize_variant = self._planned_optimize_variant(config, base_plan.facts)
+        apply_tags, apply_column_tags, tag_variant = self._planned_tag_operations(
+            model, config, base_plan.facts
+        )
+        if (
+            mutation_plan.requested_strategy == "insert_overwrite"
+            and mutation_plan.facts.format.table_provider == constants.ICEBERG_TABLE_FORMAT
+            and config.get("partition_by")
+        ):
+            raise DbtConfigError(
+                "Partition-scoped insert_overwrite is only supported for Delta tables; "
+                "managed Iceberg supports whole-table INSERT OVERWRITE"
+            )
         if not self.get_behavior_flag_no_warn(USE_MATERIALIZATION_V2["name"]):
             return self._resolve_v1_incremental_lifecycle_plan(
                 base_plan,
                 mutation_plan,
+                model,
                 existing_relation,
                 full_refresh,
                 staging_is_temporary,
@@ -909,7 +1039,7 @@ class DatabricksAdapter(SparkAdapter):
             ),
         ]
         replacing = existing_relation is not None and full_refresh
-        safe_create = bool(config.get("use_safer_relation_operations", False))
+        safe_create = self._config_as_bool(config.get("use_safer_relation_operations"))
         if existing_relation is None or replacing:
             if (
                 replacing
@@ -920,7 +1050,12 @@ class DatabricksAdapter(SparkAdapter):
                 operations.extend(
                     (
                         *self._create_and_populate_from_relation_operations(
-                            staging, intermediate
+                            staging,
+                            intermediate,
+                            use_insert_by_name=use_insert_by_name,
+                            apply_tags=apply_tags,
+                            apply_column_tags=apply_column_tags,
+                            tag_renderer_variant=tag_variant,
                         ),
                         MaterializationOperation(
                             kind=MaterializationOperationKind.DROP_RELATION_IF_EXISTS,
@@ -959,7 +1094,14 @@ class DatabricksAdapter(SparkAdapter):
                         )
                     )
                 operations.extend(
-                    self._create_and_populate_from_relation_operations(target, intermediate)
+                    self._create_and_populate_from_relation_operations(
+                        target,
+                        intermediate,
+                        use_insert_by_name=use_insert_by_name,
+                        apply_tags=apply_tags,
+                        apply_column_tags=apply_column_tags,
+                        tag_renderer_variant=tag_variant,
+                    )
                 )
         else:
             use_dynamic_overwrite = mutation_plan.requested_strategy == "insert_overwrite" and bool(
@@ -972,23 +1114,27 @@ class DatabricksAdapter(SparkAdapter):
                         name="DYNAMIC",
                     )
                 )
-            operations.extend(
-                (
-                    MaterializationOperation(
-                        kind=MaterializationOperationKind.PROCESS_SCHEMA_CHANGES,
-                        relation=existing,
-                        source=intermediate,
-                    ),
+            operations.append(
+                MaterializationOperation(
+                    kind=MaterializationOperationKind.PROCESS_SCHEMA_CHANGES,
+                    relation=existing,
+                    source=intermediate,
+                )
+            )
+            if apply_config_changes:
+                operations.append(
                     MaterializationOperation(
                         kind=MaterializationOperationKind.PROCESS_CONFIG_CHANGES,
                         relation=target,
                         source=existing,
-                    ),
-                    MaterializationOperation(
-                        kind=MaterializationOperationKind.EXECUTE_INCREMENTAL_MUTATION,
-                        relation=target,
-                        source=intermediate,
-                    ),
+                        renderer_variant="enabled",
+                    )
+                )
+            operations.append(
+                MaterializationOperation(
+                    kind=MaterializationOperationKind.EXECUTE_INCREMENTAL_MUTATION,
+                    relation=target,
+                    source=intermediate,
                 )
             )
             if mutation_plan.requested_strategy == "insert_overwrite":
@@ -998,16 +1144,22 @@ class DatabricksAdapter(SparkAdapter):
                         name="STATIC",
                     )
                 )
-        operations.extend(
-            (
-                MaterializationOperation(
-                    kind=MaterializationOperationKind.APPLY_GRANTS,
-                    relation=target,
-                ),
+        operations.append(
+            MaterializationOperation(
+                kind=MaterializationOperationKind.APPLY_GRANTS,
+                relation=target,
+            )
+        )
+        if optimize_variant is not None:
+            operations.append(
                 MaterializationOperation(
                     kind=MaterializationOperationKind.OPTIMIZE,
                     relation=target,
-                ),
+                    renderer_variant=optimize_variant,
+                )
+            )
+        operations.extend(
+            (
                 MaterializationOperation(
                     kind=MaterializationOperationKind.RUN_HOOKS,
                     name="post",
@@ -1039,6 +1191,7 @@ class DatabricksAdapter(SparkAdapter):
         self,
         base_plan: IncrementalLifecyclePlan,
         mutation_plan: IncrementalMutationPlan,
+        model: RelationConfig,
         existing_relation: Optional[BaseRelation],
         full_refresh: bool,
         staging_is_temporary: bool,
@@ -1047,6 +1200,16 @@ class DatabricksAdapter(SparkAdapter):
         existing = MaterializationRelationRole.EXISTING
         target = MaterializationRelationRole.TARGET
         temp = MaterializationRelationRole.TEMP
+        apply_config_changes = self._config_as_bool(
+            config.get("incremental_apply_config_changes"), default=True
+        )
+        optimize_variant = self._planned_optimize_variant(config, base_plan.facts)
+        column_comment_variant = self._column_comment_renderer_variant(base_plan.facts)
+        constraints_requested = self._constraints_requested(config)
+        constraint_variant = self._constraint_renderer_variant(base_plan.facts)
+        apply_tags, apply_column_tags, tag_variant = self._planned_tag_operations(
+            model, config, base_plan.facts
+        )
         operations = [
             MaterializationOperation(
                 kind=MaterializationOperationKind.RUN_HOOKS,
@@ -1075,7 +1238,7 @@ class DatabricksAdapter(SparkAdapter):
                     auto_begin=False,
                 )
             )
-            if (
+            if constraints_requested and (
                 existing_relation is None
                 or base_plan.facts.existing is None
                 or base_plan.facts.existing.relation.relation_type != "view"
@@ -1084,23 +1247,31 @@ class DatabricksAdapter(SparkAdapter):
                     MaterializationOperation(
                         kind=MaterializationOperationKind.PERSIST_CONSTRAINTS,
                         relation=target,
+                        renderer_variant=constraint_variant,
                     )
                 )
-            operations.extend(
-                (
+            if apply_tags:
+                operations.append(
                     MaterializationOperation(
                         kind=MaterializationOperationKind.APPLY_TAGS,
                         relation=target,
-                    ),
+                        renderer_variant=tag_variant,
+                    )
+                )
+            if apply_column_tags:
+                operations.append(
                     MaterializationOperation(
                         kind=MaterializationOperationKind.APPLY_COLUMN_TAGS,
                         relation=target,
-                    ),
+                        renderer_variant=tag_variant,
+                    )
+                )
+            operations.append(
                     MaterializationOperation(
                         kind=MaterializationOperationKind.PERSIST_DOCUMENTATION,
                         relation=target,
-                    ),
-                )
+                        renderer_variant=column_comment_variant,
+                    )
             )
         else:
             use_dynamic_overwrite = mutation_plan.requested_strategy == "insert_overwrite" and bool(
@@ -1113,12 +1284,15 @@ class DatabricksAdapter(SparkAdapter):
                         name="DYNAMIC",
                     )
                 )
-            operations.extend(
-                (
+            if apply_config_changes:
+                operations.append(
                     MaterializationOperation(
                         kind=MaterializationOperationKind.CAPTURE_CONFIG_CHANGES,
                         relation=existing,
-                    ),
+                    )
+                )
+            operations.extend(
+                (
                     MaterializationOperation(
                         kind=MaterializationOperationKind.CREATE_FROM_QUERY,
                         relation=temp,
@@ -1135,28 +1309,40 @@ class DatabricksAdapter(SparkAdapter):
                         relation=target,
                         source=temp,
                     ),
+                )
+            )
+            if apply_config_changes:
+                operations.append(
                     MaterializationOperation(
                         kind=MaterializationOperationKind.APPLY_CONFIG_CHANGES,
                         relation=target,
                         source=existing,
-                    ),
-                    MaterializationOperation(
-                        kind=MaterializationOperationKind.PERSIST_DOCUMENTATION,
-                        relation=target,
-                        name="for_relation",
-                    ),
+                    )
+                )
+            operations.append(
+                MaterializationOperation(
+                    kind=MaterializationOperationKind.PERSIST_DOCUMENTATION,
+                    relation=target,
+                    name="for_relation",
+                    renderer_variant=column_comment_variant,
+                )
+            )
+        operations.append(
+            MaterializationOperation(
+                kind=MaterializationOperationKind.APPLY_GRANTS,
+                relation=target,
+            )
+        )
+        if optimize_variant is not None:
+            operations.append(
+                MaterializationOperation(
+                    kind=MaterializationOperationKind.OPTIMIZE,
+                    relation=target,
+                    renderer_variant=optimize_variant,
                 )
             )
         operations.extend(
             (
-                MaterializationOperation(
-                    kind=MaterializationOperationKind.APPLY_GRANTS,
-                    relation=target,
-                ),
-                MaterializationOperation(
-                    kind=MaterializationOperationKind.OPTIMIZE,
-                    relation=target,
-                ),
                 MaterializationOperation(
                     kind=MaterializationOperationKind.RUN_HOOKS,
                     name="post",
@@ -1207,6 +1393,14 @@ class DatabricksAdapter(SparkAdapter):
         staging = MaterializationRelationRole.STAGING
         backup = MaterializationRelationRole.BACKUP
         use_v2 = "materialization_v2" in facts.execution.capabilities
+        use_insert_by_name = "insert_by_name" in facts.execution.capabilities
+        optimize_variant = self._planned_optimize_variant(config, facts)
+        column_comment_variant = self._column_comment_renderer_variant(facts)
+        constraints_requested = self._constraints_requested(config)
+        constraint_variant = self._constraint_renderer_variant(facts)
+        apply_tags, apply_column_tags, tag_variant = self._planned_tag_operations(
+            model, config, facts
+        )
         if use_v2:
             operations = [
                 MaterializationOperation(
@@ -1226,12 +1420,17 @@ class DatabricksAdapter(SparkAdapter):
                     auto_begin=False,
                 ),
             ]
-            safe_create = bool(config.get("use_safer_relation_operations", False))
+            safe_create = self._config_as_bool(config.get("use_safer_relation_operations"))
             if facts.existing is not None and safe_create and facts.existing.can_be_renamed:
                 operations.extend(
                     (
                         *self._create_and_populate_from_relation_operations(
-                            staging, intermediate
+                            staging,
+                            intermediate,
+                            use_insert_by_name=use_insert_by_name,
+                            apply_tags=apply_tags,
+                            apply_column_tags=apply_column_tags,
+                            tag_renderer_variant=tag_variant,
                         ),
                         MaterializationOperation(
                             kind=MaterializationOperationKind.DROP_RELATION_IF_EXISTS,
@@ -1266,18 +1465,31 @@ class DatabricksAdapter(SparkAdapter):
                         )
                     )
                 operations.extend(
-                    self._create_and_populate_from_relation_operations(target, intermediate)
+                    self._create_and_populate_from_relation_operations(
+                        target,
+                        intermediate,
+                        use_insert_by_name=use_insert_by_name,
+                        apply_tags=apply_tags,
+                        apply_column_tags=apply_column_tags,
+                        tag_renderer_variant=tag_variant,
+                    )
                 )
-            operations.extend(
-                (
-                    MaterializationOperation(
-                        kind=MaterializationOperationKind.APPLY_GRANTS,
-                        relation=target,
-                    ),
+            operations.append(
+                MaterializationOperation(
+                    kind=MaterializationOperationKind.APPLY_GRANTS,
+                    relation=target,
+                )
+            )
+            if optimize_variant is not None:
+                operations.append(
                     MaterializationOperation(
                         kind=MaterializationOperationKind.OPTIMIZE,
                         relation=target,
-                    ),
+                        renderer_variant=optimize_variant,
+                    )
+                )
+            operations.extend(
+                (
                     MaterializationOperation(
                         kind=MaterializationOperationKind.RUN_HOOKS,
                         name="post",
@@ -1330,31 +1542,52 @@ class DatabricksAdapter(SparkAdapter):
                     kind=MaterializationOperationKind.APPLY_GRANTS,
                     relation=target,
                 ),
+            )
+        )
+        if apply_tags:
+            operations.append(
                 MaterializationOperation(
                     kind=MaterializationOperationKind.APPLY_TAGS,
                     relation=target,
-                ),
+                    renderer_variant=tag_variant,
+                )
+            )
+        if apply_column_tags:
+            operations.append(
                 MaterializationOperation(
                     kind=MaterializationOperationKind.APPLY_COLUMN_TAGS,
                     relation=target,
-                ),
-                MaterializationOperation(
-                    kind=MaterializationOperationKind.PERSIST_DOCUMENTATION,
-                    relation=target,
-                ),
+                    renderer_variant=tag_variant,
+                )
+            )
+        operations.append(
+            MaterializationOperation(
+                kind=MaterializationOperationKind.PERSIST_DOCUMENTATION,
+                relation=target,
+                renderer_variant=column_comment_variant,
+            )
+        )
+        if constraints_requested:
+            operations.append(
                 MaterializationOperation(
                     kind=MaterializationOperationKind.PERSIST_CONSTRAINTS,
                     relation=target,
-                ),
+                    renderer_variant=constraint_variant,
+                )
+            )
+        if optimize_variant is not None:
+            operations.append(
                 MaterializationOperation(
                     kind=MaterializationOperationKind.OPTIMIZE,
                     relation=target,
-                ),
-                MaterializationOperation(
-                    kind=MaterializationOperationKind.RUN_HOOKS,
-                    name="post",
-                    inside_transaction=True,
-                ),
+                    renderer_variant=optimize_variant,
+                )
+            )
+        operations.append(
+            MaterializationOperation(
+                kind=MaterializationOperationKind.RUN_HOOKS,
+                name="post",
+                inside_transaction=True,
             )
         )
         return plan.resolve(

--- a/dbt/adapters/databricks/impl.py
+++ b/dbt/adapters/databricks/impl.py
@@ -602,17 +602,17 @@ class DatabricksAdapter(SparkAdapter):
             language != "sql"
             or materialization_macro_id
             != "macro.dbt_databricks.materialization_incremental_databricks"
-            or not self.get_behavior_flag_no_warn(USE_MATERIALIZATION_V2["name"])
         ):
             return None
+        use_v2 = self.get_behavior_flag_no_warn(USE_MATERIALIZATION_V2["name"])
         return IncrementalMaterializationPlan(
             materialization_macro_id=materialization_macro_id,
             provenance=(
                 PlanProvenance(
-                    rule="databricks.incremental.v2",
+                    rule=("databricks.incremental.v2" if use_v2 else "databricks.incremental.v1"),
                     detail=(
-                        "Databricks v2 SQL incremental materialization uses an ordered "
-                        "create-then-insert or mutation program"
+                        "Databricks SQL incremental materialization uses an ordered "
+                        f"{'create-then-insert' if use_v2 else 'direct create'} or mutation program"
                     ),
                 ),
             ),
@@ -663,6 +663,15 @@ class DatabricksAdapter(SparkAdapter):
         if model.config is None:
             raise DbtConfigError("Databricks incremental planning requires model configuration")
         config = model.config
+        if not self.get_behavior_flag_no_warn(USE_MATERIALIZATION_V2["name"]):
+            return self._resolve_v1_incremental_lifecycle_plan(
+                base_plan,
+                mutation_plan,
+                existing_relation,
+                full_refresh,
+                staging_is_temporary,
+                config,
+            )
         existing = MaterializationRelationRole.EXISTING
         target = MaterializationRelationRole.TARGET
         intermediate = MaterializationRelationRole.INTERMEDIATE
@@ -814,6 +823,158 @@ class DatabricksAdapter(SparkAdapter):
                     detail=(
                         "Databricks v2 staging, replacement or mutation, config changes, "
                         "overwrite mode, grants, optimize, and hooks are ordered explicitly"
+                    ),
+                ),
+            ),
+        )
+
+    def _resolve_v1_incremental_lifecycle_plan(
+        self,
+        base_plan: IncrementalLifecyclePlan,
+        mutation_plan: IncrementalMutationPlan,
+        existing_relation: Optional[BaseRelation],
+        full_refresh: bool,
+        staging_is_temporary: bool,
+        config: BaseConfig,
+    ) -> IncrementalLifecyclePlan:
+        existing = MaterializationRelationRole.EXISTING
+        target = MaterializationRelationRole.TARGET
+        temp = MaterializationRelationRole.TEMP
+        operations = [
+            MaterializationOperation(
+                kind=MaterializationOperationKind.RUN_HOOKS,
+                name="pre",
+                inside_transaction=True,
+            )
+        ]
+        replacing = existing_relation is not None and full_refresh
+        if existing_relation is None or replacing:
+            if (
+                replacing
+                and base_plan.facts.existing is not None
+                and base_plan.facts.existing.requires_drop_before_replace
+            ):
+                operations.append(
+                    MaterializationOperation(
+                        kind=MaterializationOperationKind.DROP_RELATION_IF_EXISTS,
+                        relation=existing,
+                    )
+                )
+            operations.append(
+                MaterializationOperation(
+                    kind=MaterializationOperationKind.CREATE_FROM_QUERY,
+                    relation=target,
+                    temporary=False,
+                    auto_begin=False,
+                )
+            )
+            if (
+                existing_relation is None
+                or base_plan.facts.existing is None
+                or base_plan.facts.existing.relation.relation_type != "view"
+            ):
+                operations.append(
+                    MaterializationOperation(
+                        kind=MaterializationOperationKind.PERSIST_CONSTRAINTS,
+                        relation=target,
+                    )
+                )
+            operations.extend(
+                (
+                    MaterializationOperation(
+                        kind=MaterializationOperationKind.APPLY_TAGS,
+                        relation=target,
+                    ),
+                    MaterializationOperation(
+                        kind=MaterializationOperationKind.APPLY_COLUMN_TAGS,
+                        relation=target,
+                    ),
+                    MaterializationOperation(
+                        kind=MaterializationOperationKind.PERSIST_DOCUMENTATION,
+                        relation=target,
+                    ),
+                )
+            )
+        else:
+            use_dynamic_overwrite = mutation_plan.requested_strategy == "insert_overwrite" and bool(
+                config.get("partition_by")
+            )
+            if use_dynamic_overwrite:
+                operations.append(
+                    MaterializationOperation(
+                        kind=MaterializationOperationKind.SET_INCREMENTAL_OVERWRITE_MODE,
+                        name="DYNAMIC",
+                    )
+                )
+            operations.extend(
+                (
+                    MaterializationOperation(
+                        kind=MaterializationOperationKind.CAPTURE_CONFIG_CHANGES,
+                        relation=existing,
+                    ),
+                    MaterializationOperation(
+                        kind=MaterializationOperationKind.CREATE_FROM_QUERY,
+                        relation=temp,
+                        temporary=staging_is_temporary,
+                        auto_begin=False,
+                    ),
+                    MaterializationOperation(
+                        kind=MaterializationOperationKind.PROCESS_SCHEMA_CHANGES,
+                        relation=existing,
+                        source=temp,
+                    ),
+                    MaterializationOperation(
+                        kind=MaterializationOperationKind.EXECUTE_INCREMENTAL_MUTATION,
+                        relation=target,
+                        source=temp,
+                    ),
+                    MaterializationOperation(
+                        kind=MaterializationOperationKind.APPLY_CONFIG_CHANGES,
+                        relation=target,
+                        source=existing,
+                    ),
+                    MaterializationOperation(
+                        kind=MaterializationOperationKind.PERSIST_DOCUMENTATION,
+                        relation=target,
+                        name="for_relation",
+                    ),
+                )
+            )
+        operations.extend(
+            (
+                MaterializationOperation(
+                    kind=MaterializationOperationKind.APPLY_GRANTS,
+                    relation=target,
+                ),
+                MaterializationOperation(
+                    kind=MaterializationOperationKind.OPTIMIZE,
+                    relation=target,
+                ),
+                MaterializationOperation(
+                    kind=MaterializationOperationKind.RUN_HOOKS,
+                    name="post",
+                    inside_transaction=True,
+                ),
+            )
+        )
+        if mutation_plan.requested_strategy == "insert_overwrite" and not full_refresh:
+            operations.append(
+                MaterializationOperation(
+                    kind=MaterializationOperationKind.SET_INCREMENTAL_OVERWRITE_MODE,
+                    name="STATIC",
+                )
+            )
+        return replace(
+            base_plan,
+            operations=tuple(operations),
+            provenance=base_plan.provenance
+            + (
+                PlanProvenance(
+                    rule="databricks.incremental.v1.operations",
+                    detail=(
+                        "Databricks v1 creation or mutation, captured config changes, "
+                        "overwrite mode, metadata, grants, optimize, and hooks are "
+                        "ordered explicitly"
                     ),
                 ),
             ),

--- a/dbt/adapters/databricks/impl.py
+++ b/dbt/adapters/databricks/impl.py
@@ -3,10 +3,10 @@ import posixpath
 import re
 from abc import ABC, abstractmethod
 from collections import defaultdict
-from collections.abc import Iterable, Iterator
+from collections.abc import Iterable, Iterator, Mapping
 from concurrent.futures import Future
 from contextlib import contextmanager
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from importlib import metadata
 from multiprocessing.context import SpawnContext
 from typing import TYPE_CHECKING, Any, ClassVar, Generic, NamedTuple, Optional, Union, cast
@@ -20,6 +20,22 @@ from dbt.adapters.capability import Capability, CapabilityDict, CapabilitySuppor
 from dbt.adapters.catalogs import CatalogRelation
 from dbt.adapters.contracts.connection import AdapterResponse, Connection
 from dbt.adapters.contracts.relation import RelationConfig, RelationType
+from dbt.adapters.planning import (
+    CreateFromQueryFacts,
+    FormatFacts,
+    MaterializationExecutionFacts,
+    MaterializationHookStrategy,
+    MaterializationOperation,
+    MaterializationOperationKind,
+    MaterializationRelationRole,
+    MaterializationStatementStrategy,
+    MaterializationTransactionMode,
+    MaterializationTransactionStrategy,
+    PlanProvenance,
+    RuntimeFacts,
+    TableLifecyclePlan,
+    TableMaterializationFacts,
+)
 from dbt.adapters.relation_configs import RelationResults
 from dbt.adapters.spark.impl import (
     DESCRIBE_TABLE_EXTENDED_MACRO_NAME,
@@ -366,6 +382,401 @@ class DatabricksAdapter(SparkAdapter):
             return not self.get_behavior_flag_no_warn(USE_MANAGED_ICEBERG["name"])
         else:
             return False
+
+    def get_create_from_query_catalog_provider(
+        self,
+        catalog_relation: CatalogRelation,
+        model: Optional[RelationConfig],
+    ) -> Optional[str]:
+        """Return an explicit provider without inferring Glue from Hive Metastore."""
+
+        provider = getattr(catalog_relation, "catalog_provider", None)
+        return str(provider).casefold() if provider is not None else None
+
+    def get_create_from_query_runtime_facts(
+        self,
+        temporary: bool,
+        relation: BaseRelation,
+        model: Optional[RelationConfig],
+    ) -> RuntimeFacts:
+        connection = cast(
+            DatabricksDBTConnection,
+            self.connections.get_thread_connection(),
+        )
+        capabilities = connection.capabilities
+        runtime_version = capabilities.dbr_version
+        return RuntimeFacts(
+            engine=(
+                "databricks_sql_warehouse"
+                if capabilities.is_sql_warehouse
+                else "databricks_runtime"
+            ),
+            version=(
+                f"{runtime_version[0]}.{runtime_version[1]}"
+                if runtime_version is not None
+                else None
+            ),
+        )
+
+    def build_create_from_query_facts(
+        self,
+        temporary: bool,
+        relation: BaseRelation,
+        model: Optional[RelationConfig] = None,
+    ) -> CreateFromQueryFacts:
+        facts = super().build_create_from_query_facts(temporary, relation, model)
+        if model is None:
+            return facts
+        if model.config is None:
+            raise DbtConfigError("Databricks create planning requires model configuration")
+        model_config = model.config
+
+        catalog_relation = cast(
+            Optional[DatabricksCatalogRelation],
+            self.build_catalog_relation(model),
+        )
+        table_format = (
+            catalog_relation.table_format
+            if catalog_relation is not None
+            else model_config.get("table_format")
+        )
+        if table_format == constants.ICEBERG_TABLE_FORMAT:
+            self.require_capability(DBRCapability.ICEBERG)
+            if (
+                self.get_behavior_flag_no_warn(USE_MANAGED_ICEBERG["name"])
+                and catalog_relation is not None
+                and catalog_relation.catalog_type != constants.UNITY_CATALOG_TYPE
+            ):
+                raise DbtConfigError(
+                    "Managed Iceberg tables are only supported in Unity Catalog. "
+                    "Set 'use_managed_iceberg' behavior flag to false for Hive Metastore."
+                )
+
+        return replace(
+            facts,
+            format=FormatFacts(
+                table_format=self._create_from_query_fact_value(
+                    table_format,
+                    canonical=True,
+                ),
+                file_format=self._create_from_query_fact_value(
+                    self.resolve_file_format(model_config),
+                    canonical=True,
+                ),
+            ),
+        )
+
+    def get_table_materialization_execution_facts(
+        self,
+        model: RelationConfig,
+        target_relation: BaseRelation,
+    ) -> MaterializationExecutionFacts:
+        if model.config is None:
+            raise DbtConfigError("Databricks table planning requires model configuration")
+        model_config = model.config
+        connection = cast(
+            DatabricksDBTConnection,
+            self.connections.get_thread_connection(),
+        )
+        enabled = tuple(
+            sorted(
+                capability.value for capability in connection.capabilities.enabled_capabilities()
+            )
+        )
+        catalog_relation = cast(
+            Optional[DatabricksCatalogRelation],
+            self.build_catalog_relation(model),
+        )
+        capabilities = list(enabled)
+        if catalog_relation is not None:
+            capabilities.append(f"catalog_type:{catalog_relation.catalog_type}")
+            if catalog_relation.catalog_provider is not None:
+                capabilities.append(f"catalog_provider:{catalog_relation.catalog_provider}")
+        table_format = (
+            catalog_relation.table_format
+            if catalog_relation is not None
+            else model_config.get("table_format")
+        )
+        if table_format == constants.ICEBERG_TABLE_FORMAT:
+            capabilities.append(
+                "managed_iceberg"
+                if self.get_behavior_flag_no_warn(USE_MANAGED_ICEBERG["name"])
+                else "uniform_iceberg"
+            )
+        if self.get_behavior_flag_no_warn(USE_MATERIALIZATION_V2["name"]):
+            capabilities.append("materialization_v2")
+        return MaterializationExecutionFacts(
+            transaction_mode=MaterializationTransactionMode.NONE,
+            capabilities=tuple(dict.fromkeys(capabilities)),
+        )
+
+    def build_table_materialization_facts(
+        self,
+        model: RelationConfig,
+        target_relation: BaseRelation,
+        existing_relation: Optional[BaseRelation],
+    ) -> TableMaterializationFacts:
+        facts = super().build_table_materialization_facts(
+            model,
+            target_relation,
+            existing_relation,
+        )
+        if facts.existing is None or existing_relation is None:
+            return facts
+
+        existing_provider = self._create_from_query_fact_value(
+            (getattr(existing_relation, "metadata", None) or {}).get(KEY_TABLE_PROVIDER),
+            canonical=True,
+        )
+        managed_iceberg = (
+            facts.create.format.table_format == constants.ICEBERG_TABLE_FORMAT
+            and self.get_behavior_flag_no_warn(USE_MANAGED_ICEBERG["name"])
+        )
+        desired_provider = (
+            constants.ICEBERG_TABLE_FORMAT if managed_iceberg else facts.create.format.file_format
+        )
+        existing = replace(
+            facts.existing,
+            format=FormatFacts(
+                table_format=(
+                    constants.ICEBERG_TABLE_FORMAT
+                    if existing_provider == constants.ICEBERG_TABLE_FORMAT
+                    else None
+                ),
+                file_format=existing_provider,
+            ),
+            requires_drop_before_replace=(
+                facts.existing.is_shallow_clone
+                or facts.existing.relation.relation_type != "table"
+                or not facts.existing.can_be_replaced
+                or desired_provider
+                not in {
+                    constants.DELTA_FILE_FORMAT,
+                    constants.ICEBERG_TABLE_FORMAT,
+                }
+                or existing_provider != desired_provider
+            ),
+        )
+        return replace(facts, existing=existing)
+
+    @available.parse_none
+    def plan_table_materialization(
+        self,
+        materialization_macro_id: str,
+        language: str,
+        model: Optional[RelationConfig] = None,
+    ) -> Optional[TableLifecyclePlan]:
+        if (
+            language != "sql"
+            or materialization_macro_id != "macro.dbt_databricks.materialization_table_databricks"
+        ):
+            return None
+        use_v2 = self.get_behavior_flag_no_warn(USE_MATERIALIZATION_V2["name"])
+        return TableLifecyclePlan.direct_replace(
+            transaction=MaterializationTransactionStrategy.ADAPTER_MANAGED,
+            hooks=MaterializationHookStrategy.IN_TRANSACTION,
+            statement=MaterializationStatementStrategy.NO_AUTO_BEGIN,
+            provenance=(
+                PlanProvenance(
+                    rule="databricks.table.v2" if use_v2 else "databricks.table.v1",
+                    detail=(
+                        "Databricks SQL table materialization uses an ordered "
+                        f"{'create-then-insert' if use_v2 else 'direct replacement'} "
+                        "program resolved from physical Delta or Iceberg provider facts"
+                    ),
+                ),
+            ),
+        )
+
+    @available
+    def resolve_table_lifecycle_plan(
+        self,
+        plan: TableLifecyclePlan,
+        model: RelationConfig,
+        target_relation: BaseRelation,
+        existing_relation: Optional[BaseRelation],
+        config: Mapping[str, Any],
+    ) -> TableLifecyclePlan:
+        facts = self.build_table_materialization_facts(
+            model,
+            target_relation,
+            existing_relation,
+        )
+        target = MaterializationRelationRole.TARGET
+        existing = MaterializationRelationRole.EXISTING
+        intermediate = MaterializationRelationRole.INTERMEDIATE
+        staging = MaterializationRelationRole.STAGING
+        backup = MaterializationRelationRole.BACKUP
+        use_v2 = "materialization_v2" in facts.execution.capabilities
+        if use_v2:
+            operations = [
+                MaterializationOperation(
+                    kind=MaterializationOperationKind.RUN_HOOKS,
+                    name="pre",
+                    inside_transaction=False,
+                ),
+                MaterializationOperation(
+                    kind=MaterializationOperationKind.RUN_HOOKS,
+                    name="pre",
+                    inside_transaction=True,
+                ),
+                MaterializationOperation(
+                    kind=MaterializationOperationKind.CREATE_FROM_QUERY,
+                    relation=intermediate,
+                    temporary=True,
+                    auto_begin=False,
+                ),
+            ]
+            safe_create = bool(config.get("use_safer_relation_operations", False))
+            if facts.existing is not None and safe_create and facts.existing.can_be_renamed:
+                operations.extend(
+                    (
+                        MaterializationOperation(
+                            kind=MaterializationOperationKind.CREATE_FROM_RELATION,
+                            relation=staging,
+                            source=intermediate,
+                        ),
+                        MaterializationOperation(
+                            kind=MaterializationOperationKind.DROP_RELATION_IF_EXISTS,
+                            relation=backup,
+                        ),
+                        MaterializationOperation(
+                            kind=MaterializationOperationKind.RENAME_RELATION,
+                            relation=existing,
+                            destination=backup,
+                        ),
+                        MaterializationOperation(
+                            kind=MaterializationOperationKind.RENAME_RELATION,
+                            relation=staging,
+                            destination=target,
+                        ),
+                        MaterializationOperation(
+                            kind=MaterializationOperationKind.DROP_RELATION_IF_EXISTS,
+                            relation=backup,
+                        ),
+                        MaterializationOperation(
+                            kind=MaterializationOperationKind.DROP_RELATION_IF_EXISTS,
+                            relation=intermediate,
+                        ),
+                    )
+                )
+            else:
+                if facts.existing is not None and facts.existing.requires_drop_before_replace:
+                    operations.append(
+                        MaterializationOperation(
+                            kind=MaterializationOperationKind.DROP_RELATION_IF_EXISTS,
+                            relation=existing,
+                        )
+                    )
+                operations.append(
+                    MaterializationOperation(
+                        kind=MaterializationOperationKind.CREATE_FROM_RELATION,
+                        relation=target,
+                        source=intermediate,
+                    )
+                )
+            operations.extend(
+                (
+                    MaterializationOperation(
+                        kind=MaterializationOperationKind.APPLY_GRANTS,
+                        relation=target,
+                    ),
+                    MaterializationOperation(
+                        kind=MaterializationOperationKind.OPTIMIZE,
+                        relation=target,
+                    ),
+                    MaterializationOperation(
+                        kind=MaterializationOperationKind.RUN_HOOKS,
+                        name="post",
+                        inside_transaction=True,
+                    ),
+                    MaterializationOperation(
+                        kind=MaterializationOperationKind.RUN_HOOKS,
+                        name="post",
+                        inside_transaction=False,
+                    ),
+                )
+            )
+            return plan.resolve(
+                facts=facts,
+                operations=tuple(operations),
+                provenance=(
+                    PlanProvenance(
+                        rule="databricks.table.v2.operations",
+                        detail=(
+                            "Databricks create-then-insert, safe replacement, grants, "
+                            "optimization, and split hooks are ordered explicitly"
+                        ),
+                    ),
+                ),
+            )
+
+        operations = [
+            MaterializationOperation(
+                kind=MaterializationOperationKind.RUN_HOOKS,
+                name="pre",
+                inside_transaction=True,
+            )
+        ]
+        if facts.existing is not None and facts.existing.requires_drop_before_replace:
+            operations.append(
+                MaterializationOperation(
+                    kind=MaterializationOperationKind.DROP_RELATION_IF_EXISTS,
+                    relation=existing,
+                )
+            )
+        operations.extend(
+            (
+                MaterializationOperation(
+                    kind=MaterializationOperationKind.CREATE_FROM_QUERY,
+                    relation=target,
+                    temporary=False,
+                    auto_begin=False,
+                ),
+                MaterializationOperation(
+                    kind=MaterializationOperationKind.APPLY_GRANTS,
+                    relation=target,
+                ),
+                MaterializationOperation(
+                    kind=MaterializationOperationKind.APPLY_TAGS,
+                    relation=target,
+                ),
+                MaterializationOperation(
+                    kind=MaterializationOperationKind.APPLY_COLUMN_TAGS,
+                    relation=target,
+                ),
+                MaterializationOperation(
+                    kind=MaterializationOperationKind.PERSIST_DOCUMENTATION,
+                    relation=target,
+                ),
+                MaterializationOperation(
+                    kind=MaterializationOperationKind.PERSIST_CONSTRAINTS,
+                    relation=target,
+                ),
+                MaterializationOperation(
+                    kind=MaterializationOperationKind.OPTIMIZE,
+                    relation=target,
+                ),
+                MaterializationOperation(
+                    kind=MaterializationOperationKind.RUN_HOOKS,
+                    name="post",
+                    inside_transaction=True,
+                ),
+            )
+        )
+        return plan.resolve(
+            facts=facts,
+            operations=tuple(operations),
+            provenance=(
+                PlanProvenance(
+                    rule="databricks.table.v1.operations",
+                    detail=(
+                        "Databricks table hooks, replacement, grants, tags, "
+                        "documentation, constraints, and optimization are ordered explicitly"
+                    ),
+                ),
+            ),
+        )
 
     @available.parse(lambda *a, **k: 0)
     def update_tblproperties_for_uniform_iceberg(

--- a/dbt/adapters/databricks/impl.py
+++ b/dbt/adapters/databricks/impl.py
@@ -9,7 +9,7 @@ from contextlib import contextmanager
 from dataclasses import dataclass, field, replace
 from importlib import metadata
 from multiprocessing.context import SpawnContext
-from typing import TYPE_CHECKING, Any, ClassVar, Generic, NamedTuple, Optional, Union, cast
+from typing import TYPE_CHECKING, Any, ClassVar, Generic, NamedTuple, Optional, Sequence, Union, cast
 from uuid import uuid4
 
 from dbt.adapters.base import AdapterConfig, PythonJobHelper
@@ -22,10 +22,16 @@ from dbt.adapters.contracts.connection import AdapterResponse, Connection
 from dbt.adapters.contracts.relation import RelationConfig, RelationType
 from dbt.adapters.planning import (
     CreateFromQueryFacts,
+    DdlAtomicity,
     FormatFacts,
+    IncrementalMutationFacts,
     IncrementalLifecyclePlan,
     IncrementalMaterializationPlan,
     IncrementalMutationPlan,
+    IncrementalMutationStrategyOffer,
+    IncrementalSourceConsistency,
+    IncrementalStrategyRequirements,
+    IncrementalUniqueKeyRequirement,
     MaterializationExecutionFacts,
     MaterializationHookStrategy,
     MaterializationOperation,
@@ -38,6 +44,8 @@ from dbt.adapters.planning import (
     RuntimeFacts,
     TableLifecyclePlan,
     TableMaterializationFacts,
+    incremental_renderer_macro,
+    incremental_strategy,
 )
 from dbt.adapters.relation_configs import RelationResults
 from dbt.adapters.spark.impl import (
@@ -466,6 +474,216 @@ class DatabricksAdapter(SparkAdapter):
                     self.resolve_file_format(model_config),
                     canonical=True,
                 ),
+                table_provider=(
+                    constants.ICEBERG_TABLE_FORMAT
+                    if table_format == constants.ICEBERG_TABLE_FORMAT
+                    and self.get_behavior_flag_no_warn(USE_MANAGED_ICEBERG["name"])
+                    else self._create_from_query_fact_value(
+                        self.resolve_file_format(model_config),
+                        canonical=True,
+                    )
+                ),
+            ),
+        )
+
+    def build_incremental_mutation_facts(
+        self,
+        *,
+        requested_strategy: Optional[str],
+        language: str,
+        unique_key: Optional[Union[str, Sequence[str]]],
+        requested_temp_relation_type: Optional[str],
+        catalog_relation: Optional[CatalogRelation],
+    ) -> IncrementalMutationFacts:
+        facts = super().build_incremental_mutation_facts(
+            requested_strategy=requested_strategy,
+            language=language,
+            unique_key=unique_key,
+            requested_temp_relation_type=requested_temp_relation_type,
+            catalog_relation=catalog_relation,
+        )
+        connection = cast(
+            DatabricksDBTConnection,
+            self.connections.get_thread_connection(),
+        )
+        runtime = connection.capabilities
+        capabilities = [
+            capability.value for capability in sorted(
+                runtime.enabled_capabilities(), key=lambda item: item.value
+            )
+        ]
+        if runtime.is_sql_warehouse:
+            capabilities.append("sql_warehouse")
+        if self.get_behavior_flag_no_warn(USE_REPLACE_ON_FOR_INSERT_OVERWRITE["name"]):
+            capabilities.append("replace_on_for_insert_overwrite")
+
+        table_format = facts.format.table_format
+        managed_iceberg = (
+            table_format == constants.ICEBERG_TABLE_FORMAT
+            and self.get_behavior_flag_no_warn(USE_MANAGED_ICEBERG["name"])
+        )
+        provider = (
+            constants.ICEBERG_TABLE_FORMAT
+            if managed_iceberg
+            else facts.format.file_format
+        )
+        capabilities.append("managed_iceberg" if managed_iceberg else "uniform_or_native_format")
+        return replace(
+            facts,
+            format=replace(facts.format, table_provider=provider),
+            runtime=RuntimeFacts(
+                engine=(
+                    "databricks_sql_warehouse"
+                    if runtime.is_sql_warehouse
+                    else "databricks_runtime"
+                ),
+                version=(
+                    None
+                    if runtime.dbr_version is None
+                    else f"{runtime.dbr_version[0]}.{runtime.dbr_version[1]}"
+                ),
+            ),
+            capabilities=tuple(capabilities),
+        )
+
+    def get_incremental_mutation_strategy_offers(
+        self, facts: IncrementalMutationFacts
+    ) -> tuple[IncrementalMutationStrategyOffer, ...]:
+        requested = facts.requested_strategy
+        effective = "merge" if requested == "default" else requested
+        strategy = incremental_strategy(requested)
+        unique_key = (
+            IncrementalUniqueKeyRequirement.REQUIRED
+            if effective == "delete+insert"
+            else IncrementalUniqueKeyRequirement.OPTIONAL
+        )
+        requirements = IncrementalStrategyRequirements(
+            unique_key=unique_key,
+            source_consistency=IncrementalSourceConsistency.STABLE_REUSE,
+            supported_languages=("sql",),
+        )
+        provider = facts.format.table_provider
+        runtime_capabilities = set(facts.capabilities)
+        if effective == "insert_overwrite":
+            use_replace_on = "replace_on" in runtime_capabilities and (
+                facts.runtime.engine == "databricks_runtime"
+                or "replace_on_for_insert_overwrite" in runtime_capabilities
+            )
+            renderer_variant = (
+                "replace_on"
+                if use_replace_on
+                else (
+                    "legacy_by_name"
+                    if "insert_by_name" in runtime_capabilities
+                    else "legacy_positional"
+                )
+            )
+        elif effective == "delete+insert":
+            renderer_variant = (
+                "replace_on"
+                if "replace_on" in runtime_capabilities
+                else (
+                    "delete_insert_by_name"
+                    if "insert_by_name" in runtime_capabilities
+                    else "delete_insert_positional"
+                )
+            )
+        elif effective == "replace_where":
+            renderer_variant = (
+                "replace_where_by_name"
+                if "insert_by_name_replace_where" in runtime_capabilities
+                else "replace_where_positional"
+            )
+        else:
+            renderer_variant = f"{effective}_{provider or 'unknown'}"
+        rejected_reason = None
+        managed_iceberg = "managed_iceberg" in facts.capabilities
+        if managed_iceberg and facts.catalog.catalog_type != constants.UNITY_CATALOG_TYPE:
+            rejected_reason = "Managed Iceberg incremental models require Unity Catalog"
+        elif (
+            managed_iceberg
+            and facts.runtime.engine == "databricks_runtime"
+            and facts.runtime.version is not None
+            and tuple(int(part) for part in facts.runtime.version.split(".", maxsplit=1)) < (16, 4)
+        ):
+            rejected_reason = "Managed Iceberg incremental models require DBR 16.4 or newer"
+        elif effective == "merge" and provider not in {
+            constants.DELTA_FILE_FORMAT,
+            constants.HUDI_FILE_FORMAT,
+            constants.ICEBERG_TABLE_FORMAT,
+        }:
+            rejected_reason = (
+                f"Incremental strategy '{requested}' requires a Delta, Hudi, or managed "
+                f"Iceberg table provider; resolved provider was '{provider}'"
+            )
+        elif effective in {"replace_where", "microbatch", "delete+insert"} and provider != (
+            constants.DELTA_FILE_FORMAT
+        ):
+            rejected_reason = (
+                f"Incremental strategy '{requested}' requires the Delta table provider; "
+                f"resolved provider was '{provider}'"
+            )
+
+        provenance = (
+            PlanProvenance(
+                rule=f"databricks.incremental.provider.{provider or 'unknown'}",
+                detail=(
+                    f"Resolved '{requested}' against logical format "
+                    f"'{facts.format.table_format}', physical provider '{provider}', catalog "
+                    f"'{facts.catalog.catalog_type}', provider "
+                    f"'{facts.catalog.catalog_provider}', and runtime '{facts.runtime.engine}' "
+                    f"version '{facts.runtime.version}', selecting renderer variant "
+                    f"'{renderer_variant}'"
+                ),
+            ),
+        )
+        if rejected_reason is not None:
+            return (
+                IncrementalMutationStrategyOffer.rejected(
+                    strategy=strategy,
+                    requirements=requirements,
+                    reason=rejected_reason,
+                    provenance=provenance,
+                ),
+            )
+        return (
+            IncrementalMutationStrategyOffer.available(
+                strategy=strategy,
+                renderer_macro=incremental_renderer_macro(requested),
+                atomicity=DdlAtomicity.UNKNOWN,
+                requirements=requirements,
+                provenance=provenance,
+                renderer_variant=renderer_variant,
+            ),
+        )
+
+    @staticmethod
+    def _create_and_populate_from_relation_operations(
+        relation: MaterializationRelationRole,
+        source: MaterializationRelationRole,
+    ) -> tuple[MaterializationOperation, ...]:
+        return (
+            MaterializationOperation(
+                kind=MaterializationOperationKind.CREATE_STRUCTURE_FROM_RELATION,
+                relation=relation,
+                source=source,
+            ),
+            MaterializationOperation(
+                kind=MaterializationOperationKind.APPLY_ALTER_CONSTRAINTS,
+                relation=relation,
+            ),
+            MaterializationOperation(
+                kind=MaterializationOperationKind.APPLY_TAGS,
+                relation=relation,
+            ),
+            MaterializationOperation(
+                kind=MaterializationOperationKind.APPLY_COLUMN_TAGS,
+                relation=relation,
+            ),
+            MaterializationOperation(
+                kind=MaterializationOperationKind.INSERT_FROM_RELATION,
+                relation=relation,
+                source=source,
             ),
         )
 
@@ -531,13 +749,7 @@ class DatabricksAdapter(SparkAdapter):
             (getattr(existing_relation, "metadata", None) or {}).get(KEY_TABLE_PROVIDER),
             canonical=True,
         )
-        managed_iceberg = (
-            facts.create.format.table_format == constants.ICEBERG_TABLE_FORMAT
-            and self.get_behavior_flag_no_warn(USE_MANAGED_ICEBERG["name"])
-        )
-        desired_provider = (
-            constants.ICEBERG_TABLE_FORMAT if managed_iceberg else facts.create.format.file_format
-        )
+        desired_provider = facts.create.format.table_provider
         existing = replace(
             facts.existing,
             format=FormatFacts(
@@ -547,6 +759,7 @@ class DatabricksAdapter(SparkAdapter):
                     else None
                 ),
                 file_format=existing_provider,
+                table_provider=existing_provider,
             ),
             requires_drop_before_replace=(
                 facts.existing.is_shallow_clone
@@ -706,10 +919,8 @@ class DatabricksAdapter(SparkAdapter):
             ):
                 operations.extend(
                     (
-                        MaterializationOperation(
-                            kind=MaterializationOperationKind.CREATE_FROM_RELATION,
-                            relation=staging,
-                            source=intermediate,
+                        *self._create_and_populate_from_relation_operations(
+                            staging, intermediate
                         ),
                         MaterializationOperation(
                             kind=MaterializationOperationKind.DROP_RELATION_IF_EXISTS,
@@ -747,12 +958,8 @@ class DatabricksAdapter(SparkAdapter):
                             relation=existing,
                         )
                     )
-                operations.append(
-                    MaterializationOperation(
-                        kind=MaterializationOperationKind.CREATE_FROM_RELATION,
-                        relation=target,
-                        source=intermediate,
-                    )
+                operations.extend(
+                    self._create_and_populate_from_relation_operations(target, intermediate)
                 )
         else:
             use_dynamic_overwrite = mutation_plan.requested_strategy == "insert_overwrite" and bool(
@@ -1023,10 +1230,8 @@ class DatabricksAdapter(SparkAdapter):
             if facts.existing is not None and safe_create and facts.existing.can_be_renamed:
                 operations.extend(
                     (
-                        MaterializationOperation(
-                            kind=MaterializationOperationKind.CREATE_FROM_RELATION,
-                            relation=staging,
-                            source=intermediate,
+                        *self._create_and_populate_from_relation_operations(
+                            staging, intermediate
                         ),
                         MaterializationOperation(
                             kind=MaterializationOperationKind.DROP_RELATION_IF_EXISTS,
@@ -1060,12 +1265,8 @@ class DatabricksAdapter(SparkAdapter):
                             relation=existing,
                         )
                     )
-                operations.append(
-                    MaterializationOperation(
-                        kind=MaterializationOperationKind.CREATE_FROM_RELATION,
-                        relation=target,
-                        source=intermediate,
-                    )
+                operations.extend(
+                    self._create_and_populate_from_relation_operations(target, intermediate)
                 )
             operations.extend(
                 (

--- a/dbt/include/databricks/macros/adapters/persist_docs.sql
+++ b/dbt/include/databricks/macros/adapters/persist_docs.sql
@@ -1,19 +1,32 @@
-{% macro databricks__alter_column_comment(relation, column_dict) %}
-  {% set file_format = adapter.resolve_file_format(config) %}
-  {% if file_format in ['delta', 'hudi'] %}
+{% macro databricks__alter_column_comment(relation, column_dict, renderer_variant=none) %}
+  {% set supported = renderer_variant in ['comment_on_column', 'alter_column'] %}
+  {% set file_format = none %}
+  {% if renderer_variant is none %}
+    {% set file_format = adapter.resolve_file_format(config) %}
+    {% set supported = file_format in ['delta', 'hudi'] %}
+  {% endif %}
+  {% if supported %}
     {% for column in column_dict.values() %}
       {% set comment = column['description'] %}
       {% set escaped_comment = comment | replace('\'', '\\\'') %}
       {% set column_path = relation.render() ~ '.' ~ adapter.quote(column['name']) %}
-      {{ run_query_as(comment_on_column_sql(column_path, escaped_comment), 'alter_column_comment', fetch_result=False) }}
+      {{ run_query_as(comment_on_column_sql(column_path, escaped_comment, renderer_variant), 'alter_column_comment', fetch_result=False) }}
     {% endfor %}
   {% else %}
-    {{ log('WARNING - requested to update column comments, but file format ' ~ file_format ~ ' does not support that.') }}
+    {% if renderer_variant is none %}
+      {{ log('WARNING - requested to update column comments, but file format ' ~ file_format ~ ' does not support that.') }}
+    {% else %}
+      {{ log('WARNING - planned table provider does not support updating column comments.') }}
+    {% endif %}
   {% endif %}
 {% endmacro %}
 
-{% macro comment_on_column_sql(column_path, escaped_comment) %}
-  {%- if adapter.has_dbr_capability('comment_on_column') -%}
+{% macro comment_on_column_sql(column_path, escaped_comment, renderer_variant=none) %}
+  {%- if renderer_variant == 'comment_on_column' -%}
+    COMMENT ON COLUMN {{ column_path }} IS '{{ escaped_comment }}'
+  {%- elif renderer_variant == 'alter_column' -%}
+    {{ alter_table_change_column_comment_sql(column_path, escaped_comment) }}
+  {%- elif renderer_variant is none and adapter.has_dbr_capability('comment_on_column') -%}
     COMMENT ON COLUMN {{ column_path }} IS '{{ escaped_comment }}'
   {%- else -%}
     {{ alter_table_change_column_comment_sql(column_path, escaped_comment) }}
@@ -31,14 +44,14 @@
   {%- endif -%}
 {% endmacro %}
 
-{% macro databricks__persist_docs(relation, model, for_relation, for_columns) -%}
+{% macro databricks__persist_docs(relation, model, for_relation, for_columns, column_comment_renderer_variant=none) -%}
   {%- if for_relation and config.persist_relation_docs() and model.description %}
     {{ run_query_as(alter_relation_comment_sql(relation, model.description), 'alter_relation_comment', fetch_result=False) }}
   {% endif %}
   {% if for_columns and config.persist_column_docs() and model.columns %}
     {%- set existing_columns = adapter.get_columns_in_relation(relation) -%}
     {%- set columns_to_persist_docs = adapter.get_persist_doc_columns(existing_columns, model.columns) -%}
-    {{ alter_column_comment(relation, columns_to_persist_docs) }}
+    {{ alter_column_comment(relation, columns_to_persist_docs, column_comment_renderer_variant) }}
   {% endif %}
 {% endmacro %}
 

--- a/dbt/include/databricks/macros/materializations/incremental/incremental.sql
+++ b/dbt/include/databricks/macros/materializations/incremental/incremental.sql
@@ -230,8 +230,13 @@
 
 {%- endmaterialization %}
 
-{% macro set_overwrite_mode(value) %}
-  {% if adapter.is_cluster() %}
+{% macro set_overwrite_mode(value, runtime_engine=none) %}
+  {% if runtime_engine is not none %}
+    {% set use_cluster_statement = runtime_engine == 'databricks_runtime' %}
+  {% else %}
+    {% set use_cluster_statement = adapter.is_cluster() %}
+  {% endif %}
+  {% if use_cluster_statement %}
     {%- call statement('Setting partitionOverwriteMode: ' ~ value) -%}
       set spark.sql.sources.partitionOverwriteMode = {{ value }}
     {%- endcall -%}

--- a/dbt/include/databricks/macros/materializations/incremental/incremental.sql
+++ b/dbt/include/databricks/macros/materializations/incremental/incremental.sql
@@ -267,3 +267,10 @@
     {{ apply_config_changeset(target_relation, model, configuration_changes, existing_relation) }}
   {% endif %}
 {% endmacro %}
+
+{% macro process_config_changes_from_plan(target_relation, existing_relation=none) %}
+  {%- set model_config = adapter.get_config_from_model(config.model) -%}
+  {%- set existing_config = adapter.get_relation_config(target_relation, model_config) -%}
+  {%- set configuration_changes = model_config.get_changeset(existing_config) -%}
+  {{ apply_config_changeset(target_relation, model, configuration_changes, existing_relation) }}
+{% endmacro %}

--- a/dbt/include/databricks/macros/materializations/incremental/strategies.sql
+++ b/dbt/include/databricks/macros/materializations/incremental/strategies.sql
@@ -19,6 +19,26 @@
   {% do return(get_delete_insert_sql(arg_dict)) %}
 {% endmacro %}
 
+{% macro databricks__get_incremental_insert_overwrite_sql(arg_dict) %}
+  {%- set plan = arg_dict.get('incremental_plan') -%}
+  {%- set variant = plan.renderer_variant if plan is not none else none -%}
+  {%- set source_relation = arg_dict['temp_relation'] -%}
+  {%- set target_relation = arg_dict['target_relation'] -%}
+  {%- if variant == 'replace_on' -%}
+    {{ return(get_insert_replace_on_sql(source_relation, target_relation)) }}
+  {%- elif variant in ('legacy_by_name', 'legacy_positional') -%}
+    {%- if plan.facts.runtime.engine == 'databricks_sql_warehouse' -%}
+      {{ exceptions.warn("insert_overwrite uses legacy overwrite semantics on this SQL warehouse; enable use_replace_on_for_insert_overwrite to select REPLACE ON") }}
+    {%- endif -%}
+    insert overwrite table {{ target_relation }}
+    {{ partition_cols(label="partition") }}
+    {%- if variant == 'legacy_by_name' %} by name{% endif %}
+    select * from {{ source_relation }}
+  {%- else -%}
+    {{ return(get_insert_overwrite_sql(source_relation, target_relation)) }}
+  {%- endif -%}
+{% endmacro %}
+
 {% macro get_incremental_replace_where_sql(arg_dict) %}
 
   {{ return(adapter.dispatch('get_incremental_replace_where_sql', 'dbt')(arg_dict)) }}
@@ -122,7 +142,12 @@
   {%- set temp_relation = args_dict['temp_relation'] -%}
   {#-- BY NAME + REPLACE WHERE needs DBR 18.0+ on clusters (SPARK-54803), a higher floor than
        plain insert_by_name; emitting it on older clusters fails to parse (issue #1532). --#}
-  {%- set has_by_name = adapter.has_dbr_capability('insert_by_name_replace_where') -%}
+  {%- set plan = args_dict.get('incremental_plan') -%}
+  {%- if plan is not none and plan.renderer_variant is not none -%}
+    {%- set has_by_name = plan.renderer_variant == 'replace_where_by_name' -%}
+  {%- else -%}
+    {%- set has_by_name = adapter.has_dbr_capability('insert_by_name_replace_where') -%}
+  {%- endif -%}
 INSERT INTO {{ target_relation.render() }}
 {%- if has_by_name %} BY NAME{% endif %}
 {%- if predicates %}
@@ -141,7 +166,16 @@ INSERT INTO {{ target_relation.render() }}
   {%- set incremental_predicates = config.get('incremental_predicates') -%}
   {%- set target_columns = (adapter.get_columns_in_relation(target_relation) | map(attribute='quoted') | list) -%}
   {%- set unique_key = config.require('unique_key') -%}
-  {% do return(delete_insert_sql_impl(source_relation, target_relation, target_columns, unique_key, incremental_predicates)) %}
+  {%- set plan = arg_dict.get('incremental_plan') -%}
+  {%- set variant = plan.renderer_variant if plan is not none else none -%}
+  {%- if variant == 'replace_on' -%}
+    {{ return(delete_insert_replace_on_sql(source_relation, target_relation, target_columns, unique_key, incremental_predicates)) }}
+  {%- elif variant in ('delete_insert_by_name', 'delete_insert_positional') -%}
+    {%- set unique_keys = unique_key if unique_key is sequence and unique_key is not string else [unique_key] -%}
+    {% do return(delete_insert_legacy_sql(source_relation, target_relation, target_columns, unique_keys, incremental_predicates, variant == 'delete_insert_by_name')) %}
+  {%- else -%}
+    {% do return(delete_insert_sql_impl(source_relation, target_relation, target_columns, unique_key, incremental_predicates)) %}
+  {%- endif -%}
 {% endmacro %}
 
 {% macro delete_insert_sql_impl(source_relation, target_relation, target_columns, unique_key, incremental_predicates) %}
@@ -157,23 +191,34 @@ INSERT INTO {{ target_relation.render() }}
   {%- set unique_keys = unique_key if unique_key is sequence and unique_key is not string else [unique_key] -%}
   
   {%- if adapter.has_dbr_capability('replace_on') -%}
-    {#-- DBR 17.1+: Use efficient REPLACE ON syntax --#}
-    {%- set replace_on_expr = [] -%}
-    {%- for key in unique_keys -%}
-      {%- do replace_on_expr.append('target.' ~ adapter.quote(key) ~ ' <=> temp.' ~ adapter.quote(key)) -%}
-    {%- endfor -%}
-    {%- set replace_on_expr = replace_on_expr | join(' and ') -%}
- insert into table {{ target_relation }} as target
-replace on ({{ replace_on_expr }})
-(select {{ target_cols_csv }}
-   from {{ source_relation }} {{ predicates }}) as temp
+    {{ return(delete_insert_replace_on_sql(source_relation, target_relation, target_columns, unique_keys, incremental_predicates)) }}
   {%- else -%}
     {#-- DBR < 17.1: Fallback to DELETE FROM + INSERT INTO --#}
     {% do return(delete_insert_legacy_sql(source_relation, target_relation, target_columns, unique_keys, incremental_predicates)) %}
   {%- endif -%}
 {% endmacro %}
 
-{% macro delete_insert_legacy_sql(source_relation, target_relation, target_columns, unique_keys, incremental_predicates) %}
+{% macro delete_insert_replace_on_sql(source_relation, target_relation, target_columns, unique_key, incremental_predicates) %}
+  {%- set target_cols_csv = target_columns | join(', ') -%}
+  {%- set predicates -%}
+    {%- if incremental_predicates is sequence and incremental_predicates is not string -%}
+      where {{ incremental_predicates | join(' and ') }}
+    {%- elif incremental_predicates is string and incremental_predicates is not none -%}
+      where {{ incremental_predicates }}
+    {%- endif -%}
+  {%- endset -%}
+  {%- set unique_keys = unique_key if unique_key is sequence and unique_key is not string else [unique_key] -%}
+  {%- set replace_on_expr = [] -%}
+  {%- for key in unique_keys -%}
+    {%- do replace_on_expr.append('target.' ~ adapter.quote(key) ~ ' <=> temp.' ~ adapter.quote(key)) -%}
+  {%- endfor -%}
+ insert into table {{ target_relation }} as target
+replace on ({{ replace_on_expr | join(' and ') }})
+(select {{ target_cols_csv }}
+   from {{ source_relation }} {{ predicates }}) as temp
+{% endmacro %}
+
+{% macro delete_insert_legacy_sql(source_relation, target_relation, target_columns, unique_keys, incremental_predicates, use_insert_by_name=none) %}
   {#-- Legacy implementation for DBR < 17.1 using DELETE FROM + INSERT INTO --#}
   {#-- Returns a list of SQL statements to be executed via execute_multiple_statements --#}
   {%- set target_cols_csv = target_columns | join(', ') -%}
@@ -211,7 +256,7 @@ where {{ delete_conditions | join('\n  and ') }}
   {%- do statements.append(delete_sql) -%}
 
   {#-- Step 2: INSERT new rows --#}
-  {%- set has_insert_by_name = adapter.has_dbr_capability('insert_by_name') -%}
+  {%- set has_insert_by_name = adapter.has_dbr_capability('insert_by_name') if use_insert_by_name is none else use_insert_by_name -%}
   {%- set insert_sql -%}
 insert into {{ target_relation }}{% if has_insert_by_name %} by name{% endif %}
 

--- a/dbt/include/databricks/macros/materializations/incremental/strategies.sql
+++ b/dbt/include/databricks/macros/materializations/incremental/strategies.sql
@@ -8,7 +8,22 @@
 {% endmacro %}
 
 {% macro databricks__get_incremental_append_sql(arg_dict) %}
-  {% do return(get_insert_into_sql(arg_dict["temp_relation"], arg_dict["target_relation"])) %}
+  {%- set plan = arg_dict.get('incremental_plan') -%}
+  {%- if plan is not none and plan.renderer_variant in ('append_by_name', 'append_positional') -%}
+    {%- set source_relation = arg_dict["temp_relation"] -%}
+    {%- set target_relation = arg_dict["target_relation"] -%}
+    {%- set source_columns = adapter.get_columns_in_relation(source_relation) | map(attribute="name") | list -%}
+    {%- set dest_columns = adapter.get_columns_in_relation(target_relation) | map(attribute="name") | list -%}
+    {{ return(insert_into_sql_impl(
+        target_relation,
+        dest_columns,
+        source_relation,
+        source_columns,
+        plan.renderer_variant == 'append_by_name'
+    )) }}
+  {%- else -%}
+    {% do return(get_insert_into_sql(arg_dict["temp_relation"], arg_dict["target_relation"])) %}
+  {%- endif -%}
 {% endmacro %}
 
 {% macro databricks__get_incremental_replace_where_sql(arg_dict) %}
@@ -280,10 +295,10 @@ where {{ incremental_predicates }}
     {{ insert_into_sql_impl(target_relation, dest_columns, source_relation, source_columns) }}
 {% endmacro %}
 
-{% macro insert_into_sql_impl(target_relation, dest_columns, source_relation, source_columns) %}
+{% macro insert_into_sql_impl(target_relation, dest_columns, source_relation, source_columns, use_insert_by_name=none) %}
     {%- set dest_cols_lower = dest_columns | map('lower') | list -%}
     {%- set source_cols_lower = source_columns | map('lower') | list -%}
-    {%- set has_insert_by_name = adapter.has_dbr_capability('insert_by_name') -%}
+    {%- set has_insert_by_name = adapter.has_dbr_capability('insert_by_name') if use_insert_by_name is none else use_insert_by_name -%}
 
     {%- if dest_cols_lower | sort == source_cols_lower | sort -%}
         {#-- All columns match (case-insensitive) --#}

--- a/dbt/include/databricks/macros/relations/components/column_tags.sql
+++ b/dbt/include/databricks/macros/relations/components/column_tags.sql
@@ -33,6 +33,19 @@
   {%- endif %}
 {%- endmacro -%}
 
+{% macro apply_column_tags_from_plan(relation, column_tags, renderer_variant) -%}
+  {% if renderer_variant != 'unity' %}
+    {{ exceptions.raise_compiler_error(
+      "Column tags are not supported for planned catalog type " ~ renderer_variant
+    ) }}
+  {% endif %}
+  {%- for column, tags in column_tags.set_column_tags.items() -%}
+    {%- call statement('main') -%}
+      {{ alter_set_column_tags(relation, column, tags) }}
+    {%- endcall -%}
+  {%- endfor -%}
+{%- endmacro -%}
+
 {% macro alter_set_column_tags(relation, column, tags) -%}
   {# ALTER VIEW does not support setting column tags, but ALTER TABLE works for views #}
   {%- if relation.type == 'view' -%}
@@ -92,4 +105,3 @@
   {{ return(false) }}
 {% endmacro %}
 
- 

--- a/dbt/include/databricks/macros/relations/constraints.sql
+++ b/dbt/include/databricks/macros/relations/constraints.sql
@@ -25,6 +25,19 @@
   {% endif %}
 {% endmacro %}
 
+{% macro persist_constraints_from_plan(relation, model, renderer_variant) %}
+  {% if renderer_variant == 'delta' %}
+    {% do alter_column_set_constraints(relation, model) %}
+    {% do alter_table_add_constraints(relation, model) %}
+  {% elif renderer_variant == 'unsupported' %}
+    {{ exceptions.warn("Constraints are not supported for the planned table provider") }}
+  {% else %}
+    {{ exceptions.raise_compiler_error(
+      "Unknown planned constraint renderer variant: " ~ renderer_variant
+    ) }}
+  {% endif %}
+{% endmacro %}
+
 {% macro apply_alter_constraints(relation) %}
   {%- for constraint in relation.alter_constraints -%}
     {% call statement('add constraint') %}

--- a/dbt/include/databricks/macros/relations/file_format.sql
+++ b/dbt/include/databricks/macros/relations/file_format.sql
@@ -1,10 +1,12 @@
-{% macro file_format_clause(catalog_relation=none) %}
+{% macro file_format_clause(catalog_relation=none, format_facts=none) %}
   {#--
     Moving forward, this macro should require a `catalog_relation`, which is covered by the first condition.
     However, there could be existing macros that is still passing no arguments, including user macros.
     Hence, we need to support the old code still, which is covered by the second condition.
   --#}
-  {% if catalog_relation is not none %}
+  {% if format_facts is not none %}
+    {%- set table_provider = format_facts.table_provider -%}
+  {% elif catalog_relation is not none %}
     {%- set table_format = catalog_relation.table_format -%}
     {%- set file_format = catalog_relation.file_format -%}
   {% else %}
@@ -13,7 +15,9 @@
   {% endif %}
   
   {#-- Use managed Iceberg if behavior flag is enabled and table_format is iceberg --#}
-  {% if table_format == 'iceberg' and adapter.behavior.use_managed_iceberg %}
+  {% if format_facts is not none %}
+    using {{ table_provider }}
+  {% elif table_format == 'iceberg' and adapter.behavior.use_managed_iceberg %}
     using iceberg
   {% else %}
     using {{ file_format }}

--- a/dbt/include/databricks/macros/relations/location.sql
+++ b/dbt/include/databricks/macros/relations/location.sql
@@ -1,10 +1,11 @@
-{% macro location_clause(relation) %}
+{% macro location_clause(relation, catalog_facts=none) %}
   {#--
     Moving forward, `relation` should be a `CatalogRelation`, which is covered by the first condition.
     However, there could be existing macros that are still passing in a `BaseRelation`, including user macros.
     Hence, we need to support the old code still, which is covered by the second condition.
   --#}
-  {%- if relation.catalog_type is not none -%}
+  {%- if (catalog_facts is not none and catalog_facts.catalog_type is not none)
+      or (catalog_facts is none and relation.catalog_type is not none) -%}
 
     {%- if relation.location is not none -%}
     location '{{ relation.location }}{% if is_incremental() %}_tmp{% endif %}'

--- a/dbt/include/databricks/macros/relations/optimize.sql
+++ b/dbt/include/databricks/macros/relations/optimize.sql
@@ -2,6 +2,33 @@
   {{ return(adapter.dispatch('optimize', 'dbt')(relation)) }}
 {% endmacro %}
 
+{% macro optimize_from_plan(relation, renderer_variant) %}
+  {%- if var('DATABRICKS_SKIP_OPTIMIZE', 'false')|lower != 'true' and
+        var('databricks_skip_optimize', 'false')|lower != 'true' -%}
+    {%- call statement('run_optimize_stmt') -%}
+      {{ get_optimize_sql_from_plan(relation, renderer_variant) }}
+    {%- endcall -%}
+  {%- endif -%}
+{% endmacro %}
+
+{% macro get_optimize_sql_from_plan(relation, renderer_variant) %}
+  optimize {{ relation.render() }}
+  {%- if renderer_variant == 'zorder' %}
+    {%- set zorder = config.get('zorder') %}
+    zorder by (
+    {%- if zorder is sequence and zorder is not string -%}
+      {%- for col in zorder -%}
+        {{ col }}{% if not loop.last %}, {% endif %}
+      {%- endfor -%}
+    {%- else -%}
+      {{ zorder }}
+    {%- endif -%}
+    )
+  {%- elif renderer_variant != 'plain' -%}
+    {{ exceptions.raise_compiler_error("Unknown planned optimize renderer variant: " ~ renderer_variant) }}
+  {%- endif %}
+{% endmacro %}
+
 {%- macro databricks__optimize(relation) -%}
   {%- if config.get('skip_optimize', false) | as_bool -%}
   {%- elif var('DATABRICKS_SKIP_OPTIMIZE', 'false')|lower != 'true' and

--- a/dbt/include/databricks/macros/relations/table/create.sql
+++ b/dbt/include/databricks/macros/relations/table/create.sql
@@ -1,5 +1,22 @@
 {% macro create_table_at(relation, intermediate_relation, compiled_code) %}
-  {% set tags = config.get('databricks_tags') %}
+  {% set target_relation = create_table_structure_at(relation, intermediate_relation, compiled_code) %}
+
+  {{ apply_alter_constraints(target_relation) }}
+  {{ apply_tags(target_relation, config.get('databricks_tags')) }}
+  {% set column_tags = adapter.get_column_tags_from_model(config.model) %}
+  {% if column_tags and column_tags.set_column_tags %}
+    {{ apply_column_tags(target_relation, column_tags) }}
+  {% endif %}
+
+  {{ insert_from_relation(target_relation, intermediate_relation) }}
+{% endmacro %}
+
+{% macro create_table_structure_at(relation, intermediate_relation, compiled_code, format_facts=none, catalog_facts=none) %}
+  {% if format_facts is none %}
+    {% set create_plan = adapter.plan_create_from_query(False, relation, config.model) %}
+    {% set format_facts = create_plan.facts.format %}
+    {% set catalog_facts = create_plan.facts.catalog %}
+  {% endif %}
   {% set model_columns = model.get('columns', []) %}
   {% set existing_columns = adapter.get_columns_in_relation(intermediate_relation) %}
   {% set contract_config = config.get('contract') %}
@@ -13,22 +30,19 @@
   {% set target_relation = relation.enrich(columns_and_constraints[1]) %}
   
   {% call statement('main') %}
-    {{ get_create_table_sql(target_relation, columns_and_constraints[0], compiled_code) }}
+    {{ get_create_table_sql(target_relation, columns_and_constraints[0], compiled_code, format_facts, catalog_facts) }}
   {% endcall %}
 
-  {{ apply_alter_constraints(target_relation) }}
-  {{ apply_tags(target_relation, tags) }}
-  {% set column_tags = adapter.get_column_tags_from_model(config.model) %}
-  {% if column_tags and column_tags.set_column_tags %}
-    {{ apply_column_tags(target_relation, column_tags) }}
-  {% endif %}
+  {% do return(target_relation) %}
+{% endmacro %}
 
+{% macro insert_from_relation(target_relation, intermediate_relation) %}
   {% call statement('merge into target') %}
     insert into {{ target_relation }} by name select * from {{ intermediate_relation }}
   {% endcall %}
 {% endmacro %}
 
-{% macro get_create_table_sql(target_relation, columns, compiled_code) %}
+{% macro get_create_table_sql(target_relation, columns, compiled_code, format_facts=none, catalog_facts=none) %}
 
   {%- set catalog_relation = adapter.build_catalog_relation(config.model) -%}
 
@@ -38,24 +52,35 @@
     {{ get_assert_columns_equivalent(compiled_code) }}
   {%- endif -%}
 
-  {%- if catalog_relation.file_format in ('delta', 'iceberg') %}
+  {%- if format_facts is not none and format_facts.table_provider in ('delta', 'iceberg') %}
+  create or replace table {{ target_relation.render() }}
+  {% elif format_facts is none and catalog_relation.file_format in ('delta', 'iceberg') %}
   create or replace table {{ target_relation.render() }}
   {% else %}
   create table {{ target_relation.render() }}
   {% endif -%}
   {{ get_column_and_constraints_sql(target_relation, columns) }}
-  {{ file_format_clause(catalog_relation) }}
-  {{ databricks__options_clause(catalog_relation) }}
+  {{ file_format_clause(catalog_relation, format_facts) }}
+  {{ databricks__options_clause(catalog_relation, format_facts) }}
   {{ partition_cols(label="partitioned by") }}
   {{ get_create_row_filter_clause(target_relation) }}
   {{ liquid_clustered_cols() }}
   {{ clustered_cols(label="clustered by") }}
-  {{ location_clause(catalog_relation) }}
+  {{ location_clause(catalog_relation, catalog_facts) }}
   {{ comment_clause() }}
-  {{ tblproperties_clause() }}
+  {{ databricks__tblproperties_clause(format_facts=format_facts) }}
 {% endmacro %}
 
-{% macro databricks__create_table_as(temporary, relation, compiled_code, language='sql') -%}
+{% macro databricks__render_create_from_query_plan(plan, relation, compiled_code) -%}
+  {{ return(databricks__create_table_as(
+      plan.temporary,
+      relation,
+      compiled_code,
+      create_plan=plan
+  )) }}
+{%- endmacro %}
+
+{% macro databricks__create_table_as(temporary, relation, compiled_code, language='sql', create_plan=none) -%}
 
   {%- set catalog_relation = adapter.build_catalog_relation(config.model) -%}
 
@@ -63,7 +88,12 @@
     {%- if temporary -%}
       {{ create_temporary_view(relation, compiled_code) }}
     {%- else -%}
-      {% if catalog_relation.file_format == 'delta' %}
+      {%- if create_plan is none -%}
+        {%- set create_plan = adapter.plan_create_from_query(temporary, relation, config.model) -%}
+      {%- endif -%}
+      {%- set format_facts = create_plan.facts.format -%}
+      {%- set catalog_facts = create_plan.facts.catalog -%}
+      {% if format_facts.table_provider in ('delta', 'iceberg') %}
         create or replace table {{ relation.render() }}
       {% else %}
         create table {{ relation.render() }}
@@ -73,15 +103,15 @@
         {{ get_assert_columns_equivalent(compiled_code) }}
         {%- set compiled_code = get_select_subquery(compiled_code) %}
       {% endif %}
-      {{ file_format_clause(catalog_relation) }}
-      {{ databricks__options_clause(catalog_relation) }}
+      {{ file_format_clause(catalog_relation, format_facts) }}
+      {{ databricks__options_clause(catalog_relation, format_facts) }}
       {{ partition_cols(label="partitioned by") }}
       {{ get_create_row_filter_clause(relation) }}
       {{ liquid_clustered_cols() }}
       {{ clustered_cols(label="clustered by") }}
-      {{ location_clause(catalog_relation) }}
+      {{ location_clause(catalog_relation, catalog_facts) }}
       {{ comment_clause() }}
-      {{ tblproperties_clause() }}
+      {{ databricks__tblproperties_clause(format_facts=format_facts) }}
       as
       {{ compiled_code }}
     {%- endif -%}
@@ -97,7 +127,7 @@
   {%- endif -%}
 {%- endmacro -%}
 
-{% macro databricks__options_clause(catalog_relation=none) -%}
+{% macro databricks__options_clause(catalog_relation=none, format_facts=none) -%}
   {#-
     Moving forward, this macro should require a `catalog_relation`, which is covered by the first condition.
     However, there could be existing macros that is still passing no arguments, including user macros.
@@ -106,7 +136,9 @@
     all calls to `options_clause` will take the second path. This macro needs to be called directly
     via `databricks__options_clause`.
   -#}
-  {%- if catalog_relation is not none -%}
+  {%- if format_facts is not none -%}
+    {%- set file_format = format_facts.file_format -%}
+  {%- elif catalog_relation is not none -%}
     {%- set file_format = catalog_relation.file_format -%}
   {%- else -%}
     {%- set file_format = adapter.resolve_file_format(config) -%}

--- a/dbt/include/databricks/macros/relations/table/create.sql
+++ b/dbt/include/databricks/macros/relations/table/create.sql
@@ -36,9 +36,10 @@
   {% do return(target_relation) %}
 {% endmacro %}
 
-{% macro insert_from_relation(target_relation, intermediate_relation) %}
+{% macro insert_from_relation(target_relation, intermediate_relation, use_insert_by_name=none) %}
   {% call statement('merge into target') %}
-    insert into {{ target_relation }} by name select * from {{ intermediate_relation }}
+    insert into {{ target_relation }}{% if use_insert_by_name is not false %} by name{% endif %}
+    select * from {{ intermediate_relation }}
   {% endcall %}
 {% endmacro %}
 

--- a/dbt/include/databricks/macros/relations/tags.sql
+++ b/dbt/include/databricks/macros/relations/tags.sql
@@ -28,6 +28,19 @@
   {%- endif %}
 {%- endmacro -%}
 
+{% macro apply_tags_from_plan(relation, set_tags, renderer_variant) -%}
+  {% if renderer_variant != 'unity' %}
+    {{ exceptions.raise_compiler_error(
+      "Tags are not supported for planned catalog type " ~ renderer_variant
+    ) }}
+  {% endif %}
+  {%- if set_tags and set_tags != [] %}
+    {%- call statement('main') -%}
+       {{ alter_set_tags(relation, set_tags) }}
+    {%- endcall -%}
+  {%- endif %}
+{%- endmacro -%}
+
 {% macro alter_set_tags(relation, tags) -%}
   ALTER {{ relation.type.render_for_alter() }} {{ relation.render() }} SET TAGS (
     {% for tag in tags -%}

--- a/dbt/include/databricks/macros/relations/tblproperties.sql
+++ b/dbt/include/databricks/macros/relations/tblproperties.sql
@@ -2,8 +2,13 @@
   {{ return(adapter.dispatch('tblproperties_clause', 'dbt')()) }}
 {%- endmacro -%}
 
-{% macro databricks__tblproperties_clause(tblproperties=None) -%}
-  {%- if adapter.is_uniform(config) -%}
+{% macro databricks__tblproperties_clause(tblproperties=None, format_facts=None) -%}
+  {%- if format_facts is not none -%}
+    {%- set tblproperties = tblproperties or config.get("tblproperties", {}) -%}
+    {%- if format_facts.table_format == 'iceberg' and format_facts.table_provider == 'delta' -%}
+      {%- set tblproperties = adapter.update_tblproperties_for_uniform_iceberg(config, tblproperties) -%}
+    {%- endif -%}
+  {%- elif adapter.is_uniform(config) -%}
     {%- set tblproperties = adapter.update_tblproperties_for_uniform_iceberg(config, tblproperties) -%}
   {%- else -%}
     {%- set tblproperties = tblproperties or config.get("tblproperties", {}) -%}

--- a/docs/flow/incremental_flow.md
+++ b/docs/flow/incremental_flow.md
@@ -8,10 +8,19 @@ _Last updated: 2026-08-23_
 > `dbt/include/databricks/macros/materializations/incremental/incremental.sql`.
 
 For SQL models on dbt-core versions that expose typed materialization execution, the adapter now
-serializes these branches as an ordered Python operation plan. The plan includes the mutation and
-schema-change strategies, logical and physical formats, explicit catalog provider, DBR capabilities,
-full-refresh state, config-change timing, overwrite-mode transitions, and multi-statement execution.
-The macro remains the compatibility fallback and supplies leaf SQL renderers where required.
+serializes these branches as an ordered Python operation plan. The mutation plan retains the
+resolved catalog binding, explicit catalog provider, logical table format, physical Delta/Hudi/
+Iceberg provider, runtime and version, and named DBR capabilities. The lifecycle adds schema-change
+strategy, full-refresh state, config-change timing, overwrite-mode transitions, and multi-statement
+execution. The macro remains the compatibility fallback and supplies leaf SQL renderers where
+required.
+
+The serialization boundary is deliberate: the plan owns every decision that changes the selected
+strategy, operation ordering, staging policy, replacement safety, overwrite behavior, or SQL
+renderer variant. Relations, compiled SQL, resolved destination columns, predicates, and literal
+configuration payloads remain late-bound execution arguments. Leaf renderers may interpolate those
+values, but must not re-resolve catalog, format, provider, runtime, version, or capability policy
+when plan facts are present.
 
 ## Existing Incremental Flow
 
@@ -94,4 +103,5 @@ the incremental branch even when its configuration changes. Safe staging is sele
 `use_safer_relation_operations` is enabled and the existing relation can be renamed; otherwise a
 non-replaceable relation or shallow clone is dropped before `create_table_at`. Unlike the Existing
 path, V2 does not call `persist_docs` — relation and column comments are handled via
-`apply_config_changeset` or the create/insert path.
+`apply_config_changeset` or the create/insert path. Typed creation expands that latter path into
+create-structure, alter-constraint, table-tag, column-tag, and insert-from-intermediate operations.

--- a/docs/flow/incremental_flow.md
+++ b/docs/flow/incremental_flow.md
@@ -1,11 +1,17 @@
 # Incremental Flow
 
-_Last updated: 2026-08-10_
+_Last updated: 2026-08-23_
 
 > Two diagrams follow: **Existing** is the default path, **New** is used when the
 > `use_materialization_v2` behavior flag is enabled. See [flow/README.md](README.md) for what the
 > flag is and how the selection works. Source:
 > `dbt/include/databricks/macros/materializations/incremental/incremental.sql`.
+
+For SQL models on dbt-core versions that expose typed materialization execution, the adapter now
+serializes these branches as an ordered Python operation plan. The plan includes the mutation and
+schema-change strategies, logical and physical formats, explicit catalog provider, DBR capabilities,
+full-refresh state, config-change timing, overwrite-mode transitions, and multi-statement execution.
+The macro remains the compatibility fallback and supplies leaf SQL renderers where required.
 
 ## Existing Incremental Flow
 

--- a/docs/flow/table_flow.md
+++ b/docs/flow/table_flow.md
@@ -1,10 +1,16 @@
 # Table Flow
 
-_Last updated: 2026-08-10_
+_Last updated: 2026-08-23_
 
 > Two diagrams follow: **V1** is the default path, **V2** is used when the `use_materialization_v2`
 > behavior flag is enabled. See [flow/README.md](README.md) for what the flag is and how the
 > selection works. Source: `dbt/include/databricks/macros/materializations/table.sql`.
+
+For SQL models on dbt-core versions that expose typed materialization execution, the adapter now
+resolves the same flow into an ordered Python operation plan before mutation begins. Logical table
+format, physical Delta versus managed-Iceberg provider, catalog type/provider, DBR capabilities,
+and live replacement safety are plan inputs. The macros remain compatibility fallbacks and leaf SQL
+renderers; they are not the source of those decisions on the typed path.
 
 ## V1 Table Flow
 

--- a/docs/flow/table_flow.md
+++ b/docs/flow/table_flow.md
@@ -12,6 +12,12 @@ format, physical Delta versus managed-Iceberg provider, catalog type/provider, D
 and live replacement safety are plan inputs. The macros remain compatibility fallbacks and leaf SQL
 renderers; they are not the source of those decisions on the typed path.
 
+The serialization boundary is deliberate: the plan owns every decision that changes the selected
+strategy, operation ordering, replacement safety, or SQL renderer variant. Relations, compiled SQL,
+resolved columns, and literal configuration payloads such as tag values remain late-bound execution
+arguments. Leaf renderers may interpolate those values, but must not re-resolve catalog, format,
+provider, runtime, version, or capability policy when plan facts are present.
+
 ## V1 Table Flow
 
 ```mermaid
@@ -66,7 +72,9 @@ flowchart LR
     CLEAN --> POST
 ```
 
-The `create_table_at` helper applies constraints, table tags, and column tags before inserting from
-the intermediate relation. The safe-replacement helper performs its own intermediate cleanup;
-Python paths also clean up the intermediate relation after optimization. Unlike V1, V2 does not call
-`persist_docs` — column and relation comments are handled on the create/insert path.
+On the typed SQL path, `create_table_at` is decomposed into explicit create-structure,
+alter-constraint, table-tag, column-tag, and insert-from-intermediate operations. The compatibility
+macro composes those same leaf macros for callers that have not opted into typed execution. The
+safe-replacement path performs its own intermediate cleanup; Python paths also clean up the
+intermediate relation after optimization. Unlike V1, V2 does not call `persist_docs` — column and
+relation comments are handled on the create/insert path.

--- a/tests/unit/macros/adapters/test_persist_docs_macros.py
+++ b/tests/unit/macros/adapters/test_persist_docs_macros.py
@@ -248,6 +248,28 @@ class TestPersistDocsMacros(MacroTestBase):
             "but file format parquet does not support that."
         )
 
+    def test_planned_column_comment_does_not_probe_format_or_runtime(
+        self, template_bundle, context, relation, mock_model_with_columns
+    ):
+        context["adapter"].resolve_file_format.side_effect = AssertionError(
+            "typed renderer must not resolve file format"
+        )
+        context["adapter"].has_dbr_capability.side_effect = AssertionError(
+            "typed renderer must not probe runtime capability"
+        )
+        context["adapter"].quote = lambda identifier: f"`{identifier}`"
+        context["run_query_as"] = Mock()
+
+        self.run_macro_raw(
+            template_bundle.template,
+            "databricks__alter_column_comment",
+            relation,
+            mock_model_with_columns.columns,
+            "comment_on_column",
+        )
+
+        assert context["run_query_as"].call_count == 2
+
     def test_databricks__persist_docs_relation_only(self, template_bundle, context, relation):
         context["config"] = MagicMock()
         context["config"].persist_relation_docs.return_value = True

--- a/tests/unit/macros/materializations/incremental/test_delete_insert.py
+++ b/tests/unit/macros/materializations/incremental/test_delete_insert.py
@@ -1,3 +1,5 @@
+from types import SimpleNamespace
+
 import pytest
 
 from tests.unit.macros.base import MacroTestBase
@@ -256,6 +258,35 @@ class TestDeleteInsertMacros(MacroTestBase):
         # since Jinja2 macro testing cannot capture the return value as a Python list
 
     # ========== Tests for routing logic (replace_on capability check) ==========
+
+    @pytest.mark.parametrize(
+        "variant", ["replace_on", "delete_insert_by_name", "delete_insert_positional"]
+    )
+    def test_typed_plan_selects_renderer_without_capability_inference(
+        self, template, context, variant
+    ):
+        context["adapter"].has_dbr_capability = lambda _cap: (_ for _ in ()).throw(
+            AssertionError("typed renderer must not probe runtime capabilities")
+        )
+        context["adapter"].get_columns_in_relation.return_value = [
+            SimpleNamespace(quoted="a"),
+            SimpleNamespace(quoted="b"),
+        ]
+        context["config"].require = lambda key: "a" if key == "unique_key" else None
+        plan = SimpleNamespace(renderer_variant=variant)
+
+        result = self.run_macro_raw(
+            template,
+            "get_delete_insert_sql",
+            {
+                "temp_relation": "source",
+                "target_relation": "target",
+                "incremental_plan": plan,
+            },
+        )
+
+        if variant == "replace_on":
+            assert "replace on" in self.clean_sql(result)
 
     def test_delete_insert_sql_impl__routes_to_replace_on(self, template, context):
         """Verify that with replace_on capability, we use REPLACE ON syntax"""

--- a/tests/unit/macros/materializations/incremental/test_insert_into_macros.py
+++ b/tests/unit/macros/materializations/incremental/test_insert_into_macros.py
@@ -1,3 +1,4 @@
+from types import SimpleNamespace
 from unittest.mock import Mock
 
 import pytest
@@ -68,6 +69,35 @@ class TestInsertIntoMacros(MacroTestBase):
         target_relation.render.return_value = "target_table"
 
         return source_relation, target_relation
+
+    @pytest.mark.parametrize(
+        "variant,expects_by_name",
+        [("append_by_name", True), ("append_positional", False)],
+    )
+    def test_typed_append_uses_planned_renderer_variant(
+        self, template_bundle, mock_relations, variant, expects_by_name
+    ):
+        source_relation, target_relation = mock_relations
+        adapter = template_bundle.context["adapter"]
+        adapter.has_dbr_capability = Mock(
+            side_effect=AssertionError("typed append must not probe runtime capabilities")
+        )
+        adapter.get_columns_in_relation.side_effect = [
+            [SimpleNamespace(name="id"), SimpleNamespace(name="value")],
+            [SimpleNamespace(name="id"), SimpleNamespace(name="value")],
+        ]
+
+        result = self.run_macro(
+            template_bundle.template,
+            "databricks__get_incremental_append_sql",
+            {
+                "temp_relation": source_relation,
+                "target_relation": target_relation,
+                "incremental_plan": SimpleNamespace(renderer_variant=variant),
+            },
+        )
+
+        assert ("by name" in self.clean_sql(result)) is expects_by_name
 
     def test_insert_into_sql_impl__with_capability_matching_columns(
         self, template_bundle, mock_relations

--- a/tests/unit/macros/materializations/incremental/test_insert_overwrite_macros.py
+++ b/tests/unit/macros/materializations/incremental/test_insert_overwrite_macros.py
@@ -1,3 +1,4 @@
+from types import SimpleNamespace
 from unittest.mock import Mock
 
 import pytest
@@ -53,6 +54,47 @@ class TestInsertOverwriteMacros(MacroTestBase):
 
         # Mock exceptions.warn to return empty string to avoid polluting SQL output
         context["exceptions"].warn.return_value = ""
+
+    @pytest.mark.parametrize(
+        "variant,expected_fragment",
+        [
+            ("replace_on", "replace on"),
+            ("legacy_by_name", "by name"),
+            ("legacy_positional", "select * from source_table"),
+        ],
+    )
+    def test_typed_plan_selects_renderer_without_capability_inference(
+        self, template, context, config, variant, expected_fragment
+    ):
+        context["adapter"].has_dbr_capability = Mock(
+            side_effect=AssertionError("typed renderer must not probe runtime capabilities")
+        )
+        context["adapter"].is_cluster = Mock(
+            side_effect=AssertionError("typed renderer must not infer runtime type")
+        )
+        config["partition_by"] = ["a"]
+        source_relation = Mock()
+        source_relation.__str__ = lambda self: "source_table"
+        target_relation = Mock()
+        target_relation.__str__ = lambda self: "target_table"
+        plan = SimpleNamespace(
+            renderer_variant=variant,
+            facts=SimpleNamespace(runtime=SimpleNamespace(engine="databricks_cluster")),
+        )
+
+        result = self.run_macro_raw(
+            template,
+            "databricks__get_incremental_insert_overwrite_sql",
+            {
+                "temp_relation": source_relation,
+                "target_relation": target_relation,
+                "incremental_plan": plan,
+            },
+        )
+
+        assert expected_fragment in self.clean_sql(result)
+        if variant == "legacy_positional":
+            assert "by name" not in self.clean_sql(result)
 
     @pytest.mark.parametrize(
         "has_replace_on_capability,expected_sql",

--- a/tests/unit/macros/materializations/incremental/test_replace_where_macros.py
+++ b/tests/unit/macros/materializations/incremental/test_replace_where_macros.py
@@ -1,3 +1,4 @@
+from types import SimpleNamespace
 from unittest.mock import Mock
 
 import pytest
@@ -35,6 +36,28 @@ class TestReplaceWhereMacros(MacroTestBase):
         temp_relation.render.return_value = "schema.temp_table"
 
         return target_relation, temp_relation
+
+    @pytest.mark.parametrize(
+        "variant,expects_by_name",
+        [("replace_where_by_name", True), ("replace_where_positional", False)],
+    )
+    def test_typed_plan_selects_renderer_without_capability_inference(
+        self, template_bundle, context, mock_relations, variant, expects_by_name
+    ):
+        context["adapter"].has_dbr_capability = Mock(
+            side_effect=AssertionError("typed renderer must not probe runtime capabilities")
+        )
+        target_relation, temp_relation = mock_relations
+        args_dict = {
+            "target_relation": target_relation,
+            "temp_relation": temp_relation,
+            "incremental_predicates": "date_col > '2023-01-01'",
+            "incremental_plan": SimpleNamespace(renderer_variant=variant),
+        }
+
+        result = self.run_macro(template_bundle.template, "get_replace_where_sql", args_dict)
+
+        assert ("by name" in self.clean_sql(result)) is expects_by_name
 
     def test_get_replace_where_sql_with_string_predicate(self, template_bundle, mock_relations):
         target_relation, temp_relation = mock_relations

--- a/tests/unit/macros/relations/components/test_column_tags_macros.py
+++ b/tests/unit/macros/relations/components/test_column_tags_macros.py
@@ -61,6 +61,21 @@ class TestColumnTagsMacros(MacroTestBase):
         assert "alter" not in sql
         assert "set tags" not in sql
 
+    def test_planned_column_tags_do_not_probe_relation_catalog(self, passthrough_statement):
+        passthrough_statement.relation.is_hive_metastore = lambda: (_ for _ in ()).throw(
+            AssertionError("typed renderer must not infer catalog type")
+        )
+        config = ColumnTagsConfig(set_column_tags={"email": {"pii": "true"}})
+
+        sql = self.render_bundle(
+            passthrough_statement,
+            "apply_column_tags_from_plan",
+            config,
+            "unity",
+        )
+
+        assert "alter column `email` set tags ('pii' = 'true')" in sql
+
     def test_alter_unset_column_tags_table(self, template_bundle):
         sql = self.render_bundle(
             template_bundle, "alter_unset_column_tags", "email", ["pii", "team"]

--- a/tests/unit/macros/relations/test_optimize_macros.py
+++ b/tests/unit/macros/relations/test_optimize_macros.py
@@ -28,6 +28,30 @@ class TestOptimizeMacros(MacroTestBase):
 
         assert sql == "optimize `some_database`.`some_schema`.`some_table` zorder by (foo, bar)"
 
+    @pytest.mark.parametrize(
+        ("renderer_variant", "zorder", "expected"),
+        [
+            ("plain", None, "optimize `some_database`.`some_schema`.`some_table`"),
+            (
+                "zorder",
+                ["foo", "bar"],
+                "optimize `some_database`.`some_schema`.`some_table` zorder by (foo, bar)",
+            ),
+        ],
+    )
+    def test_planned_optimize_renders_only_selected_variant(
+        self, renderer_variant, zorder, expected, config, template_bundle
+    ):
+        config["zorder"] = zorder
+
+        sql = self.render_bundle(
+            template_bundle,
+            "get_optimize_sql_from_plan",
+            renderer_variant,
+        )
+
+        assert sql == expected
+
     def test_macros_optimize_with_extraneous_info(self, config, var, template_bundle):
         config["zorder"] = ["foo", "bar"]
         var["FOO"] = True

--- a/tests/unit/macros/relations/test_table_macros.py
+++ b/tests/unit/macros/relations/test_table_macros.py
@@ -1,3 +1,5 @@
+from types import SimpleNamespace
+
 import pytest
 
 from dbt.adapters.databricks import constants
@@ -39,12 +41,32 @@ class TestCreateTableAs(MacroTestBase):
         """
         template.globals["adapter"].is_uniform.return_value = False
         template.globals["adapter"].update_tblproperties_for_uniform_iceberg.return_value = {}
+        template.globals["adapter"].behavior.use_managed_iceberg = False
         return template.globals
 
     def render_create_table_as(self, template_bundle, temporary=False, sql="select 1"):
         external_path = f"/mnt/root/{template_bundle.relation.identifier}"
         adapter_mock = template_bundle.template.globals["adapter"]
         adapter_mock.compute_external_path.return_value = external_path
+        catalog_relation = adapter_mock.build_catalog_relation.return_value
+        managed_iceberg = (
+            catalog_relation.table_format == constants.ICEBERG_TABLE_FORMAT
+            and adapter_mock.behavior.use_managed_iceberg is True
+        )
+        adapter_mock.plan_create_from_query.return_value = SimpleNamespace(
+            facts=SimpleNamespace(
+                catalog=SimpleNamespace(catalog_type=catalog_relation.catalog_type),
+                format=SimpleNamespace(
+                    table_format=catalog_relation.table_format,
+                    file_format=catalog_relation.file_format,
+                    table_provider=(
+                        constants.ICEBERG_TABLE_FORMAT
+                        if managed_iceberg
+                        else catalog_relation.file_format
+                    ),
+                )
+            )
+        )
         return self.run_macro(
             template_bundle.template,
             "databricks__create_table_as",
@@ -58,6 +80,38 @@ class TestCreateTableAs(MacroTestBase):
         sql = self.render_create_table_as(template_bundle)
         assert (
             sql == f"create or replace table {template_bundle.relation.render()}"
+            " using delta as select 1"
+        )
+
+    def test_typed_create_renderer_uses_supplied_plan(self, template_bundle):
+        catalog_relation = unity_relation()
+        adapter = template_bundle.context["adapter"]
+        adapter.build_catalog_relation.return_value = catalog_relation
+        adapter.plan_create_from_query.side_effect = AssertionError(
+            "typed renderer must not resolve a second create plan"
+        )
+        plan = SimpleNamespace(
+            temporary=False,
+            facts=SimpleNamespace(
+                catalog=SimpleNamespace(catalog_type=catalog_relation.catalog_type),
+                format=SimpleNamespace(
+                    table_format=catalog_relation.table_format,
+                    file_format=catalog_relation.file_format,
+                    table_provider=catalog_relation.file_format,
+                ),
+            ),
+        )
+
+        sql = self.run_macro(
+            template_bundle.template,
+            "databricks__render_create_from_query_plan",
+            plan,
+            template_bundle.relation,
+            "select 1",
+        )
+
+        assert sql == (
+            f"create or replace table {template_bundle.relation.render()}"
             " using delta as select 1"
         )
 
@@ -260,10 +314,7 @@ class TestCreateTableAs(MacroTestBase):
         config["clustered_by"] = ["cluster_1", "cluster_2"]
         config["buckets"] = "1"
         config["persist_docs"] = {"relation": True}
-        template_bundle.context["adapter"].is_uniform.return_value = True
-        template_bundle.context["adapter"].update_tblproperties_for_uniform_iceberg.return_value = {
-            "delta.appendOnly": "true"
-        }
+        config["tblproperties"] = {"delta.appendOnly": "true"}
         template_bundle.context["model"].description = "Description Test"
 
         sql = self.render_create_table_as(template_bundle)
@@ -294,10 +345,7 @@ class TestCreateTableAs(MacroTestBase):
         config["clustered_by"] = ["cluster_1", "cluster_2"]
         config["buckets"] = "1"
         config["persist_docs"] = {"relation": True}
-        template_bundle.context["adapter"].is_uniform.return_value = True
-        template_bundle.context["adapter"].update_tblproperties_for_uniform_iceberg.return_value = {
-            "delta.appendOnly": "true"
-        }
+        config["tblproperties"] = {"delta.appendOnly": "true"}
         template_bundle.context["model"].description = "Description Test"
 
         sql = self.render_create_table_as(template_bundle)

--- a/tests/unit/macros/relations/test_tags_macros.py
+++ b/tests/unit/macros/relations/test_tags_macros.py
@@ -32,3 +32,20 @@ class TestTagsMacros(MacroTestBase):
         )
 
         assert sql == expected
+
+    def test_planned_tags_do_not_probe_relation_catalog(self, template_bundle):
+        template_bundle.context["statement"] = (
+            lambda label, fetch_result=False, caller=None: caller() if caller else label
+        )
+        template_bundle.relation.is_hive_metastore = lambda: (_ for _ in ()).throw(
+            AssertionError("typed renderer must not infer catalog type")
+        )
+
+        sql = self.render_bundle(
+            template_bundle,
+            "apply_tags_from_plan",
+            {"domain": "finance"},
+            "unity",
+        )
+
+        assert "set tags ('domain' = 'finance')" in sql

--- a/tests/unit/test_adapter.py
+++ b/tests/unit/test_adapter.py
@@ -1874,6 +1874,7 @@ class TestManagedIcebergBehaviorFlag(DatabricksAdapterBase):
         model.database = "test_catalog"
         model.schema = "analytics"
         model.identifier = "model"
+        model.columns = {}
         model.config = {
             "materialized": "table",
             "table_format": constants.ICEBERG_TABLE_FORMAT,
@@ -1991,6 +1992,57 @@ class TestManagedIcebergBehaviorFlag(DatabricksAdapterBase):
         )
         assert warehouse_replace_on.renderer_variant == "replace_on"
 
+        adapter.behavior.use_managed_iceberg.setting = True
+        managed_iceberg = adapter.plan_incremental_mutation(
+            "insert_overwrite",
+            catalog_relation=unity_catalog_relation,
+        )
+        assert managed_iceberg.facts.format.table_provider == constants.ICEBERG_TABLE_FORMAT
+        assert "managed_iceberg" in managed_iceberg.facts.capabilities
+        assert "uniform_iceberg" not in managed_iceberg.facts.capabilities
+        assert managed_iceberg.renderer_variant == "legacy_by_name"
+
+    def test_partitioned_insert_overwrite_rejects_managed_iceberg(
+        self, adapter, unity_catalog_relation
+    ):
+        adapter.behavior.use_managed_iceberg.setting = True
+        adapter.behavior.use_materialization_v2.setting = True
+        adapter.build_catalog_relation = Mock(return_value=unity_catalog_relation)
+        self._set_planning_runtime(adapter, version=(17, 1))
+        model = self._planning_model()
+        model.config.update(
+            {
+                "materialized": "incremental",
+                "incremental_strategy": "insert_overwrite",
+                "partition_by": ["event_date"],
+            }
+        )
+        mutation = adapter.plan_incremental_mutation(
+            "insert_overwrite",
+            catalog_relation=unity_catalog_relation,
+        )
+        materialization = adapter.plan_incremental_materialization(
+            "macro.dbt_databricks.materialization_incremental_databricks",
+            "sql",
+            model,
+        )
+
+        with pytest.raises(
+            DbtConfigError,
+            match="Partition-scoped insert_overwrite is only supported for Delta tables",
+        ):
+            adapter.resolve_incremental_lifecycle_plan(
+                mutation,
+                model,
+                self._planning_relation(),
+                self._planning_relation(provider=constants.ICEBERG_TABLE_FORMAT),
+                full_refresh=False,
+                on_schema_change="ignore",
+                staging_is_temporary=True,
+                contract_enforced=False,
+                materialization_plan=materialization,
+            )
+
     def test_managed_iceberg_incremental_rejects_hms_and_old_runtime(
         self, adapter, hive_catalog_relation, unity_catalog_relation
     ):
@@ -2096,6 +2148,8 @@ class TestManagedIcebergBehaviorFlag(DatabricksAdapterBase):
         adapter.build_catalog_relation = Mock(return_value=unity_catalog_relation)
         self._set_planning_runtime(adapter)
         model = self._planning_model()
+        model.config["zorder"] = "id"
+        model.config["persist_constraints"] = True
         target = self._planning_relation()
         existing = self._planning_relation(provider=constants.DELTA_FILE_FORMAT)
 
@@ -2117,13 +2171,84 @@ class TestManagedIcebergBehaviorFlag(DatabricksAdapterBase):
             "run_hooks",
             "create_from_query",
             "apply_grants",
-            "apply_tags",
-            "apply_column_tags",
             "persist_documentation",
             "persist_constraints",
             "optimize",
             "run_hooks",
         ]
+        variants = {
+            operation.kind.value: operation.renderer_variant
+            for operation in resolved.operations
+            if operation.renderer_variant is not None
+        }
+        assert variants["persist_constraints"] == "delta"
+        assert variants["optimize"] == "zorder"
+
+    def test_managed_iceberg_table_plan_owns_unsupported_post_create_variants(
+        self, adapter, unity_catalog_relation_managed_iceberg_relation
+    ):
+        adapter.behavior.use_managed_iceberg.setting = True
+        adapter.behavior.use_materialization_v2.setting = False
+        adapter.build_catalog_relation = Mock(
+            return_value=unity_catalog_relation_managed_iceberg_relation
+        )
+        self._set_planning_runtime(adapter)
+        model = self._planning_model()
+        model.config.update({"persist_constraints": True, "zorder": "id"})
+        plan = adapter.plan_table_materialization(
+            "macro.dbt_databricks.materialization_table_databricks",
+            "sql",
+            model,
+        )
+
+        resolved = adapter.resolve_table_lifecycle_plan(
+            plan,
+            model,
+            self._planning_relation(),
+            None,
+            model.config,
+        )
+
+        operations = {operation.kind.value: operation for operation in resolved.operations}
+        assert operations["persist_documentation"].renderer_variant == "unsupported"
+        assert operations["persist_constraints"].renderer_variant == "unsupported"
+        assert "optimize" not in operations
+
+    def test_table_plan_owns_catalog_specific_tag_operations(
+        self, adapter, unity_catalog_relation
+    ):
+        adapter.behavior.use_managed_iceberg.setting = False
+        adapter.behavior.use_materialization_v2.setting = False
+        adapter.build_catalog_relation = Mock(return_value=unity_catalog_relation)
+        self._set_planning_runtime(adapter)
+        model = self._planning_model()
+        model.config["databricks_tags"] = {"domain": "finance"}
+        model.columns = {
+            "id": {
+                "name": "id",
+                "_extra": {"databricks_tags": {"classification": "internal"}},
+            }
+        }
+        plan = adapter.plan_table_materialization(
+            "macro.dbt_databricks.materialization_table_databricks",
+            "sql",
+            model,
+        )
+
+        resolved = adapter.resolve_table_lifecycle_plan(
+            plan,
+            model,
+            self._planning_relation(),
+            None,
+            model.config,
+        )
+
+        variants = {
+            operation.kind.value: operation.renderer_variant
+            for operation in resolved.operations
+        }
+        assert variants["apply_tags"] == "unity"
+        assert variants["apply_column_tags"] == "unity"
 
     def test_v2_safe_table_plan_encapsulates_create_insert_and_swap(
         self, adapter, unity_catalog_relation
@@ -2134,6 +2259,7 @@ class TestManagedIcebergBehaviorFlag(DatabricksAdapterBase):
         self._set_planning_runtime(adapter)
         model = self._planning_model()
         model.config["use_safer_relation_operations"] = True
+        model.config["zorder"] = "id"
         target = self._planning_relation()
         existing = self._planning_relation(provider=constants.DELTA_FILE_FORMAT)
 
@@ -2157,8 +2283,6 @@ class TestManagedIcebergBehaviorFlag(DatabricksAdapterBase):
             "create_from_query",
             "create_structure_from_relation",
             "apply_alter_constraints",
-            "apply_tags",
-            "apply_column_tags",
             "insert_from_relation",
             "drop_relation_if_exists",
             "rename_relation",
@@ -2175,6 +2299,7 @@ class TestManagedIcebergBehaviorFlag(DatabricksAdapterBase):
         assert create_intermediate.temporary is True
         assert resolved.operations[3].source.value == "intermediate"
         assert resolved.operations[3].relation.value == "staging"
+        assert resolved.operations[5].renderer_variant == "by_name"
 
     def test_v2_incremental_plan_orders_config_schema_and_mutation(
         self, adapter, unity_catalog_relation
@@ -2188,6 +2313,7 @@ class TestManagedIcebergBehaviorFlag(DatabricksAdapterBase):
             {
                 "materialized": "incremental",
                 "incremental_strategy": "merge",
+                "zorder": "id",
             }
         )
         target = self._planning_relation()
@@ -2255,6 +2381,7 @@ class TestManagedIcebergBehaviorFlag(DatabricksAdapterBase):
             {
                 "materialized": "incremental",
                 "incremental_strategy": "merge",
+                "zorder": "id",
             }
         )
         target = self._planning_relation()
@@ -2308,6 +2435,48 @@ class TestManagedIcebergBehaviorFlag(DatabricksAdapterBase):
             "run_hooks",
         ]
         assert resolved.operations[6].name == "for_relation"
+
+    def test_incremental_plan_omits_disabled_config_changes_and_unconfigured_optimize(
+        self, adapter, unity_catalog_relation
+    ):
+        adapter.behavior.use_managed_iceberg.setting = False
+        adapter.behavior.use_materialization_v2.setting = True
+        adapter.build_catalog_relation = Mock(return_value=unity_catalog_relation)
+        self._set_planning_runtime(adapter)
+        model = self._planning_model()
+        model.config.update(
+            {
+                "materialized": "incremental",
+                "incremental_strategy": "append",
+                "incremental_apply_config_changes": "false",
+            }
+        )
+        target = self._planning_relation()
+        existing = self._planning_relation(provider=constants.DELTA_FILE_FORMAT)
+        mutation = adapter.plan_incremental_mutation(
+            "append",
+            catalog_relation=unity_catalog_relation,
+        )
+
+        resolved = adapter.resolve_incremental_lifecycle_plan(
+            mutation,
+            model,
+            target,
+            existing,
+            full_refresh=False,
+            on_schema_change="ignore",
+            staging_is_temporary=True,
+            contract_enforced=False,
+            materialization_plan=adapter.plan_incremental_materialization(
+                "macro.dbt_databricks.materialization_incremental_databricks",
+                "sql",
+                model,
+            ),
+        )
+
+        operation_kinds = [operation.kind.value for operation in resolved.operations]
+        assert "process_config_changes" not in operation_kinds
+        assert "optimize" not in operation_kinds
 
     def test_is_uniform_with_managed_iceberg_returns_false(
         self, adapter, mock_config, unity_catalog_relation_managed_iceberg_relation

--- a/tests/unit/test_adapter.py
+++ b/tests/unit/test_adapter.py
@@ -8,6 +8,12 @@ from unittest.mock import Mock, patch
 import agate
 import dbt.flags as flags
 import pytest
+from dbt.adapters.planning import (
+    DdlAtomicity,
+    IncrementalMutationPlan,
+    IncrementalMutationStrategy,
+    PlanProvenance,
+)
 from agate import Row
 from dbt.config import RuntimeConfig
 from dbt_common.clients.agate_helper import merge_tables
@@ -2017,6 +2023,68 @@ class TestManagedIcebergBehaviorFlag(DatabricksAdapterBase):
         assert create_intermediate.temporary is True
         assert resolved.operations[3].source.value == "intermediate"
         assert resolved.operations[3].relation.value == "staging"
+
+    def test_v2_incremental_plan_orders_config_schema_and_mutation(
+        self, adapter, unity_catalog_relation
+    ):
+        adapter.behavior.use_managed_iceberg.setting = False
+        adapter.behavior.use_materialization_v2.setting = True
+        adapter.build_catalog_relation = Mock(return_value=unity_catalog_relation)
+        self._set_planning_runtime(adapter)
+        model = self._planning_model()
+        model.config.update(
+            {
+                "materialized": "incremental",
+                "incremental_strategy": "merge",
+            }
+        )
+        target = self._planning_relation()
+        existing = self._planning_relation(provider=constants.DELTA_FILE_FORMAT)
+        mutation = IncrementalMutationPlan(
+            requested_strategy="merge",
+            strategy=IncrementalMutationStrategy.MERGE,
+            renderer_macro="get_incremental_merge_sql",
+            atomicity=DdlAtomicity.UNKNOWN,
+            provenance=(
+                PlanProvenance(
+                    rule="test.databricks.merge",
+                    detail="Test Databricks merge",
+                ),
+            ),
+        )
+        materialization = adapter.plan_incremental_materialization(
+            "macro.dbt_databricks.materialization_incremental_databricks",
+            "sql",
+            model,
+        )
+        assert materialization is not None
+
+        resolved = adapter.resolve_incremental_lifecycle_plan(
+            mutation,
+            model,
+            target,
+            existing,
+            full_refresh=False,
+            on_schema_change="sync_all_columns",
+            staging_is_temporary=True,
+            contract_enforced=False,
+            materialization_plan=materialization,
+        )
+
+        assert resolved.facts.create.format.table_format == "iceberg"
+        assert resolved.facts.create.format.file_format == "delta"
+        assert [operation.kind.value for operation in resolved.operations] == [
+            "run_hooks",
+            "run_hooks",
+            "create_from_query",
+            "process_schema_changes",
+            "process_config_changes",
+            "execute_incremental_mutation",
+            "apply_grants",
+            "optimize",
+            "run_hooks",
+            "run_hooks",
+        ]
 
     def test_is_uniform_with_managed_iceberg_returns_false(
         self, adapter, mock_config, unity_catalog_relation_managed_iceberg_relation

--- a/tests/unit/test_adapter.py
+++ b/tests/unit/test_adapter.py
@@ -8,13 +8,13 @@ from unittest.mock import Mock, patch
 import agate
 import dbt.flags as flags
 import pytest
+from agate import Row
 from dbt.adapters.planning import (
     DdlAtomicity,
     IncrementalMutationPlan,
     IncrementalMutationStrategy,
     PlanProvenance,
 )
-from agate import Row
 from dbt.config import RuntimeConfig
 from dbt_common.clients.agate_helper import merge_tables
 from dbt_common.events.event_manager_client import add_callback_to_manager
@@ -2085,6 +2085,67 @@ class TestManagedIcebergBehaviorFlag(DatabricksAdapterBase):
             "run_hooks",
             "run_hooks",
         ]
+
+    def test_v1_incremental_plan_captures_then_applies_config_changes(
+        self, adapter, unity_catalog_relation
+    ):
+        adapter.behavior.use_managed_iceberg.setting = False
+        adapter.behavior.use_materialization_v2.setting = False
+        adapter.build_catalog_relation = Mock(return_value=unity_catalog_relation)
+        self._set_planning_runtime(adapter)
+        model = self._planning_model()
+        model.config.update(
+            {
+                "materialized": "incremental",
+                "incremental_strategy": "merge",
+            }
+        )
+        target = self._planning_relation()
+        existing = self._planning_relation(provider=constants.DELTA_FILE_FORMAT)
+        mutation = IncrementalMutationPlan(
+            requested_strategy="merge",
+            strategy=IncrementalMutationStrategy.MERGE,
+            renderer_macro="get_incremental_merge_sql",
+            atomicity=DdlAtomicity.UNKNOWN,
+            provenance=(
+                PlanProvenance(
+                    rule="test.databricks.merge",
+                    detail="Test Databricks merge",
+                ),
+            ),
+        )
+        materialization = adapter.plan_incremental_materialization(
+            "macro.dbt_databricks.materialization_incremental_databricks",
+            "sql",
+            model,
+        )
+        assert materialization is not None
+
+        resolved = adapter.resolve_incremental_lifecycle_plan(
+            mutation,
+            model,
+            target,
+            existing,
+            full_refresh=False,
+            on_schema_change="append_new_columns",
+            staging_is_temporary=True,
+            contract_enforced=False,
+            materialization_plan=materialization,
+        )
+
+        assert [operation.kind.value for operation in resolved.operations] == [
+            "run_hooks",
+            "capture_config_changes",
+            "create_from_query",
+            "process_schema_changes",
+            "execute_incremental_mutation",
+            "apply_config_changes",
+            "persist_documentation",
+            "apply_grants",
+            "optimize",
+            "run_hooks",
+        ]
+        assert resolved.operations[6].name == "for_relation"
 
     def test_is_uniform_with_managed_iceberg_returns_false(
         self, adapter, mock_config, unity_catalog_relation_managed_iceberg_relation

--- a/tests/unit/test_adapter.py
+++ b/tests/unit/test_adapter.py
@@ -11,6 +11,7 @@ import pytest
 from agate import Row
 from dbt.adapters.planning import (
     DdlAtomicity,
+    IncrementalMutationFacts,
     IncrementalMutationPlan,
     IncrementalMutationStrategy,
     PlanProvenance,
@@ -1889,10 +1890,155 @@ class TestManagedIcebergBehaviorFlag(DatabricksAdapterBase):
             metadata={KEY_TABLE_PROVIDER: provider} if provider is not None else {},
         )
 
-    def _set_planning_runtime(self, adapter):
+    def _set_planning_runtime(self, adapter, version=(14, 3), *, warehouse=False):
         connection = Mock()
-        connection.capabilities = DBRCapabilities(dbr_version=(14, 3))
+        connection.capabilities = DBRCapabilities(
+            dbr_version=version,
+            is_sql_warehouse=warehouse,
+        )
         adapter.connections.get_thread_connection = Mock(return_value=connection)
+
+    def test_incremental_plan_serializes_delta_catalog_provider_and_runtime(self, adapter):
+        adapter.behavior.use_managed_iceberg.setting = False
+        adapter.build_catalog_relation = Mock(
+            return_value=DatabricksCatalogRelation(
+                catalog_type=constants.HIVE_METASTORE_CATALOG_TYPE,
+                catalog_name="hive_metastore",
+                table_format=constants.DEFAULT_TABLE_FORMAT,
+                file_format=constants.DELTA_FILE_FORMAT,
+                catalog_provider="glue",
+            )
+        )
+        self._set_planning_runtime(adapter, version=(17, 1))
+
+        plan = adapter.plan_incremental_mutation(
+            "merge",
+            language="sql",
+            unique_key="id",
+            catalog_relation=adapter.build_catalog_relation(Mock()),
+        )
+
+        assert plan.strategy == IncrementalMutationStrategy.MERGE
+        assert plan.renderer_variant == "merge_delta"
+        assert plan.facts is not None
+        assert plan.facts.catalog.catalog_type == constants.HIVE_METASTORE_CATALOG_TYPE
+        assert plan.facts.catalog.catalog_provider == "glue"
+        assert plan.facts.format.table_provider == constants.DELTA_FILE_FORMAT
+        assert plan.facts.runtime.engine == "databricks_runtime"
+        assert plan.facts.runtime.version == "17.1"
+        assert "replace_on" in plan.facts.capabilities
+        assert plan.to_dict()["facts"]["catalog"]["catalog_provider"] == "glue"
+
+    def test_incremental_plan_distinguishes_uniform_from_managed_iceberg(
+        self, adapter, unity_catalog_relation
+    ):
+        adapter.build_catalog_relation = Mock(return_value=unity_catalog_relation)
+        self._set_planning_runtime(adapter, version=(16, 4))
+
+        adapter.behavior.use_managed_iceberg.setting = False
+        uniform = adapter.plan_incremental_mutation(
+            "merge",
+            catalog_relation=unity_catalog_relation,
+        )
+        assert uniform.facts is not None
+        assert uniform.facts.format.table_format == constants.ICEBERG_TABLE_FORMAT
+        assert uniform.facts.format.table_provider == constants.DELTA_FILE_FORMAT
+        assert uniform.strategy == IncrementalMutationStrategy.MERGE
+        assert uniform.renderer_variant == "merge_delta"
+
+        adapter.behavior.use_managed_iceberg.setting = True
+        managed = adapter.plan_incremental_mutation(
+            "merge",
+            catalog_relation=unity_catalog_relation,
+        )
+        assert managed.facts is not None
+        assert managed.facts.format.table_format == constants.ICEBERG_TABLE_FORMAT
+        assert managed.facts.format.table_provider == constants.ICEBERG_TABLE_FORMAT
+        assert managed.strategy == IncrementalMutationStrategy.MERGE
+        assert managed.renderer_variant == "merge_iceberg"
+
+    def test_insert_overwrite_variant_is_resolved_from_runtime_and_flag(
+        self, adapter, unity_catalog_relation
+    ):
+        adapter.behavior.use_managed_iceberg.setting = False
+        adapter.behavior.use_replace_on_for_insert_overwrite.setting = False
+
+        self._set_planning_runtime(adapter, version=(16, 4))
+        old_cluster = adapter.plan_incremental_mutation(
+            "insert_overwrite",
+            catalog_relation=unity_catalog_relation,
+        )
+        assert old_cluster.renderer_variant == "legacy_by_name"
+
+        self._set_planning_runtime(adapter, version=(17, 1))
+        new_cluster = adapter.plan_incremental_mutation(
+            "insert_overwrite",
+            catalog_relation=unity_catalog_relation,
+        )
+        assert new_cluster.renderer_variant == "replace_on"
+
+        self._set_planning_runtime(adapter, warehouse=True)
+        warehouse_legacy = adapter.plan_incremental_mutation(
+            "insert_overwrite",
+            catalog_relation=unity_catalog_relation,
+        )
+        assert warehouse_legacy.renderer_variant == "legacy_by_name"
+
+        adapter.behavior.use_replace_on_for_insert_overwrite.setting = True
+        warehouse_replace_on = adapter.plan_incremental_mutation(
+            "insert_overwrite",
+            catalog_relation=unity_catalog_relation,
+        )
+        assert warehouse_replace_on.renderer_variant == "replace_on"
+
+    def test_managed_iceberg_incremental_rejects_hms_and_old_runtime(
+        self, adapter, hive_catalog_relation, unity_catalog_relation
+    ):
+        adapter.behavior.use_managed_iceberg.setting = True
+        self._set_planning_runtime(adapter, version=(16, 4))
+        hms = adapter.plan_incremental_mutation(
+            "merge",
+            catalog_relation=hive_catalog_relation,
+        )
+        assert hms.strategy == IncrementalMutationStrategy.UNSUPPORTED
+        assert hms.reason == "Managed Iceberg incremental models require Unity Catalog"
+
+        self._set_planning_runtime(adapter, version=(15, 4))
+        old_runtime = adapter.plan_incremental_mutation(
+            "merge",
+            catalog_relation=unity_catalog_relation,
+        )
+        assert old_runtime.strategy == IncrementalMutationStrategy.UNSUPPORTED
+        assert old_runtime.reason == "Managed Iceberg incremental models require DBR 16.4 or newer"
+
+    def test_incremental_strategy_validation_uses_physical_provider(self, adapter):
+        adapter.behavior.use_managed_iceberg.setting = False
+        self._set_planning_runtime(adapter, version=(17, 1))
+        parquet = DatabricksCatalogRelation(
+            catalog_type=constants.HIVE_METASTORE_CATALOG_TYPE,
+            file_format=constants.PARQUET_FILE_FORMAT,
+        )
+
+        merge = adapter.plan_incremental_mutation("merge", catalog_relation=parquet)
+        append = adapter.plan_incremental_mutation("append", catalog_relation=parquet)
+
+        assert merge.strategy == IncrementalMutationStrategy.UNSUPPORTED
+        assert "resolved provider was 'parquet'" in (merge.reason or "")
+        assert append.strategy == IncrementalMutationStrategy.APPEND
+
+    def test_custom_incremental_strategy_remains_available(self, adapter):
+        adapter.behavior.use_managed_iceberg.setting = False
+        self._set_planning_runtime(adapter, version=(17, 1))
+        parquet = DatabricksCatalogRelation(
+            catalog_type=constants.HIVE_METASTORE_CATALOG_TYPE,
+            file_format=constants.PARQUET_FILE_FORMAT,
+        )
+
+        plan = adapter.plan_incremental_mutation("custom_upsert", catalog_relation=parquet)
+
+        assert plan.strategy == IncrementalMutationStrategy.CUSTOM
+        assert plan.renderer_macro == "get_incremental_custom_upsert_sql"
+        assert plan.renderer_variant == "custom_upsert_parquet"
 
     def test_uniform_planning_keeps_delta_physical_provider(self, adapter, unity_catalog_relation):
         adapter.behavior.use_managed_iceberg.setting = False
@@ -1907,6 +2053,7 @@ class TestManagedIcebergBehaviorFlag(DatabricksAdapterBase):
 
         assert facts.create.format.table_format == constants.ICEBERG_TABLE_FORMAT
         assert facts.create.format.file_format == constants.DELTA_FILE_FORMAT
+        assert facts.create.format.table_provider == constants.DELTA_FILE_FORMAT
         assert facts.existing is not None
         assert facts.existing.requires_drop_before_replace is False
         assert "uniform_iceberg" in facts.execution.capabilities
@@ -1934,6 +2081,7 @@ class TestManagedIcebergBehaviorFlag(DatabricksAdapterBase):
         )
 
         assert delta_facts.create.format.file_format == constants.PARQUET_FILE_FORMAT
+        assert delta_facts.create.format.table_provider == constants.ICEBERG_TABLE_FORMAT
         assert delta_facts.existing is not None
         assert delta_facts.existing.requires_drop_before_replace is True
         assert iceberg_facts.existing is not None
@@ -2007,7 +2155,11 @@ class TestManagedIcebergBehaviorFlag(DatabricksAdapterBase):
             "run_hooks",
             "run_hooks",
             "create_from_query",
-            "create_from_relation",
+            "create_structure_from_relation",
+            "apply_alter_constraints",
+            "apply_tags",
+            "apply_column_tags",
+            "insert_from_relation",
             "drop_relation_if_exists",
             "rename_relation",
             "rename_relation",
@@ -2050,6 +2202,11 @@ class TestManagedIcebergBehaviorFlag(DatabricksAdapterBase):
                     rule="test.databricks.merge",
                     detail="Test Databricks merge",
                 ),
+            ),
+            facts=IncrementalMutationFacts(
+                requested_strategy="merge",
+                language="sql",
+                unique_key_present=False,
             ),
         )
         materialization = adapter.plan_incremental_materialization(
@@ -2112,6 +2269,11 @@ class TestManagedIcebergBehaviorFlag(DatabricksAdapterBase):
                     rule="test.databricks.merge",
                     detail="Test Databricks merge",
                 ),
+            ),
+            facts=IncrementalMutationFacts(
+                requested_strategy="merge",
+                language="sql",
+                unique_key_present=False,
             ),
         )
         materialization = adapter.plan_incremental_materialization(

--- a/tests/unit/test_adapter.py
+++ b/tests/unit/test_adapter.py
@@ -25,6 +25,7 @@ from dbt.adapters.databricks.column import DatabricksColumn
 from dbt.adapters.databricks.credentials import (
     CATALOG_KEY_IN_SESSION_PROPERTIES,
 )
+from dbt.adapters.databricks.dbr_capabilities import DBRCapabilities
 from dbt.adapters.databricks.impl import (
     DESCRIBE_TABLE_EXTENDED_MACRO_NAME,
     DatabricksConfig,
@@ -36,6 +37,7 @@ from dbt.adapters.databricks.impl import (
     get_identifier_list_string,
 )
 from dbt.adapters.databricks.relation import (
+    KEY_TABLE_PROVIDER,
     DatabricksRelation,
     DatabricksRelationType,
     DatabricksTableType,
@@ -1859,6 +1861,162 @@ class TestManagedIcebergBehaviorFlag(DatabricksAdapterBase):
             table_format=constants.ICEBERG_TABLE_FORMAT,
             file_format=constants.DELTA_FILE_FORMAT,
         )
+
+    def _planning_model(self):
+        model = Mock()
+        model.database = "test_catalog"
+        model.schema = "analytics"
+        model.identifier = "model"
+        model.config = {
+            "materialized": "table",
+            "table_format": constants.ICEBERG_TABLE_FORMAT,
+        }
+        return model
+
+    def _planning_relation(self, *, provider: Optional[str] = None):
+        return DatabricksRelation.create(
+            database="test_catalog",
+            schema="analytics",
+            identifier="model",
+            type=DatabricksRelationType.Table,
+            is_delta=provider == constants.DELTA_FILE_FORMAT,
+            metadata={KEY_TABLE_PROVIDER: provider} if provider is not None else {},
+        )
+
+    def _set_planning_runtime(self, adapter):
+        connection = Mock()
+        connection.capabilities = DBRCapabilities(dbr_version=(14, 3))
+        adapter.connections.get_thread_connection = Mock(return_value=connection)
+
+    def test_uniform_planning_keeps_delta_physical_provider(self, adapter, unity_catalog_relation):
+        adapter.behavior.use_managed_iceberg.setting = False
+        adapter.build_catalog_relation = Mock(return_value=unity_catalog_relation)
+        self._set_planning_runtime(adapter)
+
+        facts = adapter.build_table_materialization_facts(
+            self._planning_model(),
+            self._planning_relation(),
+            self._planning_relation(provider=constants.DELTA_FILE_FORMAT),
+        )
+
+        assert facts.create.format.table_format == constants.ICEBERG_TABLE_FORMAT
+        assert facts.create.format.file_format == constants.DELTA_FILE_FORMAT
+        assert facts.existing is not None
+        assert facts.existing.requires_drop_before_replace is False
+        assert "uniform_iceberg" in facts.execution.capabilities
+
+    def test_managed_iceberg_drops_delta_but_replaces_native_iceberg(
+        self, adapter, unity_catalog_relation_managed_iceberg_relation
+    ):
+        adapter.behavior.use_managed_iceberg.setting = True
+        adapter.build_catalog_relation = Mock(
+            return_value=unity_catalog_relation_managed_iceberg_relation
+        )
+        self._set_planning_runtime(adapter)
+        model = self._planning_model()
+        target = self._planning_relation()
+
+        delta_facts = adapter.build_table_materialization_facts(
+            model,
+            target,
+            self._planning_relation(provider=constants.DELTA_FILE_FORMAT),
+        )
+        iceberg_facts = adapter.build_table_materialization_facts(
+            model,
+            target,
+            self._planning_relation(provider=constants.ICEBERG_TABLE_FORMAT),
+        )
+
+        assert delta_facts.create.format.file_format == constants.PARQUET_FILE_FORMAT
+        assert delta_facts.existing is not None
+        assert delta_facts.existing.requires_drop_before_replace is True
+        assert iceberg_facts.existing is not None
+        assert iceberg_facts.existing.requires_drop_before_replace is False
+        assert "managed_iceberg" in iceberg_facts.execution.capabilities
+
+    def test_v1_table_plan_encapsulates_databricks_post_create_operations(
+        self, adapter, unity_catalog_relation
+    ):
+        adapter.behavior.use_managed_iceberg.setting = False
+        adapter.behavior.use_materialization_v2.setting = False
+        adapter.build_catalog_relation = Mock(return_value=unity_catalog_relation)
+        self._set_planning_runtime(adapter)
+        model = self._planning_model()
+        target = self._planning_relation()
+        existing = self._planning_relation(provider=constants.DELTA_FILE_FORMAT)
+
+        plan = adapter.plan_table_materialization(
+            "macro.dbt_databricks.materialization_table_databricks",
+            "sql",
+            model,
+        )
+        assert plan is not None
+        resolved = adapter.resolve_table_lifecycle_plan(
+            plan,
+            model,
+            target,
+            existing,
+            model.config,
+        )
+
+        assert [operation.kind.value for operation in resolved.operations] == [
+            "run_hooks",
+            "create_from_query",
+            "apply_grants",
+            "apply_tags",
+            "apply_column_tags",
+            "persist_documentation",
+            "persist_constraints",
+            "optimize",
+            "run_hooks",
+        ]
+
+    def test_v2_safe_table_plan_encapsulates_create_insert_and_swap(
+        self, adapter, unity_catalog_relation
+    ):
+        adapter.behavior.use_managed_iceberg.setting = False
+        adapter.behavior.use_materialization_v2.setting = True
+        adapter.build_catalog_relation = Mock(return_value=unity_catalog_relation)
+        self._set_planning_runtime(adapter)
+        model = self._planning_model()
+        model.config["use_safer_relation_operations"] = True
+        target = self._planning_relation()
+        existing = self._planning_relation(provider=constants.DELTA_FILE_FORMAT)
+
+        plan = adapter.plan_table_materialization(
+            "macro.dbt_databricks.materialization_table_databricks",
+            "sql",
+            model,
+        )
+        assert plan is not None
+        resolved = adapter.resolve_table_lifecycle_plan(
+            plan,
+            model,
+            target,
+            existing,
+            model.config,
+        )
+
+        assert [operation.kind.value for operation in resolved.operations] == [
+            "run_hooks",
+            "run_hooks",
+            "create_from_query",
+            "create_from_relation",
+            "drop_relation_if_exists",
+            "rename_relation",
+            "rename_relation",
+            "drop_relation_if_exists",
+            "drop_relation_if_exists",
+            "apply_grants",
+            "optimize",
+            "run_hooks",
+            "run_hooks",
+        ]
+        create_intermediate = resolved.operations[2]
+        assert create_intermediate.relation.value == "intermediate"
+        assert create_intermediate.temporary is True
+        assert resolved.operations[3].source.value == "intermediate"
+        assert resolved.operations[3].relation.value == "staging"
 
     def test_is_uniform_with_managed_iceberg_returns_false(
         self, adapter, mock_config, unity_catalog_relation_managed_iceberg_relation

--- a/tests/unit/test_catalogs_v2.py
+++ b/tests/unit/test_catalogs_v2.py
@@ -3,9 +3,12 @@ from typing import Any, Optional
 
 import pytest
 from dbt.adapters.capability import Capability, Support
-from dbt_common.exceptions import DbtValidationError
+from dbt_common.exceptions import DbtConfigError, DbtValidationError
 
-from dbt.adapters.databricks.catalogs import UnityCatalogIntegration
+from dbt.adapters.databricks.catalogs import (
+    HiveMetastoreCatalogIntegration,
+    UnityCatalogIntegration,
+)
 from dbt.adapters.databricks.impl import DatabricksAdapter
 
 
@@ -100,6 +103,23 @@ def test_unity_no_catalog_database_defaults_none():
     integration = UnityCatalogIntegration(_Config())
     assert integration.catalog_database is None
     assert integration.build_relation(_Model()).catalog_database is None
+
+
+def test_unity_catalog_provider_is_explicit_and_canonical():
+    integration = UnityCatalogIntegration(
+        _Config(adapter_properties={"catalog_provider": " Glue "})
+    )
+    assert integration.build_relation(_Model()).catalog_provider == "glue"
+
+
+def test_hive_metastore_does_not_imply_glue_provider():
+    integration = HiveMetastoreCatalogIntegration(_Config(catalog_type="hive_metastore"))
+    assert integration.build_relation(_Model()).catalog_provider is None
+
+
+def test_blank_catalog_provider_is_rejected():
+    with pytest.raises(DbtConfigError, match="catalog_provider cannot be blank"):
+        UnityCatalogIntegration(_Config(adapter_properties={"catalog_provider": "  "}))
 
 
 def test_unity_catalog_database_absent_on_older_adapters():


### PR DESCRIPTION
## Summary

- resolve table and incremental control flow into typed, serializable operation plans
- distinguish logical Iceberg from Delta-backed UniForm and native managed Iceberg
- reject Delta-only partition overwrite for managed Iceberg and prevent managed Iceberg from selecting `REPLACE ON`
- retain explicit catalog provider, physical provider, DBR runtime/version, named capabilities, and selected SQL renderer variants
- plan config-change inclusion, insert-by-name, tags/catalog legality, column comments, constraints, and optimization before execution
- keep legacy Jinja fallbacks while ensuring typed leaf renderers do not probe provider, catalog, runtime, version, or capabilities

## Dependency stack

- dbt-core: https://github.com/dbt-labs/dbt-core/pull/16061
- dbt-adapters: https://github.com/dbt-labs/dbt-adapters/pull/2139

## Planning boundary

The plan owns decisions that change strategy, operation ordering, staging/replacement safety, overwrite behavior, operation inclusion, or SQL renderer variant. Relations, compiled SQL, resolved columns and predicates, and literal tag/property values remain late-bound execution inputs.

## Validation

- full unit suite: 1,376 passed, 4 skipped
- final changed-surface suite: 191 passed, 2 skipped
- renderer tests deliberately fail if typed paths probe format, catalog, runtime capability, or re-plan creation
- Ruff fatal-error and unused-import checks passed; git diff checks passed
- live Databricks validation remains blocked by the invalid configured access token

This remains a draft while dependency PRs and live Databricks validation continue.
