### PR TITLE
docs: drop Claude eval-spec stub for pr-ready

### DIFF
--- a/.claude/skills/dbt-databricks-pr-ready/SKILL.md
+++ b/.claude/skills/dbt-databricks-pr-ready/SKILL.md
@@ -8,5 +8,4 @@ description: "Use for an open dbt-databricks pull request, including your own PR
 Derive the active repository root first with
 `ROOT="$(git rev-parse --show-toplevel)"`. Then read and follow the canonical
 skill at `$ROOT/.agents/skills/dbt-databricks-pr-ready/SKILL.md`. That file is
-the only source of the workflow and its rubric. The eval contract is
-`$ROOT/.agents/skills/dbt-databricks-pr-ready/eval-spec.md`.
+the only source of the workflow and its rubric.

--- a/.claude/skills/dbt-databricks-pr-ready/eval-spec.md
+++ b/.claude/skills/dbt-databricks-pr-ready/eval-spec.md
@@ -1,5 +1,0 @@
-# Eval spec: pr-ready compatibility entry point
-
-This file is not the behavioral contract. Read and follow
-`.agents/skills/dbt-databricks-pr-ready/eval-spec.md` in the same
-checkout. That file is the only source of dims and corpus for this skill.


### PR DESCRIPTION
## Summary
- Remove the leftover `.claude/skills/dbt-databricks-pr-ready/eval-spec.md` pointer after #1676.
- Claude Code still discovers the skill via `SKILL.md`; evals should use `.agents/skills/dbt-databricks-pr-ready/eval-spec.md`.

## Test plan
- [ ] Confirm `.claude/skills/dbt-databricks-pr-ready/` contains only `SKILL.md`.
- [ ] Confirm the Claude stub still redirects to `.agents/skills/dbt-databricks-pr-ready/SKILL.md`.