### PR TITLE
ci: keep nightly integration junit artifacts for 21 days

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -341,7 +341,7 @@ jobs:
         with:
           name: uc-cluster-test-logs-${{ matrix.target.pr }}-shard-${{ matrix.shard }}
           path: logs/
-          retention-days: 7
+          retention-days: ${{ matrix.target.pr == 'nightly' && 21 || 7 }}
 
   run-sqlwarehouse-e2e-tests:
     needs:
@@ -442,7 +442,7 @@ jobs:
         with:
           name: sql-endpoint-test-logs-${{ matrix.target.pr }}-shard-${{ matrix.shard }}
           path: logs/
-          retention-days: 7
+          retention-days: ${{ matrix.target.pr == 'nightly' && 21 || 7 }}
 
   run-cluster-e2e-tests:
     needs:
@@ -542,7 +542,7 @@ jobs:
         with:
           name: cluster-test-logs-${{ matrix.target.pr }}-shard-${{ matrix.shard }}
           path: logs/
-          retention-days: 7
+          retention-days: ${{ matrix.target.pr == 'nightly' && 21 || 7 }}
 
   gather-shards:
     # `prepare` is in needs because the matrix below references


### PR DESCRIPTION
<!-- Please review our pull request review process in CONTRIBUTING.md before your proceed. -->

Resolves #

<!---
  Include the number of the issue addressed by this PR above if applicable.

  Example:
    resolves #1234

  Please review our pull request review process in CONTRIBUTING.md before your proceed.
-->

### Description

The weekly Refresh Test Timings job from #1587 has never opened a PR. Every Monday run succeeds but skips because it cannot find 3 distinct-SHA scheduled integration runs with still-downloadable junit artifacts.

Nightly skip-if-unchanged means a quiet week produces few artifact-bearing runs, and 7-day retention expires them before the next Monday. Replaying the last 7 Mondays: 7-day (and even 14-day) retention still miss the 3-run bar some weeks; 21 days covers all of them. `num_runs` stays 3.

This keeps nightly test-log artifacts for 21 days and leaves PR / manual-run artifacts at 7 days.

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
- [ ] [Optional] I have run the `dbt-databricks-pr-ready` project skill for this PR and addressed its merge-readiness feedback