### PR TITLE
Honor transaction: false hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## dbt-databricks 1.12.6 (TBD)
 
+### Fixes
+
+- Honor `transaction: false` hooks by executing all hooks without transaction filtering or an explicit `COMMIT` ([#1549](https://github.com/databricks/dbt-databricks/issues/1549))
+
 ### Under the Hood
 
 - Emit only changed `databricks_tags` keys in `ALTER … SET TAGS` ([#1667](https://github.com/databricks/dbt-databricks/pull/1667))

--- a/dbt/include/databricks/macros/materializations/hooks.sql
+++ b/dbt/include/databricks/macros/materializations/hooks.sql
@@ -1,9 +1,19 @@
+{% macro run_hooks(hooks, inside_transaction=True) %}
+  {% for hook in hooks %}
+    {% set rendered = render(hook.get('sql')) | trim %}
+    {% if (rendered | length) > 0 %}
+      {% call statement(auto_begin=False) %}
+        {{ rendered }}
+      {% endcall %}
+    {% endif %}
+  {% endfor %}
+{% endmacro %}
+
+
 {% macro run_pre_hooks() %}
-  {{ run_hooks(pre_hooks, inside_transaction=False) }}
-  {{ run_hooks(pre_hooks, inside_transaction=True) }}
+  {{ run_hooks(pre_hooks) }}
 {% endmacro %}
 
 {% macro run_post_hooks() %}
-  {{ run_hooks(post_hooks, inside_transaction=True) }}
-  {{ run_hooks(post_hooks, inside_transaction=False) }}
+  {{ run_hooks(post_hooks) }}
 {% endmacro %}

--- a/tests/functional/adapter/hooks/test_model_hooks.py
+++ b/tests/functional/adapter/hooks/test_model_hooks.py
@@ -82,3 +82,58 @@ class TestPrePostModelHooks(BaseTestPrePost):
         util.run_dbt()
         self.check_hooks("start", project, dbt_profile_target)
         self.check_hooks("end", project, dbt_profile_target)
+
+
+class TestTransactionFalseModelHooks(TestPrePostModelHooks):
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {
+            "models": {
+                "test": {
+                    "pre-hook": [
+                        override_fixtures.MODEL_PRE_HOOK,
+                        {
+                            "sql": override_fixtures.MODEL_PRE_HOOK,
+                            "transaction": False,
+                        },
+                    ],
+                    "post-hook": [
+                        override_fixtures.MODEL_POST_HOOK,
+                        {
+                            "sql": override_fixtures.MODEL_POST_HOOK,
+                            "transaction": False,
+                        },
+                    ],
+                }
+            }
+        }
+
+    def test_transaction_false_hooks(self, project, dbt_profile_target):
+        util.run_dbt()
+        self.check_hooks("start", project, dbt_profile_target, count=2)
+        self.check_hooks("end", project, dbt_profile_target, count=2)
+
+class TestTransactionFalseModelHooksV2(TestTransactionFalseModelHooks):
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {
+            "flags": {"use_materialization_v2": True},
+            "models": {
+                "test": {
+                    "pre-hook": [
+                        override_fixtures.MODEL_PRE_HOOK,
+                        {
+                            "sql": override_fixtures.MODEL_PRE_HOOK,
+                            "transaction": False,
+                        },
+                    ],
+                    "post-hook": [
+                        override_fixtures.MODEL_POST_HOOK,
+                        {
+                            "sql": override_fixtures.MODEL_POST_HOOK,
+                            "transaction": False,
+                        },
+                    ],
+                }
+            },
+        }


### PR DESCRIPTION
Resolves #1549

### Description

Databricks does not support the transaction semantics used by dbt-core's
default `run_hooks` macro.

Previously, `transaction: false` hooks were silently skipped on the V1
materialization path, while the V2 path could fail with
`NO_ACTIVE_TRANSACTION` because dbt-core emits an explicit `COMMIT`.

This change overrides `run_hooks` for Databricks so that hooks are executed
in a single pass without transaction filtering or an explicit `COMMIT`.
The V1 and V2 pre/post-hook paths now execute hooks consistently.

### Testing

- `tests/unit/macros`: 263 passed
- `tests/unit`: 1350 passed, 4 skipped, 1 unrelated failure due to missing Node.js
- Functional hook tests could not run locally because the Databricks test configuration has no `http_path`.

### Checklist

- [ ] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
- [ ] [Optional] I have run the `dbt-databricks-pr-ready` project skill for this PR and addressed its merge-readiness feedback
