### PR TITLE
feat: support env-oidc and file-oidc auth types for workload identity federation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Features
 
-- Support `auth_type: env-oidc` and `auth_type: file-oidc` for authenticating via workload identity federation ([#XXXX](https://github.com/databricks/dbt-databricks/pull/XXXX))
+- Support `auth_type: env-oidc` and `auth_type: file-oidc` for authenticating via workload identity federation, with a new `oidc_token_filepath` profile config for the latter ([#XXXX](https://github.com/databricks/dbt-databricks/pull/XXXX))
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Features
 
-- Support `auth_type: env-oidc` and `auth_type: file-oidc` for authenticating via workload identity federation, with a new `oidc_token_filepath` profile config for the latter ([#XXXX](https://github.com/databricks/dbt-databricks/pull/XXXX))
+- Support `auth_type: env-oidc` and `auth_type: file-oidc` for authenticating via workload identity federation, with a new `oidc_token_filepath` profile config for the latter ([#1666](https://github.com/databricks/dbt-databricks/pull/1666))
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## dbt-databricks 1.12.5 (TBD)
 
+### Features
+
+- Support `auth_type: env-oidc` and `auth_type: file-oidc` for authenticating via workload identity federation ([#XXXX](https://github.com/databricks/dbt-databricks/pull/XXXX))
+
 ### Fixes
 
 - Replace an existing table or view with a metric view using backup-and-create instead of `CREATE OR REPLACE VIEW ... WITH METRICS` ([#1640](https://github.com/databricks/dbt-databricks/pull/1640) resolves [#1639](https://github.com/databricks/dbt-databricks/issues/1639))

--- a/dbt/adapters/databricks/credentials.py
+++ b/dbt/adapters/databricks/credentials.py
@@ -52,6 +52,9 @@ class DatabricksCredentials(Credentials):
     connection_parameters: Optional[dict[str, Any]] = None
     auth_type: Optional[str] = None
 
+    # Path of the file holding the OIDC ID token, for `auth_type: file-oidc`.
+    oidc_token_filepath: Optional[str] = None
+
     # Named compute resources specified in the profile. Used for
     # creating a connection when a model specifies a compute resource.
     compute: Optional[dict[str, Any]] = None
@@ -144,6 +147,14 @@ class DatabricksCredentials(Credentials):
             raise DbtConfigError(
                 "The config `auth_type` must be one of `oauth`, `env-oidc`, or `file-oidc` "
                 "when not using an access token"
+            )
+
+        # Without an explicit client_id the SDK is handed the `dbt-databricks`
+        # public client, which carries no federation policy, and fails with a 401.
+        if not self.token and self.auth_type in ("env-oidc", "file-oidc") and not self.client_id:
+            raise DbtConfigError(
+                "The config 'client_id' is required to connect to Databricks "
+                f"with 'auth_type: {self.auth_type}'"
             )
 
         if not self.client_id and self.client_secret:
@@ -282,6 +293,7 @@ class DatabricksCredentialManager(DataClassDictMixin):
     oauth_scopes: list[str] = field(default_factory=lambda: SCOPES)
     token: Optional[str] = None
     auth_type: Optional[str] = None
+    oidc_token_filepath: Optional[str] = None
     workspace_id: Optional[str] = None
 
     @classmethod
@@ -296,6 +308,7 @@ class DatabricksCredentialManager(DataClassDictMixin):
             oauth_redirect_url=credentials.oauth_redirect_url or REDIRECT_URL,
             oauth_scopes=credentials.oauth_scopes or SCOPES,
             auth_type=credentials.auth_type,
+            oidc_token_filepath=credentials.oidc_token_filepath,
             workspace_id=extract_workspace_id(credentials.http_path),
         )
 
@@ -325,13 +338,14 @@ class DatabricksCredentialManager(DataClassDictMixin):
         )
 
     def authenticate_with_oidc(self) -> Config:
-        return Config(
-            **self._config_kwargs(
-                host=self.host,
-                client_id=self.client_id,
-                auth_type=self.auth_type,
-            )
+        kwargs = self._config_kwargs(
+            host=self.host,
+            client_id=self.client_id,
+            auth_type=self.auth_type,
         )
+        if self.oidc_token_filepath:
+            kwargs["oidc_token_filepath"] = self.oidc_token_filepath
+        return Config(**kwargs)
 
     def authenticate_with_external_browser(self) -> Config:
         return Config(

--- a/dbt/adapters/databricks/credentials.py
+++ b/dbt/adapters/databricks/credentials.py
@@ -140,9 +140,10 @@ class DatabricksCredentials(Credentials):
         for key in ["host", "http_path"]:
             if not getattr(self, key):
                 raise DbtConfigError(f"The config '{key}' is required to connect to Databricks")
-        if not self.token and self.auth_type != "oauth":
+        if not self.token and self.auth_type not in ("oauth", "env-oidc", "file-oidc"):
             raise DbtConfigError(
-                "The config `auth_type: oauth` is required when not using access token"
+                "The config `auth_type` must be one of `oauth`, `env-oidc`, or `file-oidc` "
+                "when not using an access token"
             )
 
         if not self.client_id and self.client_secret:
@@ -323,6 +324,15 @@ class DatabricksCredentialManager(DataClassDictMixin):
             )
         )
 
+    def authenticate_with_oidc(self) -> Config:
+        return Config(
+            **self._config_kwargs(
+                host=self.host,
+                client_id=self.client_id,
+                auth_type=self.auth_type,
+            )
+        )
+
     def authenticate_with_external_browser(self) -> Config:
         return Config(
             **self._config_kwargs(
@@ -373,6 +383,8 @@ class DatabricksCredentialManager(DataClassDictMixin):
 
             if self.token:
                 self._config = self.authenticate_with_pat()
+            elif self.auth_type in ("env-oidc", "file-oidc"):
+                self._config = self.authenticate_with_oidc()
             elif self.azure_client_id and self.azure_client_secret:
                 self._config = self.authenticate_with_azure_client_secret()
             elif not self.client_secret:

--- a/dbt/adapters/databricks/handle.py
+++ b/dbt/adapters/databricks/handle.py
@@ -462,6 +462,17 @@ class SqlUtils:
             args["oauth_scopes"] = creds_manager.oauth_scopes
             return
 
+        # OIDC federation has no kernel equivalent; reject on the raw auth_type
+        # before falling into the oauth-m2m check below, which would otherwise
+        # resolve `.config` and trigger the SDK's OIDC token exchange here.
+        if creds.auth_type in ("env-oidc", "file-oidc"):
+            raise DbtConfigError(
+                "use_kernel=True supports only personal access tokens and Databricks "
+                "OAuth (M2M/U2M); the configured authentication (auth_type: "
+                f"{creds.auth_type}) is not supported by the kernel backend. Remove "
+                "use_kernel to use the default backend."
+            )
+
         # Databricks OAuth M2M: forward OAuth creds so the kernel owns refresh. The
         # resolved auth_type distinguishes genuine Databricks OAuth from an Azure SP
         # supplied through the client_id/client_secret fields.

--- a/dbt/adapters/databricks/handle.py
+++ b/dbt/adapters/databricks/handle.py
@@ -439,9 +439,10 @@ class SqlUtils:
         PAT, Databricks OAuth M2M, and OAuth U2M — we forward the raw credentials it
         understands so the connector owns the token lifecycle and refresh.
 
-        The kernel has no Azure-AD flow, so an Azure service principal cannot connect
-        through it; any auth other than the three above is rejected here with a clear
-        error directing the user to the default backend.
+        The kernel has no Azure-AD or OIDC federation flow, so neither an Azure
+        service principal nor a federated identity can connect through it; any auth
+        other than the three above is rejected here with a clear error directing the
+        user to the default backend.
         """
         # PAT: forward the token directly.
         if creds_manager.token:
@@ -462,21 +463,15 @@ class SqlUtils:
             args["oauth_scopes"] = creds_manager.oauth_scopes
             return
 
-        # OIDC federation has no kernel equivalent; reject on the raw auth_type
-        # before falling into the oauth-m2m check below, which would otherwise
-        # resolve `.config` and trigger the SDK's OIDC token exchange here.
-        if creds.auth_type in ("env-oidc", "file-oidc"):
-            raise DbtConfigError(
-                "use_kernel=True supports only personal access tokens and Databricks "
-                "OAuth (M2M/U2M); the configured authentication (auth_type: "
-                f"{creds.auth_type}) is not supported by the kernel backend. Remove "
-                "use_kernel to use the default backend."
-            )
-
         # Databricks OAuth M2M: forward OAuth creds so the kernel owns refresh. The
         # resolved auth_type distinguishes genuine Databricks OAuth from an Azure SP
-        # supplied through the client_id/client_secret fields.
-        if not creds_manager.azure_client_secret and creds_manager.config.auth_type == "oauth-m2m":
+        # in the client_id/client_secret fields. The OIDC term must stay first:
+        # resolving `.config` for a federated auth_type triggers a token exchange.
+        if (
+            creds.auth_type not in ("env-oidc", "file-oidc")
+            and not creds_manager.azure_client_secret
+            and creds_manager.config.auth_type == "oauth-m2m"
+        ):
             args["oauth_client_id"] = creds_manager.client_id
             args["oauth_client_secret"] = creds_manager.client_secret
             args["oauth_scopes"] = creds_manager.oauth_scopes
@@ -485,6 +480,6 @@ class SqlUtils:
         raise DbtConfigError(
             "use_kernel=True supports only personal access tokens and Databricks "
             "OAuth (M2M/U2M); the configured authentication (e.g. an Azure service "
-            "principal) is not supported by the kernel backend. Remove use_kernel to "
-            "use the default backend."
+            "principal, or OIDC workload identity federation) is not supported by the "
+            "kernel backend. Remove use_kernel to use the default backend."
         )

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -52,6 +52,11 @@ class TestParseTimeIsOffline:
             )
             mock_config.assert_not_called()
 
+    def test_env_oidc_credentials_init_does_not_call_config(self):
+        with mock.patch("dbt.adapters.databricks.credentials.Config") as mock_config:
+            DatabricksCredentials(client_id="cid", auth_type="env-oidc", **_COMMON_KWARGS)
+            mock_config.assert_not_called()
+
 
 class TestEnsureConfigTriggersTheRightAuth:
     """Connect-time counterpart to TestParseTimeIsOffline: when something
@@ -123,6 +128,34 @@ class TestEnsureConfigTriggersTheRightAuth:
                 azure_client_secret="plain-secret",
                 auth_type="azure-client-secret",
             )
+
+    def test_env_oidc_uses_oidc_auth(self):
+        creds = DatabricksCredentials(client_id="cid", auth_type="env-oidc", **_COMMON_KWARGS)
+        with mock.patch("dbt.adapters.databricks.credentials.Config") as mock_config:
+            creds.authenticate().config
+            mock_config.assert_called_once_with(
+                host=_COMMON_KWARGS["host"],
+                client_id="cid",
+                auth_type="env-oidc",
+            )
+
+    def test_file_oidc_uses_oidc_auth(self):
+        creds = DatabricksCredentials(client_id="cid", auth_type="file-oidc", **_COMMON_KWARGS)
+        with mock.patch("dbt.adapters.databricks.credentials.Config") as mock_config:
+            creds.authenticate().config
+            mock_config.assert_called_once_with(
+                host=_COMMON_KWARGS["host"],
+                client_id="cid",
+                auth_type="file-oidc",
+            )
+
+    def test_token_takes_precedence_over_oidc_auth_type(self):
+        creds = DatabricksCredentials(
+            token="foo", client_id="cid", auth_type="env-oidc", **_COMMON_KWARGS
+        )
+        with mock.patch("dbt.adapters.databricks.credentials.Config") as mock_config:
+            creds.authenticate().config
+            mock_config.assert_called_once_with(host=_COMMON_KWARGS["host"], token="foo")
 
     def test_falls_back_to_second_method_when_first_raises(self):
         creds = DatabricksCredentials(

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -3,6 +3,7 @@ from threading import Barrier, Lock
 from unittest import mock
 
 import pytest
+from dbt_common.exceptions import DbtConfigError
 
 from dbt.adapters.databricks.credentials import (
     DatabricksCredentialManager,
@@ -56,6 +57,34 @@ class TestParseTimeIsOffline:
         with mock.patch("dbt.adapters.databricks.credentials.Config") as mock_config:
             DatabricksCredentials(client_id="cid", auth_type="env-oidc", **_COMMON_KWARGS)
             mock_config.assert_not_called()
+
+
+class TestValidateCreds:
+    """`validate_creds` runs at connect time and is the only place that rejects
+    an unusable combination of profile fields before the SDK is involved."""
+
+    def test_oidc_auth_types_need_no_token(self):
+        for auth_type in ("env-oidc", "file-oidc"):
+            creds = DatabricksCredentials(client_id="cid", auth_type=auth_type, **_COMMON_KWARGS)
+            creds.validate_creds()
+
+    def test_unknown_auth_type_without_token_raises(self):
+        creds = DatabricksCredentials(
+            client_id="cid", auth_type="not-a-real-auth-type", **_COMMON_KWARGS
+        )
+        with pytest.raises(DbtConfigError, match="must be one of"):
+            creds.validate_creds()
+
+    @pytest.mark.parametrize("auth_type", ["env-oidc", "file-oidc"])
+    def test_oidc_without_client_id_raises(self, auth_type):
+        creds = DatabricksCredentials(auth_type=auth_type, **_COMMON_KWARGS)
+        with pytest.raises(DbtConfigError, match="'client_id' is required"):
+            creds.validate_creds()
+
+    @pytest.mark.parametrize("auth_type", ["env-oidc", "file-oidc"])
+    def test_token_removes_the_client_id_requirement(self, auth_type):
+        creds = DatabricksCredentials(token="foo", auth_type=auth_type, **_COMMON_KWARGS)
+        creds.validate_creds()
 
 
 class TestEnsureConfigTriggersTheRightAuth:
@@ -147,6 +176,22 @@ class TestEnsureConfigTriggersTheRightAuth:
                 host=_COMMON_KWARGS["host"],
                 client_id="cid",
                 auth_type="file-oidc",
+            )
+
+    def test_file_oidc_forwards_token_filepath(self):
+        creds = DatabricksCredentials(
+            client_id="cid",
+            auth_type="file-oidc",
+            oidc_token_filepath="/var/run/secrets/token",
+            **_COMMON_KWARGS,
+        )
+        with mock.patch("dbt.adapters.databricks.credentials.Config") as mock_config:
+            creds.authenticate().config
+            mock_config.assert_called_once_with(
+                host=_COMMON_KWARGS["host"],
+                client_id="cid",
+                auth_type="file-oidc",
+                oidc_token_filepath="/var/run/secrets/token",
             )
 
     def test_token_takes_precedence_over_oidc_auth_type(self):

--- a/tests/unit/test_handle.py
+++ b/tests/unit/test_handle.py
@@ -320,6 +320,18 @@ class TestSqlUtils:
             with pytest.raises(DbtConfigError, match="use_kernel"):
                 SqlUtils.prepare_connection_arguments(creds, manager, _KERNEL_HTTP_PATH, {})
 
+    @pytest.mark.parametrize("auth_type", ["env-oidc", "file-oidc"])
+    def test_prepare_connection_arguments__kernel_oidc_raises(self, auth_type):
+        """The kernel has no OIDC flow. Rejected on the raw auth_type before the
+        oauth-m2m check, which would otherwise resolve `.config` and trigger the
+        SDK's OIDC token exchange here."""
+        with pytest.raises(DbtConfigError, match="use_kernel"):
+            _prepare_connection_args_without_config_auth(
+                client_id="cid",
+                auth_type=auth_type,
+                connection_parameters={"use_kernel": True},
+            )
+
     def test_prepare_connection_arguments__kernel_u2m_explicit_client_id(self):
         """use_kernel with OAuth U2M and an explicit client_id forwards that
         client_id and translates dbt's auth_type='oauth' to the kernel's


### PR DESCRIPTION
### Description

Adds `auth_type: env-oidc` and `auth_type: file-oidc`, so the adapter can authenticate through Databricks workload identity federation instead of a stored secret. Both are existing credential strategies in `databricks-sdk`; the adapter previously accepted only `oauth` when no `token` was set, so a federated identity could not be configured at all.

`file-oidc` needs the path of the file holding the OIDC ID token. A new `oidc_token_filepath` profile config supplies it, and it is forwarded to the SDK only when set, so `DATABRICKS_OIDC_TOKEN_FILE` keeps working when the profile omits it.

`client_id` is required for both new auth types. Without it the credential manager would hand the SDK its `dbt-databricks` public client, which carries no federation policy, so `dbt parse` would pass and the first connection would fail with an opaque 401. `validate_creds` now rejects that combination up front.

Example profile:

```yaml
my_project:
  target: prod
  outputs:
    prod:
      type: databricks
      host: my-workspace.cloud.databricks.com
      http_path: /sql/1.0/warehouses/abc123
      catalog: main
      schema: default
      auth_type: env-oidc
      client_id: "{{ env_var('DATABRICKS_CLIENT_ID') }}"
```

The `use_kernel=True` connector backend has no OIDC flow, so the two new auth types are rejected there with the existing kernel error. That check reads the raw `auth_type` and short-circuits before `creds_manager.config` resolves, so preparing connection arguments never triggers a token exchange.

Both strategies exist in `databricks-sdk` 0.68.0, the current lower bound, so no dependency change is needed.

### Verification

Run in a CI pipeline against a live Unity Catalog workspace with a real GitLab-to-Databricks federation policy, using this branch in place of the released adapter:

- `dbt debug` with `auth_type: env-oidc` and the ID token in `DATABRICKS_OIDC_TOKEN`: `Connection test: OK connection ok`.
- `dbt debug` with `auth_type: file-oidc` and `oidc_token_filepath` pointing at the token file: `Connection test: OK connection ok`.
- `dbt compile` over a ~1000 model project on the same `env-oidc` target, which runs introspective queries, completed without an auth error.

Environment: `databricks-sdk` 0.77.0, `databricks-sql-connector` 4.1.5, dbt 1.11.6. Before this branch, the same pipeline had to pre-mint a PAT with the SDK and pass it to dbt through the `token:` field, because dbt could not consume the federated identity directly.

### Scope note

The accepted set is `("oauth", "env-oidc", "file-oidc")`. Other SDK strategies such as `github-oidc` and `azure-devops-oidc` are still rejected, and `token_audience` is not exposed as a profile config. Happy to widen either in this PR if you prefer.

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
- [ ] [Optional] I have run the `dbt-databricks-pr-ready` project skill for this PR and addressed its merge-readiness feedback
