### PR TITLE
perf: emit only changed databricks_tags keys in ALTER SET TAGS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## dbt-databricks 1.12.6 (TBD)
+
+### Under the Hood
+
+- Emit only changed `databricks_tags` keys in `ALTER … SET TAGS`, without unsetting remote-only tags
+
 ## dbt-databricks 1.12.5 (Sep 1, 2026)
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Under the Hood
 
-- Emit only changed `databricks_tags` keys in `ALTER … SET TAGS`, without unsetting remote-only tags
+- Emit only changed `databricks_tags` keys in `ALTER … SET TAGS`, without unsetting remote-only tags ([#1667](https://github.com/databricks/dbt-databricks/pull/1667))
 
 ## dbt-databricks 1.12.5 (Sep 1, 2026)
 

--- a/dbt/adapters/databricks/relation_configs/tags.py
+++ b/dbt/adapters/databricks/relation_configs/tags.py
@@ -18,8 +18,9 @@ class TagsConfig(DatabricksComponentConfig):
 
     def get_diff(self, other: "TagsConfig") -> Optional["TagsConfig"]:
         # Tags are now "set only" - we never unset tags, only add or update them
-        if any(item not in other.set_tags.items() for item in self.set_tags.items()):
-            return TagsConfig(set_tags=self.set_tags)
+        set_tags = {k: v for k, v in self.set_tags.items() if other.set_tags.get(k) != v}
+        if set_tags:
+            return TagsConfig(set_tags=set_tags)
         return None
 
     def requires_server_metadata_for_diff(self) -> bool:

--- a/tests/unit/relation_configs/test_tags.py
+++ b/tests/unit/relation_configs/test_tags.py
@@ -90,6 +90,12 @@ class TestTagsConfig:
         diff = config.get_diff(config_old)
         assert diff == TagsConfig(set_tags={"a": "value", "b": "value"})
 
+    def test_get_diff__omits_unchanged_keys(self):
+        config = TagsConfig(set_tags={"stable": "1", "moved": "new"})
+        config_old = TagsConfig(set_tags={"stable": "1", "moved": "old", "remote_only": "x"})
+        diff = config.get_diff(config_old)
+        assert diff == TagsConfig(set_tags={"moved": "new"})
+
     def test_get_diff__no_changes(self):
         config = TagsConfig(set_tags={"tag": "value"})
         config_old = TagsConfig(set_tags={"tag": "value"})


### PR DESCRIPTION
## Summary
- Relation `databricks_tags` diffs now put only new or updated keys into `ALTER … SET TAGS`.
- Unchanged desired keys are omitted; remote-only tags are still never unset (set-only semantics unchanged).
- Unity Catalog `SET TAGS` upserts listed keys, so server state still converges.

## Test plan
- [x] Unit: `tests/unit/relation_configs/test_tags.py` (including `test_get_diff__omits_unchanged_keys`)
- [x] Functional on `databricks_uc_sql_endpoint`: incremental tags, table tags, table tags via alter, view tags via alter
- [ ] CI unit + integration on this PR