### PR TITLE
fix: replace instead of drop on managed Iceberg full refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## dbt-databricks 1.12.6 (TBD)
 
+### Fixes
+
+- Use `create or replace table` instead of dropping the table first when a full refresh rebuilds an incremental model on a Unity Catalog managed Iceberg table ([#1669](https://github.com/databricks/dbt-databricks/pull/1669) resolves [#1662](https://github.com/databricks/dbt-databricks/issues/1662))
+
 ### Under the Hood
 
 - Emit only changed `databricks_tags` keys in `ALTER … SET TAGS` ([#1667](https://github.com/databricks/dbt-databricks/pull/1667))

--- a/dbt/include/databricks/macros/materializations/incremental/incremental.sql
+++ b/dbt/include/databricks/macros/materializations/incremental/incremental.sql
@@ -11,9 +11,7 @@
   {% set partition_by = config.get('partition_by') %}
   {% set language = model['language'] %}
   {% set on_schema_change = incremental_validate_on_schema_change(config.get('on_schema_change'), default='ignore') %}
-  {% set is_delta = (catalog_relation.file_format == 'delta' and existing_relation.is_delta) %}
-  {% set is_iceberg = (catalog_relation.file_format == 'iceberg' and existing_relation.is_iceberg) %}
-  {% set is_replaceable_format = is_delta or is_iceberg %}
+  {% set is_replaceable_format = format_allows_create_or_replace(catalog_relation, existing_relation) %}
   {% set compiled_code = adapter.clean_sql(model['compiled_code']) %}
 
   {% if adapter.get_behavior_flag_no_warn('use_materialization_v2') %}

--- a/dbt/include/databricks/macros/materializations/incremental/replaceable_format.sql
+++ b/dbt/include/databricks/macros/materializations/incremental/replaceable_format.sql
@@ -6,15 +6,24 @@
      could never be true. The target is Iceberg exactly when `table_format` is iceberg and the
      behavior flag is on -- the same condition `file_format_clause` uses to emit `using iceberg`.
      The flag is read without warning because this runs for every incremental model, including
-     projects that never opt in (issue #1266). --#}
+     projects that never opt in (issue #1266).
+
+     The two arms are mutually exclusive because `create or replace` cannot change a table's
+     provider: Databricks rejects it with `MANAGED_ICEBERG_OPERATION_NOT_SUPPORTED` and leaves the
+     table as it was. A managed-Iceberg target over a legacy Delta table -- a project that has just
+     switched the flag on -- must therefore drop and recreate, even though `file_format` still reads
+     delta for it. --#}
 {% macro format_allows_create_or_replace(catalog_relation, existing_relation) %}
   {%- set target_is_managed_iceberg = (
         catalog_relation.table_format == 'iceberg'
         and adapter.get_behavior_flag_no_warn('use_managed_iceberg')
       ) -%}
-  {%- set replaceable = (
-        (catalog_relation.file_format == 'delta' and existing_relation.is_delta is true)
-        or (target_is_managed_iceberg and existing_relation.is_iceberg is true)
-      ) -%}
+  {%- if target_is_managed_iceberg -%}
+    {%- set replaceable = existing_relation.is_iceberg is true -%}
+  {%- else -%}
+    {%- set replaceable = (
+          catalog_relation.file_format == 'delta' and existing_relation.is_delta is true
+        ) -%}
+  {%- endif -%}
   {{ return(replaceable) }}
 {% endmacro %}

--- a/dbt/include/databricks/macros/materializations/incremental/replaceable_format.sql
+++ b/dbt/include/databricks/macros/materializations/incremental/replaceable_format.sql
@@ -1,0 +1,20 @@
+{#-- True when `create or replace table` can stand in for drop-then-create on a full refresh.
+
+     Managed Iceberg needs its own arm rather than reusing `file_format`: an Iceberg model keeps
+     `file_format` at delta (`iceberg_table_properties` raises for anything else) and `iceberg` is
+     not an accepted `file_format` at all, so the `file_format == 'iceberg'` test this replaced
+     could never be true. The target is Iceberg exactly when `table_format` is iceberg and the
+     behavior flag is on -- the same condition `file_format_clause` uses to emit `using iceberg`.
+     The flag is read without warning because this runs for every incremental model, including
+     projects that never opt in (issue #1266). --#}
+{% macro format_allows_create_or_replace(catalog_relation, existing_relation) %}
+  {%- set target_is_managed_iceberg = (
+        catalog_relation.table_format == 'iceberg'
+        and adapter.get_behavior_flag_no_warn('use_managed_iceberg')
+      ) -%}
+  {%- set replaceable = (
+        (catalog_relation.file_format == 'delta' and existing_relation.is_delta is true)
+        or (target_is_managed_iceberg and existing_relation.is_iceberg is true)
+      ) -%}
+  {{ return(replaceable) }}
+{% endmacro %}

--- a/tests/functional/adapter/iceberg/test_iceberg_support.py
+++ b/tests/functional/adapter/iceberg/test_iceberg_support.py
@@ -206,3 +206,29 @@ class TestManagedIcebergFullRefresh(ManagedIcebergMixin):
         assert get_version_zero_timestamp(project, "iceberg_full_refresh") == created, (
             "history restarted, so the full refresh dropped and recreated the table"
         )
+
+
+@pytest.mark.skip_profile("databricks_cluster")
+class TestManagedIcebergOverExistingDelta(ManagedIcebergMixin):
+    """Switching `use_managed_iceberg` on over tables a project already has as Delta must drop and
+    recreate them. `create or replace` cannot change a table's provider, so replacing here fails
+    with MANAGED_ICEBERG_OPERATION_NOT_SUPPORTED and leaves the table Delta (issue #1662)."""
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"iceberg_over_delta.sql": fixtures.incremental_iceberg_base}
+
+    def test_full_refresh_converts_the_delta_table(self, project):
+        project.run_sql(
+            "create or replace table {database}.{schema}.iceberg_over_delta using delta "
+            "as select 1 as id, 'initial' as status"
+        )
+        assert get_provider(project, "iceberg_over_delta") == "delta"
+
+        util.run_dbt(["run", "--full-refresh"])
+
+        assert get_provider(project, "iceberg_over_delta") == "iceberg"
+        rows = project.run_sql(
+            "select id, status from {database}.{schema}.iceberg_over_delta", fetch="all"
+        )
+        assert len(rows) == 1

--- a/tests/functional/adapter/iceberg/test_iceberg_support.py
+++ b/tests/functional/adapter/iceberg/test_iceberg_support.py
@@ -26,6 +26,19 @@ def get_tblproperty(project, identifier, key):
     return values[0] if values else None
 
 
+def get_version_zero_timestamp(project, identifier):
+    """Timestamp of the table's first history entry. A `create or replace` keeps it; dropping
+    and recreating the table starts a new history, so the value changes."""
+    rows = project.run_sql(
+        f"describe history {{database}}.{{schema}}.{identifier}",
+        fetch="all",
+    )
+    for row in rows:
+        if int(row[0]) == 0:
+            return str(row[1])
+    return None
+
+
 @pytest.mark.skip_profile("databricks_cluster")
 class TestIcebergTables:
     @pytest.fixture(scope="class")
@@ -172,3 +185,24 @@ class TestIcebergIncrementalMerge(ManagedIcebergMixin):
         assert result[0][1] == "updated"  # Updated via merge
         assert result[1][0] == 2
         assert result[1][1] == "new"  # New row
+
+
+@pytest.mark.skip_profile("databricks_cluster")
+class TestManagedIcebergFullRefresh(ManagedIcebergMixin):
+    """A full refresh must replace a managed Iceberg table in place rather than dropping it
+    first, so the table stays queryable for the whole rebuild (issue #1662)."""
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"iceberg_full_refresh.sql": fixtures.incremental_iceberg_base}
+
+    def test_full_refresh_keeps_the_table(self, project):
+        util.run_dbt()
+        created = get_version_zero_timestamp(project, "iceberg_full_refresh")
+        assert created is not None, "expected history on the managed Iceberg table"
+
+        util.run_dbt(["run", "--full-refresh"])
+
+        assert get_version_zero_timestamp(project, "iceberg_full_refresh") == created, (
+            "history restarted, so the full refresh dropped and recreated the table"
+        )

--- a/tests/unit/macros/materializations/incremental/test_replaceable_format.py
+++ b/tests/unit/macros/materializations/incremental/test_replaceable_format.py
@@ -82,16 +82,17 @@ class TestFormatAllowsCreateOrReplace(MacroTestBase):
         assert result == "True"
 
     def test_managed_iceberg_target_on_delta_relation(self, template_bundle):
-        """A project that has just switched the flag on still has a Delta table. The Delta arm
-        already covered this before #1662 and is left alone, so the full refresh keeps replacing
-        rather than dropping."""
+        """A project that has just switched the flag on still has a Delta table. `create or
+        replace` cannot change a table's provider -- Databricks rejects it with
+        MANAGED_ICEBERG_OPERATION_NOT_SUPPORTED -- so this has to drop and recreate even though
+        `file_format` still reads delta for a managed Iceberg model."""
         result = self.run_predicate(
             template_bundle,
             self._catalog_relation(table_format="iceberg"),
             self._existing_relation(is_delta=True),
             managed_iceberg=True,
         )
-        assert result == "True"
+        assert result == "False"
 
     def test_non_delta_file_format(self, template_bundle):
         result = self.run_predicate(

--- a/tests/unit/macros/materializations/incremental/test_replaceable_format.py
+++ b/tests/unit/macros/materializations/incremental/test_replaceable_format.py
@@ -1,0 +1,103 @@
+from unittest.mock import Mock
+
+import pytest
+
+from tests.unit.macros.base import MacroTestBase
+
+
+class TestFormatAllowsCreateOrReplace(MacroTestBase):
+    """The predicate that decides whether a full refresh can use `create or replace table`
+    instead of dropping the existing relation first (issue #1662)."""
+
+    @pytest.fixture(scope="class")
+    def template_name(self) -> str:
+        return "replaceable_format.sql"
+
+    @pytest.fixture(scope="class")
+    def macro_folders_to_load(self) -> list:
+        return ["macros/materializations/incremental"]
+
+    def _catalog_relation(self, table_format="default", file_format="delta"):
+        catalog_relation = Mock()
+        catalog_relation.table_format = table_format
+        catalog_relation.file_format = file_format
+        return catalog_relation
+
+    def _existing_relation(self, is_delta=False, is_iceberg=False):
+        existing_relation = Mock()
+        existing_relation.is_delta = is_delta
+        existing_relation.is_iceberg = is_iceberg
+        return existing_relation
+
+    def run_predicate(self, template_bundle, catalog_relation, existing_relation, managed_iceberg):
+        template_bundle.context["adapter"].get_behavior_flag_no_warn = Mock(
+            side_effect=lambda name: managed_iceberg if name == "use_managed_iceberg" else False
+        )
+        return self.run_macro_raw(
+            template_bundle.template,
+            "format_allows_create_or_replace",
+            catalog_relation,
+            existing_relation,
+        ).strip()
+
+    def test_delta_target_on_delta_relation(self, template_bundle):
+        result = self.run_predicate(
+            template_bundle,
+            self._catalog_relation(),
+            self._existing_relation(is_delta=True),
+            managed_iceberg=False,
+        )
+        assert result == "True"
+
+    def test_delta_target_on_iceberg_relation(self, template_bundle):
+        """Provider changed under the model, so the table has to be dropped."""
+        result = self.run_predicate(
+            template_bundle,
+            self._catalog_relation(),
+            self._existing_relation(is_iceberg=True),
+            managed_iceberg=False,
+        )
+        assert result == "False"
+
+    def test_managed_iceberg_target_on_iceberg_relation(self, template_bundle):
+        """The case from #1662: an Iceberg model keeps `file_format` at delta, so keying the
+        Iceberg arm off `file_format` never matched and the full refresh dropped the table."""
+        result = self.run_predicate(
+            template_bundle,
+            self._catalog_relation(table_format="iceberg"),
+            self._existing_relation(is_iceberg=True),
+            managed_iceberg=True,
+        )
+        assert result == "True"
+
+    def test_uniform_target_on_delta_relation(self, template_bundle):
+        """`table_format: iceberg` without the behavior flag writes a Delta table with UniForm
+        properties, so the relation stays Delta and remains replaceable."""
+        result = self.run_predicate(
+            template_bundle,
+            self._catalog_relation(table_format="iceberg"),
+            self._existing_relation(is_delta=True),
+            managed_iceberg=False,
+        )
+        assert result == "True"
+
+    def test_managed_iceberg_target_on_delta_relation(self, template_bundle):
+        """A project that has just switched the flag on still has a Delta table. The Delta arm
+        already covered this before #1662 and is left alone, so the full refresh keeps replacing
+        rather than dropping."""
+        result = self.run_predicate(
+            template_bundle,
+            self._catalog_relation(table_format="iceberg"),
+            self._existing_relation(is_delta=True),
+            managed_iceberg=True,
+        )
+        assert result == "True"
+
+    def test_non_delta_file_format(self, template_bundle):
+        result = self.run_predicate(
+            template_bundle,
+            self._catalog_relation(file_format="parquet"),
+            self._existing_relation(is_delta=True),
+            managed_iceberg=False,
+        )
+        assert result == "False"


### PR DESCRIPTION
Resolves #1662

### Description

A full refresh of an incremental model on a Unity Catalog managed Iceberg table ran `drop table if exists` and then the CTAS, so the table was absent for the whole rebuild — minutes on a large table — and concurrent queries failed with `TABLE_OR_VIEW_NOT_FOUND`.

The replaceability check keyed its Iceberg arm off `file_format`:

```jinja
{% set is_iceberg = (catalog_relation.file_format == 'iceberg' and existing_relation.is_iceberg) %}
```

An Iceberg model never has `file_format == 'iceberg'`. `iceberg_table_properties` raises for any `file_format` other than delta, and `iceberg` is not in the accepted `file_format` list at all, so this arm was unreachable. The Delta arm then failed too, because the existing table reports `Provider = iceberg`. Both false, so the macro dropped a table that `CREATE OR REPLACE` handles fine — which is exactly the statement it ran next.

This keys the arm off `table_format` plus the `use_managed_iceberg` flag, the same condition `file_format_clause` uses to decide on `using iceberg`. The flag is read through `get_behavior_flag_no_warn` so projects that never opt in do not get a warning (#1266).

The Delta arm is unchanged, so a project that has just switched the flag on and still has a Delta table keeps replacing rather than dropping. The only case whose behaviour changes is managed Iceberg over managed Iceberg.

The predicate moved into `format_allows_create_or_replace` so the V1 and V2 paths share one definition and it can be tested without a warehouse.

### Testing

The functional test asserts on the table's history rather than its id or creation time — both of those change on `create or replace` too, so only the first history entry surviving distinguishes a replace from a drop and recreate. It fails on the unfixed macro with `history restarted, so the full refresh dropped and recreated the table` and passes with the fix.

Against a serverless SQL warehouse: `tests/functional/adapter/iceberg/` 11 passed, `tests/functional/adapter/incremental/` 108 passed with 3 failures that reproduce identically on `main` (`TestAppendParquet`, and the two column-tag tests). Unit suite 1349 passed; `code-quality` clean.

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
- [ ] [Optional] I have run the `dbt-databricks-pr-ready` project skill for this PR and addressed its merge-readiness feedback
