### PR TITLE
test: trim redundant telemetry coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Under the Hood
 
+- Trim redundant POST_PARSE telemetry unit tests and consolidate equivalent cases (test-only, no runtime impact) ([#1664](https://github.com/databricks/dbt-databricks/pull/1664))
 - Remove unused internal logging-event classes (`CredentialLoadError`/`CredentialSaveError`/`CredentialShardEvent`, `PipelineEvent`/`PipelineRefresh`/`PipelineRefreshError`, and the `ConnectionReset`/`ConnectionReuse`/`ConnectionIdleClose`/`ConnectionCreated` connection events) that have had no call sites since the cursor-management and pipeline refactors ([#1547](https://github.com/databricks/dbt-databricks/pull/1547))
 
 ## dbt-databricks 1.12.5 (Sep 1, 2026)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,6 @@
 
 ### Under the Hood
 
-- Trim redundant POST_PARSE telemetry unit tests and consolidate equivalent cases (test-only, no runtime impact) ([#1664](https://github.com/databricks/dbt-databricks/pull/1664))
 - Remove unused internal logging-event classes (`CredentialLoadError`/`CredentialSaveError`/`CredentialShardEvent`, `PipelineEvent`/`PipelineRefresh`/`PipelineRefreshError`, and the `ConnectionReset`/`ConnectionReuse`/`ConnectionIdleClose`/`ConnectionCreated` connection events) that have had no call sites since the cursor-management and pipeline refactors ([#1547](https://github.com/databricks/dbt-databricks/pull/1547))
 
 ## dbt-databricks 1.12.5 (Sep 1, 2026)

--- a/tests/unit/telemetry/test_builder.py
+++ b/tests/unit/telemetry/test_builder.py
@@ -1,5 +1,7 @@
 from types import SimpleNamespace
 
+import pytest
+
 from dbt.adapters.databricks.telemetry import builder, models
 
 
@@ -26,112 +28,98 @@ def _node(resource_type, package_name="root", test_metadata=None):
 
 
 class TestClassifyComputeType:
-    def test_sql_warehouse(self):
-        assert builder.classify_compute_type("/sql/1.0/warehouses/a") == (
-            models.ComputeType.SQL_WAREHOUSE
-        )
-
-    def test_endpoints_form_is_warehouse(self):
-        assert builder.classify_compute_type("/sql/1.0/endpoints/a") == (
-            models.ComputeType.SQL_WAREHOUSE
-        )
-
-    def test_all_purpose_cluster(self):
-        assert builder.classify_compute_type("/sql/protocolv1/o/1/2") == (
-            models.ComputeType.ALL_PURPOSE_CLUSTER
-        )
-
-    def test_query_string_ignored(self):
-        assert builder.classify_compute_type("/sql/1.0/warehouses/a?o=9") == (
-            models.ComputeType.SQL_WAREHOUSE
-        )
-
-    def test_unknown_form_is_other(self):
-        assert builder.classify_compute_type("/unknown") == models.ComputeType.OTHER
-
-    def test_missing_is_unspecified(self):
-        assert builder.classify_compute_type(None) == models.ComputeType.TYPE_UNSPECIFIED
-
-    def test_optional_leading_slash(self):
-        assert builder.classify_compute_type("sql/1.0/warehouses/a") == (
-            models.ComputeType.SQL_WAREHOUSE
-        )
-        assert builder.classify_compute_type("sql/protocolv1/o/1/2") == (
-            models.ComputeType.ALL_PURPOSE_CLUSTER
-        )
+    @pytest.mark.parametrize(
+        ("http_path", "expected"),
+        [
+            (
+                "/sql/1.0/warehouses/a",
+                models.ComputeType.SQL_WAREHOUSE,
+            ),
+            (
+                "/sql/1.0/endpoints/a",
+                models.ComputeType.SQL_WAREHOUSE,
+            ),
+            (
+                "/sql/protocolv1/o/1/2",
+                models.ComputeType.ALL_PURPOSE_CLUSTER,
+            ),
+            ("/unknown", models.ComputeType.OTHER),
+            (None, models.ComputeType.TYPE_UNSPECIFIED),
+            ("sql/1.0/warehouses/a", models.ComputeType.SQL_WAREHOUSE),
+            ("sql/protocolv1/o/1/2", models.ComputeType.ALL_PURPOSE_CLUSTER),
+        ],
+    )
+    def test_classifies_compute_type(self, http_path, expected):
+        assert builder.classify_compute_type(http_path) == expected
 
 
 class TestClassifyAuthFamily:
-    def test_token_is_pat(self):
-        assert builder.classify_auth_family(_creds(token="dapi")) == models.AuthFamily.PAT
-
-    def test_azure_service_principal(self):
-        assert (
-            builder.classify_auth_family(_creds(azure_client_id="a", azure_client_secret="b"))
-            == models.AuthFamily.AZURE_SERVICE_PRINCIPAL
-        )
-
-    def test_no_secret_is_u2m(self):
-        assert builder.classify_auth_family(_creds(auth_type="oauth")) == (
-            models.AuthFamily.OAUTH_U2M
-        )
-
-    def test_client_secret_is_ambiguous(self):
-        assert builder.classify_auth_family(_creds(client_id="c", client_secret="s")) == (
-            models.AuthFamily.LEGACY_CLIENT_SECRET_AMBIGUOUS
-        )
+    @pytest.mark.parametrize(
+        ("credentials", "expected"),
+        [
+            ({"token": "dapi"}, models.AuthFamily.PAT),
+            (
+                {"azure_client_id": "a", "azure_client_secret": "b"},
+                models.AuthFamily.AZURE_SERVICE_PRINCIPAL,
+            ),
+            ({"auth_type": "oauth"}, models.AuthFamily.OAUTH_U2M),
+            (
+                {"client_id": "c", "client_secret": "s"},
+                models.AuthFamily.LEGACY_CLIENT_SECRET_AMBIGUOUS,
+            ),
+        ],
+    )
+    def test_classifies_auth_family(self, credentials, expected):
+        assert builder.classify_auth_family(_creds(**credentials)) == expected
 
 
 class TestClassifyCommand:
-    def test_known(self):
-        assert builder.classify_command("run") == models.DbtCommand.RUN
-        assert builder.classify_command("build") == models.DbtCommand.BUILD
-
-    def test_normalized_forms(self):
-        assert builder.classify_command("run-operation") == models.DbtCommand.RUN_OPERATION
-        assert builder.classify_command("source freshness") == models.DbtCommand.SOURCE
-        assert builder.classify_command("docs generate") == models.DbtCommand.DOCS
-
-    def test_unknown_is_other(self):
-        assert builder.classify_command("parse") == models.DbtCommand.OTHER
-
-    def test_missing_is_unspecified(self):
-        assert builder.classify_command(None) == models.DbtCommand.TYPE_UNSPECIFIED
+    @pytest.mark.parametrize(
+        ("command", "expected"),
+        [
+            ("run", models.DbtCommand.RUN),
+            ("build", models.DbtCommand.BUILD),
+            ("run-operation", models.DbtCommand.RUN_OPERATION),
+            ("source freshness", models.DbtCommand.SOURCE),
+            ("docs generate", models.DbtCommand.DOCS),
+            ("parse", models.DbtCommand.OTHER),
+            (None, models.DbtCommand.TYPE_UNSPECIFIED),
+        ],
+    )
+    def test_classifies_command(self, command, expected):
+        assert builder.classify_command(command) == expected
 
 
 class TestClassifyWarnErrorPolicy:
-    def test_disabled(self):
-        assert builder.classify_warn_error_policy(None, None) == (
-            models.WarnErrorPolicy.WARN_ERROR_DISABLED
-        )
-
-    def test_all(self):
-        assert builder.classify_warn_error_policy(True, None) == (
-            models.WarnErrorPolicy.WARN_ERROR_ALL
-        )
-
-    def test_error_all_without_overrides_is_all(self):
-        options = SimpleNamespace(error="all", warn=[], silence=[])
-        assert builder.classify_warn_error_policy(False, options) == (
-            models.WarnErrorPolicy.WARN_ERROR_ALL
-        )
-
-    def test_error_all_with_named_override_is_custom(self):
-        options = SimpleNamespace(error="all", warn=["SomeWarning"], silence=[])
-        assert builder.classify_warn_error_policy(False, options) == (
-            models.WarnErrorPolicy.WARN_ERROR_CUSTOM_POLICY
-        )
-
-    def test_legacy_warn_error_takes_precedence(self):
-        options = SimpleNamespace(error=[], warn=[], silence=["SomeWarning"])
-        assert builder.classify_warn_error_policy(True, options) == (
-            models.WarnErrorPolicy.WARN_ERROR_ALL
-        )
-
-    def test_custom_policy(self):
-        assert builder.classify_warn_error_policy(False, {"include": ["X"]}) == (
-            models.WarnErrorPolicy.WARN_ERROR_CUSTOM_POLICY
-        )
+    @pytest.mark.parametrize(
+        ("warn_error", "options", "expected"),
+        [
+            (None, None, models.WarnErrorPolicy.WARN_ERROR_DISABLED),
+            (True, None, models.WarnErrorPolicy.WARN_ERROR_ALL),
+            (
+                False,
+                SimpleNamespace(error="all", warn=[], silence=[]),
+                models.WarnErrorPolicy.WARN_ERROR_ALL,
+            ),
+            (
+                False,
+                SimpleNamespace(error="all", warn=["SomeWarning"], silence=[]),
+                models.WarnErrorPolicy.WARN_ERROR_CUSTOM_POLICY,
+            ),
+            (
+                True,
+                SimpleNamespace(error=[], warn=[], silence=["SomeWarning"]),
+                models.WarnErrorPolicy.WARN_ERROR_ALL,
+            ),
+            (
+                False,
+                {"include": ["X"]},
+                models.WarnErrorPolicy.WARN_ERROR_CUSTOM_POLICY,
+            ),
+        ],
+    )
+    def test_classifies_warn_error_policy(self, warn_error, options, expected):
+        assert builder.classify_warn_error_policy(warn_error, options) == expected
 
 
 class TestBuildConnectionConfig:

--- a/tests/unit/telemetry/test_client.py
+++ b/tests/unit/telemetry/test_client.py
@@ -1,5 +1,7 @@
 from types import SimpleNamespace
 
+import pytest
+
 from dbt.adapters.databricks.telemetry import client
 
 
@@ -9,7 +11,11 @@ def _ack(**overrides):
     return SimpleNamespace(status_code=200, json=lambda: payload)
 
 
-def test_numeric_workspace_id_is_sent_in_header(monkeypatch):
+@pytest.mark.parametrize(
+    ("workspace_id", "expected_header"),
+    [("42", "42"), ("customer-name", None)],
+)
+def test_workspace_id_header(monkeypatch, workspace_id, expected_header):
     captured = {}
 
     def post(url, json=None, headers=None, auth=None, timeout=None):
@@ -18,18 +24,8 @@ def test_numeric_workspace_id_is_sent_in_header(monkeypatch):
 
     monkeypatch.setattr(client.requests, "post", post)
 
-    assert client.send("https://h", {}, workspace_id="42") is True
-    assert captured["headers"]["x-databricks-org-id"] == "42"
-
-
-def test_non_numeric_workspace_id_is_omitted_from_header(monkeypatch):
-    captured = {}
-
-    def post(url, json=None, headers=None, auth=None, timeout=None):
-        captured["headers"] = headers
-        return _ack()
-
-    monkeypatch.setattr(client.requests, "post", post)
-
-    assert client.send("https://h", {}, workspace_id="customer-name") is True
-    assert "x-databricks-org-id" not in captured["headers"]
+    assert client.send("https://h", {}, workspace_id=workspace_id) is True
+    if expected_header is None:
+        assert "x-databricks-org-id" not in captured["headers"]
+    else:
+        assert captured["headers"]["x-databricks-org-id"] == expected_header

--- a/tests/unit/telemetry/test_coordinator.py
+++ b/tests/unit/telemetry/test_coordinator.py
@@ -1,6 +1,8 @@
 import json
 import threading
 
+import pytest
+
 from dbt.adapters.databricks.telemetry import coordinator as coord_mod
 from dbt.adapters.databricks.telemetry import models
 
@@ -40,29 +42,23 @@ class TestTransportOpacity:
         assert "redacted" in repr(t)
         assert "Bearer" not in repr(t)
 
-    def test_not_a_dataclass_and_no_dict(self):
-        t = _transport()
-        assert not hasattr(t, "__dict__")
-
 
 class TestSendOrdering:
-    def test_parse_then_transport_sends_once(self, monkeypatch):
+    @pytest.mark.parametrize("post_parse_first", [True, False])
+    def test_parse_and_transport_send_once(self, monkeypatch, post_parse_first):
         capture = _Capture()
         monkeypatch.setattr(coord_mod.client, "send", capture)
         c = coord_mod.Coordinator()
-        c.set_post_parse("inv-1", _log())
-        assert capture.calls == []
-        c.set_transport("inv-1", _transport())
-        c.flush()
-        assert len(capture.calls) == 1
 
-    def test_transport_then_parse_sends_once(self, monkeypatch):
-        capture = _Capture()
-        monkeypatch.setattr(coord_mod.client, "send", capture)
-        c = coord_mod.Coordinator()
-        c.set_transport("inv-1", _transport())
-        assert capture.calls == []
-        c.set_post_parse("inv-1", _log())
+        if post_parse_first:
+            c.set_post_parse("inv-1", _log())
+            assert capture.calls == []
+            c.set_transport("inv-1", _transport())
+        else:
+            c.set_transport("inv-1", _transport())
+            assert capture.calls == []
+            c.set_post_parse("inv-1", _log())
+
         c.flush()
         assert len(capture.calls) == 1
 
@@ -165,17 +161,3 @@ class TestIsolationAndClose:
         pending[0].target(*pending[0].args)
 
         assert len(capture.calls) == 1
-
-    def test_mark_start_prunes_closed_invocations(self):
-        c = coord_mod.Coordinator()
-        c.mark_start("inv-1")
-        c.close("inv-1")
-        c.mark_start("inv-2")
-
-        assert "inv-1" not in c._states
-        assert "inv-2" in c._states
-        assert c.needs_post_parse("inv-2") is True
-
-        c.close("inv-1")
-        assert c._states["inv-1"].closed
-        assert not c._states["inv-2"].closed

--- a/tests/unit/telemetry/test_encoder.py
+++ b/tests/unit/telemetry/test_encoder.py
@@ -1,5 +1,7 @@
 import json
 
+import pytest
+
 from dbt.adapters.databricks.telemetry import encoder, models
 
 
@@ -23,10 +25,6 @@ def _log():
 
 
 class TestEncoder:
-    def test_uses_dedicated_entry_field(self):
-        fe = json.loads(encoder.encode_request(_log(), "evt-1")["protoLogs"][0])
-        assert "dbt_databricks_telemetry_log" in fe["entry"]
-
     def test_post_parse_contains_every_proto_field(self):
         entry = json.loads(encoder.encode_request(_log(), "evt-1")["protoLogs"][0])["entry"][
             "dbt_databricks_telemetry_log"
@@ -87,24 +85,15 @@ class TestEncoder:
             "unit_test_count",
         }
 
-    def test_numeric_workspace_id_is_coerced(self):
-        fe = json.loads(encoder.encode_request(_log(), "e", workspace_id="42")["protoLogs"][0])
-        assert fe["workspace_id"] == 42
-
-    def test_non_numeric_workspace_id_is_omitted(self):
-        fe = json.loads(encoder.encode_request(_log(), "e", workspace_id="abc")["protoLogs"][0])
-        assert "workspace_id" not in fe
-
-    def test_post_parse_omits_unset_phase(self):
-        entry = json.loads(encoder.encode_request(_log(), "e")["protoLogs"][0])["entry"][
-            "dbt_databricks_telemetry_log"
-        ]
-        assert "post_parse" in entry
-        assert "post_run" not in entry
-
-    def test_timestamp_millis_uses_event_time_not_upload_time(self, monkeypatch):
-        monkeypatch.setattr(encoder.time, "time", lambda: 40.0)
-        body = encoder.encode_request(_log(), "e", event_timestamp_millis=10_000)
-        fe = json.loads(body["protoLogs"][0])
-        assert fe["context"]["client_context"]["timestamp_millis"] == 10_000
-        assert body["uploadTime"] == 40_000
+    @pytest.mark.parametrize(
+        ("workspace_id", "expected_workspace_id"),
+        [("42", 42), ("abc", None)],
+    )
+    def test_workspace_id_is_coerced_or_omitted(self, workspace_id, expected_workspace_id):
+        fe = json.loads(
+            encoder.encode_request(_log(), "e", workspace_id=workspace_id)["protoLogs"][0]
+        )
+        if expected_workspace_id is None:
+            assert "workspace_id" not in fe
+        else:
+            assert fe["workspace_id"] == expected_workspace_id

--- a/tests/unit/telemetry/test_hooks.py
+++ b/tests/unit/telemetry/test_hooks.py
@@ -1,6 +1,8 @@
 from types import SimpleNamespace
 from unittest.mock import Mock
 
+import pytest
+
 from dbt.adapters.databricks.telemetry import hooks
 from dbt.adapters.databricks.telemetry.coordinator import Coordinator
 
@@ -77,7 +79,8 @@ def test_stale_cleanup_does_not_tombstone_next_invocation(monkeypatch):
     assert "inv-1" not in coord._states
 
 
-def test_kernel_u2m_warns_when_telemetry_enabled(monkeypatch):
+@pytest.mark.parametrize("reusable_transport", [False, True])
+def test_kernel_warning_depends_on_transport(monkeypatch, reusable_transport):
     coord = Mock()
     log = Mock()
     monkeypatch.setattr(hooks, "coordinator", lambda: coord)
@@ -85,56 +88,39 @@ def test_kernel_u2m_warns_when_telemetry_enabled(monkeypatch):
     monkeypatch.setattr(hooks, "_current_invocation_id", lambda: "inv-1")
     monkeypatch.setattr(hooks, "DatabricksCredentials", object)
     monkeypatch.setattr(hooks, "is_enabled_for_invocation", lambda _: True)
-    monkeypatch.setattr(hooks, "has_reusable_transport", lambda _: False)
+    monkeypatch.setattr(hooks, "has_reusable_transport", lambda _: reusable_transport)
     adapter = SimpleNamespace(config=SimpleNamespace(credentials=object()))
 
     hooks.on_adapter_init(adapter)
 
-    log.warning.assert_called_once()
-    assert "kernel" in log.warning.call_args.args[0].lower()
+    if reusable_transport:
+        log.warning.assert_not_called()
+    else:
+        log.warning.assert_called_once()
+        assert "kernel" in log.warning.call_args.args[0].lower()
     coord.mark_start.assert_called_once_with("inv-1")
 
 
-def test_reusable_transport_does_not_warn_on_init(monkeypatch):
-    coord = Mock()
-    log = Mock()
-    monkeypatch.setattr(hooks, "coordinator", lambda: coord)
-    monkeypatch.setattr(hooks, "logger", log)
-    monkeypatch.setattr(hooks, "_current_invocation_id", lambda: "inv-1")
-    monkeypatch.setattr(hooks, "DatabricksCredentials", object)
-    monkeypatch.setattr(hooks, "is_enabled_for_invocation", lambda _: True)
-    monkeypatch.setattr(hooks, "has_reusable_transport", lambda _: True)
-    adapter = SimpleNamespace(config=SimpleNamespace(credentials=object()))
-
-    hooks.on_adapter_init(adapter)
-
-    log.warning.assert_not_called()
-    coord.mark_start.assert_called_once_with("inv-1")
-
-
-def test_connection_open_uses_opened_path_workspace_id(monkeypatch):
+@pytest.mark.parametrize(
+    ("manager_workspace_id", "opened_path", "expected_workspace_id"),
+    [
+        (None, "/sql/1.0/warehouses/named?o=42", "42"),
+        ("7", "/sql/1.0/warehouses/default", "7"),
+    ],
+)
+def test_connection_open_sets_workspace_id(
+    monkeypatch, manager_workspace_id, opened_path, expected_workspace_id
+):
     coord = Mock()
     monkeypatch.setattr(hooks, "coordinator", lambda: coord)
     monkeypatch.setattr(hooks, "_current_invocation_id", lambda: "inv-1")
     monkeypatch.setattr(hooks, "is_enabled_for_invocation", lambda _: True)
     monkeypatch.setattr(hooks, "has_reusable_transport", lambda _: True)
-    manager = SimpleNamespace(host="https://h", header_factory=lambda: {}, workspace_id=None)
+    manager = SimpleNamespace(
+        host="https://h", header_factory=lambda: {}, workspace_id=manager_workspace_id
+    )
 
-    hooks.on_connection_open(SimpleNamespace(), manager, "/sql/1.0/warehouses/named?o=42")
+    hooks.on_connection_open(SimpleNamespace(), manager, opened_path)
 
     transport = coord.set_transport.call_args.args[1]
-    assert transport.workspace_id == "42"
-
-
-def test_connection_open_falls_back_to_manager_workspace_id(monkeypatch):
-    coord = Mock()
-    monkeypatch.setattr(hooks, "coordinator", lambda: coord)
-    monkeypatch.setattr(hooks, "_current_invocation_id", lambda: "inv-1")
-    monkeypatch.setattr(hooks, "is_enabled_for_invocation", lambda _: True)
-    monkeypatch.setattr(hooks, "has_reusable_transport", lambda _: True)
-    manager = SimpleNamespace(host="https://h", header_factory=lambda: {}, workspace_id="7")
-
-    hooks.on_connection_open(SimpleNamespace(), manager, "/sql/1.0/warehouses/default")
-
-    transport = coord.set_transport.call_args.args[1]
-    assert transport.workspace_id == "7"
+    assert transport.workspace_id == expected_workspace_id


### PR DESCRIPTION
### Description

Follow-up cleanup for merged #1647. Removes redundant or misleading telemetry unit tests and consolidates equivalent cases into parameterized tests.

This PR intentionally does not add a changelog entry because it is test-only and has no runtime impact.

### Verification

- `hatch run pytest tests/unit/telemetry -q` — 58 passed; 5 pre-existing Pydantic deprecation warnings
- `hatch run pre-commit run --all-files` — passed

### Checklist

- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] Changelog entry intentionally omitted because this PR is test-only and has no runtime impact.
- [ ] [Optional] I have run the `dbt-databricks-pr-ready` project skill and addressed its merge-readiness feedback