### PR TITLE
perf: emit only changed column databricks_tags keys in ALTER COLUMN SET TAGS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Under the Hood
 
-- Emit only changed column-level `databricks_tags` keys in `ALTER COLUMN … SET TAGS`, without unsetting remote-only tags
+- Emit only changed column-level `databricks_tags` keys in `ALTER COLUMN … SET TAGS`, without unsetting remote-only tags ([#1668](https://github.com/databricks/dbt-databricks/pull/1668))
 
 ## dbt-databricks 1.12.5 (Sep 1, 2026)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 - Document serverless environment configuration for Python models (thanks @TangoEnSkai!) ([#1649](https://github.com/databricks/dbt-databricks/pull/1649) resolves [#1055](https://github.com/databricks/dbt-databricks/issues/1055))
 
+## dbt-databricks 1.12.6 (TBD)
+
+### Under the Hood
+
+- Emit only changed column-level `databricks_tags` keys in `ALTER COLUMN … SET TAGS`, without unsetting remote-only tags
+
 ## dbt-databricks 1.12.5 (Sep 1, 2026)
 
 ### Fixes

--- a/dbt/adapters/databricks/relation_configs/column_tags.py
+++ b/dbt/adapters/databricks/relation_configs/column_tags.py
@@ -29,13 +29,12 @@ class ColumnTagsConfig(DatabricksComponentConfig):
             col_lower = col.lower()
             # Use case-insensitive comparison for column names
             if col_lower not in other_column_tags_lower:
-                # Column doesn't exist in other, need to set it
                 set_column_tags[col] = tags
             else:
-                # Column exists, check if tags are different
                 _, other_tags = other_column_tags_lower[col_lower]
-                if other_tags != tags:
-                    set_column_tags[col] = tags
+                changed = {k: v for k, v in tags.items() if other_tags.get(k) != v}
+                if changed:
+                    set_column_tags[col] = changed
 
         if set_column_tags:
             return ColumnTagsConfig(set_column_tags=set_column_tags)

--- a/tests/unit/relation_configs/test_column_tags_config.py
+++ b/tests/unit/relation_configs/test_column_tags_config.py
@@ -173,3 +173,16 @@ class TestColumnTagsConfig:
         # Should detect that account_id tag changed
         diff = config.get_diff(other)
         assert diff == ColumnTagsConfig(set_column_tags={"account_id": {"pii": "false"}})
+
+    def test_get_diff__omits_unchanged_keys_within_column(self):
+        config = ColumnTagsConfig(
+            set_column_tags={"col1": {"stable": "1", "moved": "new"}, "col2": {"ok": "yes"}}
+        )
+        other = ColumnTagsConfig(
+            set_column_tags={
+                "col1": {"stable": "1", "moved": "old", "remote_only": "x"},
+                "col2": {"ok": "yes"},
+            }
+        )
+        diff = config.get_diff(other)
+        assert diff == ColumnTagsConfig(set_column_tags={"col1": {"moved": "new"}})


### PR DESCRIPTION
## Summary
- Column-level `databricks_tags` diffs still skip columns with no changes.
- For a column that did change, `ALTER COLUMN … SET TAGS` now includes only new or updated keys, not the full desired map for that column.
- Remote-only tags on a column are still never unset (set-only semantics unchanged).
- Companion to [#1667](https://github.com/databricks/dbt-databricks/pull/1667) for relation tags.

## Test plan
- [x] Unit: `tests/unit/relation_configs/test_column_tags_config.py` (including `test_get_diff__omits_unchanged_keys_within_column`)
- [x] Functional on `databricks_uc_sql_endpoint`: `TestIncrementalColumnTags`, `TestColumnTagsTable`
- [ ] CI unit + integration on this PR